### PR TITLE
fight_id and fight_nr

### DIFF
--- a/src/custom/schick/rewrite_m302de/common.h
+++ b/src/custom/schick/rewrite_m302de/common.h
@@ -157,7 +157,7 @@ enum {
     HERO_NPC_ID         = 0x089, /* Held = 0, NARIELL = 1, HARIKA = 2, CURIAN = 3, ARDORA = 4, GARSVIK = 5, ERWO = 6 */
     HERO_GROUP_POS      = 0x08A, /* 0x01 bis 0x06, 0x00 = not in group */
     HERO_HEAL_TIMER     = 0x08B,
-    HERO_MAGIC_TIMER    = 0x08F, /* timer for wand levelups */
+    HERO_STAFFSPELL_TIMER   = 0x08F,
     HERO_RECIPE_ID      = 0x093, /* alchemy */
     HERO_RECIPE_TIMER   = 0x094, /* timer between failed alchemy attempts */
     HERO_RUHE_KOERPER   = 0x095, /* 1 = Ruhe Koerper spell is active */
@@ -203,7 +203,7 @@ enum {
     HERO_SP_CHANGE      = 0x189,
     HERO_SP_RISE        = 0x193, /* saved from last levelup */
     HERO_MAGIC_SCHOOL   = 0x194,
-    HERO_WAND           = 0x195,
+    HERO_STAFFSPELL_LVL = 0x195,
     HERO_ITEM_HEAD      = 0x196,
     HERO_ITEM_ARM       = 0x1A4,
     HERO_ITEM_BODY      = 0x1B2,

--- a/src/custom/schick/rewrite_m302de/common.h
+++ b/src/custom/schick/rewrite_m302de/common.h
@@ -146,7 +146,7 @@ enum {
     HERO_HUNGER_TIMER   = 0x07E, /* timer for no-hunger-miracle */
     HERO_HUNGER         = 0x07F, /* percentage */
     HERO_THIRST         = 0x080, /* percentage */
-    HERO_FIGHT_ID       = 0x081,
+    HERO_FIGHTER_ID       = 0x081,
     HERO_VIEWDIR        = 0x082,
     HERO_ACTIONS        = 0x083, /* corresponds to ENEMY_SHEET_ATTACKS */
     HERO_ACTION_ID      = 0x084, /* last fight action */
@@ -420,7 +420,7 @@ enum {
     ENEMY_SHEET_DUMMY3          = 0x2a,
     ENEMY_SHEET_DUMMY4          = 0x2b,
     ENEMY_SHEET_CUR_SPELL       = 0x2c,
-    ENEMY_SHEET_FIGHT_ID        = 0x2d,
+    ENEMY_SHEET_FIGHTER_ID        = 0x2d,
     ENEMY_SHEET_DUMMY5          = 0x2e,
     ENEMY_SHEET_BLIND           = 0x2f,
     ENEMY_SHEET_BROKEN          = 0x30, /* 0 = no, 1 = yes */

--- a/src/custom/schick/rewrite_m302de/seg001.cpp
+++ b/src/custom/schick/rewrite_m302de/seg001.cpp
@@ -101,7 +101,7 @@ void seg001_00c1(unsigned short track_nr) {
 	unsigned int track_start, track_end;
 	unsigned int track_len, tmp;
 
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	real_writew(reloc_game + CDA_DATASEG, 0x8f, 0);
@@ -142,7 +142,7 @@ void seg001_02c4(void) {
 
 	signed int val;
 
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	val = CD_get_tod();
@@ -169,7 +169,7 @@ signed short CD_bioskey(signed short cmd) {
 /* static */
 void CD_audio_stop_hsg(void) {
 
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	real_writew(reloc_game + CDA_DATASEG, 3, 0);
@@ -179,7 +179,7 @@ void CD_audio_stop_hsg(void) {
 
 /* CD_audio_stop() - stop audio playback in HSG and redbook format */
 void CD_audio_stop() {
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	CD_audio_stop_hsg();
@@ -189,15 +189,15 @@ void CD_audio_stop() {
 
 void CD_audio_pause() {
 	/* Is CD initialized ? */
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	/* Is CD already paused ? */
-	if (ds_readw(0x00a1) != 0)
+	if (ds_readw(CD_AUDIO_PAUSED) != 0)
 		return;
 
 	/* set CD pause */
-	ds_writew(0x00a1, 1);
+	ds_writew(CD_AUDIO_PAUSED, 1);
 	ds_writed(CD_AUDIO_TOD_BAK, CD_get_tod());
 	/* save current position */
 	ds_writed(CD_AUDIO_POS_BAK, ds_readd(CD_AUDIO_POS));
@@ -210,17 +210,17 @@ void CD_audio_pause() {
 
 void CD_audio_play() {
 	/* Is CD initialized ? */
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	/* Is CD paused ? */
-	if (ds_readw(0x00a1) == 0)
+	if (ds_readw(CD_AUDIO_PAUSED) == 0)
 		return;
 
 	CD_check();
 
 	/* reset CD pause */
-	ds_writew(0x00a1, 0);
+	ds_writew(CD_AUDIO_PAUSED, 0);
 	ds_writed(CD_AUDIO_POS, ds_readd(CD_AUDIO_POS_BAK));
 	ds_writed(CD_AUDIO_TOD, CD_get_tod() - ds_readd(CD_AUDIO_TOD_BAK) + ds_readd(CD_AUDIO_TOD));
 
@@ -329,7 +329,7 @@ static void CD_driver_request(void * request)
 /* TODO: check adresses of seg013 */
 static void CD_unused1(void)
 {
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	req[3].status = 0;
@@ -362,7 +362,7 @@ leave_tod:
 /* Borlandified and identical */
 void CD_audio_stop_hsg(void)
 {
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	req[0].status = 0;
@@ -374,7 +374,7 @@ void CD_audio_stop_hsg(void)
 /* Borlandified and identical */
 void CD_audio_stop(void)
 {
-	if (ds_readw(0x0095) == 0)
+	if (ds_readw(CD_INIT_SUCCESSFUL) == 0)
 		return;
 
 	CD_audio_stop_hsg();

--- a/src/custom/schick/rewrite_m302de/seg001.cpp
+++ b/src/custom/schick/rewrite_m302de/seg001.cpp
@@ -101,7 +101,7 @@ void seg001_00c1(unsigned short track_nr) {
 	unsigned int track_start, track_end;
 	unsigned int track_len, tmp;
 
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	real_writew(reloc_game + CDA_DATASEG, 0x8f, 0);
@@ -142,7 +142,7 @@ void seg001_02c4(void) {
 
 	signed int val;
 
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	val = CD_get_tod();
@@ -169,7 +169,7 @@ signed short CD_bioskey(signed short cmd) {
 /* static */
 void CD_audio_stop_hsg(void) {
 
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	real_writew(reloc_game + CDA_DATASEG, 3, 0);
@@ -179,7 +179,7 @@ void CD_audio_stop_hsg(void) {
 
 /* CD_audio_stop() - stop audio playback in HSG and redbook format */
 void CD_audio_stop() {
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	CD_audio_stop_hsg();
@@ -189,11 +189,11 @@ void CD_audio_stop() {
 
 void CD_audio_pause() {
 	/* Is CD initialized ? */
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	/* Is CD already paused ? */
-	if (ds_readw(0xa1) != 0)
+	if (ds_readw(0x00a1) != 0)
 		return;
 
 	/* set CD pause */
@@ -210,11 +210,11 @@ void CD_audio_pause() {
 
 void CD_audio_play() {
 	/* Is CD initialized ? */
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	/* Is CD paused ? */
-	if (ds_readw(0xa1) == 0)
+	if (ds_readw(0x00a1) == 0)
 		return;
 
 	CD_check();
@@ -329,7 +329,7 @@ static void CD_driver_request(void * request)
 /* TODO: check adresses of seg013 */
 static void CD_unused1(void)
 {
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	req[3].status = 0;
@@ -362,7 +362,7 @@ leave_tod:
 /* Borlandified and identical */
 void CD_audio_stop_hsg(void)
 {
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	req[0].status = 0;
@@ -374,7 +374,7 @@ void CD_audio_stop_hsg(void)
 /* Borlandified and identical */
 void CD_audio_stop(void)
 {
-	if (ds_readw(0x95) == 0)
+	if (ds_readw(0x0095) == 0)
 		return;
 
 	CD_audio_stop_hsg();

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -3023,7 +3023,7 @@ void herokeeping(void)
 			if ((host_readb(hero + HERO_TYPE) != 0) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero) &&
-				(!ds_readb(TRAVELING) || ds_readb(0x26a4 + i) != ds_readb(FOOD_MESSAGE + i))) {
+				(!ds_readb(TRAVELING) || ds_readb(FOOD_MESSAGE_SHOWN + i) != ds_readb(FOOD_MESSAGE + i))) {
 
 					sprintf(buffer,
 						(ds_readb(FOOD_MESSAGE + i) == 1) ? (char*)get_ltx(0x380):
@@ -3035,7 +3035,7 @@ void herokeeping(void)
 
 						(char*)hero + HERO_NAME2, (char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 1)));
 
-					ds_writeb(0x26a4 + i, ds_readb(FOOD_MESSAGE + i));
+					ds_writeb(FOOD_MESSAGE_SHOWN + i, ds_readb(FOOD_MESSAGE + i));
 
 					GUI_output((Bit8u*)buffer);
 

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -764,10 +764,9 @@ signed short load_regular_file(Bit16u index)
 	signed short handle;
 
 	if ( (handle = bc__open((RealPt)ds_readd(FNAMES + index * 4), 0x8004)) == -1) {
-
-		/* prepare string which file is missing */
+		/* "FILE %s IS MISSING!" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)Real2Host(ds_readd(0x4480)),
+			(char*)Real2Host(ds_readd(STR_FILE_MISSING_PTR)),
 			(char*)Real2Host(ds_readd(FNAMES + index * 4)));
 		ds_writeb(0x2ca1, 1);
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -796,7 +795,7 @@ signed short open_temp_file(unsigned short index)
 	signed short handle;
 
 	sprintf((char*)Real2Host(tmppath),
-		(char*)Real2Host(ds_readd(0x4c88)),
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 		(char*)Real2Host(ds_readd(FNAMES + index * 4)));
 
 	while ( (handle = bc__open(tmppath, 0x8004)) == -1) {

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -720,6 +720,15 @@ Bit32u get_readlength2(signed short index)
 	return index != -1 ? ds_readd(ARCHIVE_FILE_LENGTH) : 0;
 }
 
+/**
+ * \brief	reads len bytes from the current position in SCHICK.DAT
+ *
+ * \param handle	handle returned by load_archive_file
+ * \param buffer	target buffer for the data
+ * \param len	number of bytes to read
+ *
+ * \return number of bytes read
+ */
 unsigned short read_archive_file(Bit16u handle, Bit8u *buffer, Bit16u len)
 {
 
@@ -776,6 +785,13 @@ signed short load_regular_file(Bit16u index)
 	return handle;
 }
 
+/**
+ * \brief	opens a file stored in temp or in SCHICK.DAT
+ *
+ * \param	index	index of the file in SCHICK.DAT or in temp (bitwise or 0x8000)
+ *
+ * \return a file handle that can be used with read_archive_file etc.
+ */
 signed short load_archive_file(Bit16u index)
 {
 	bc_flushall();

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -5215,7 +5215,7 @@ int schick_main(int argc, char** argv)
 
 		CD_init();
 
-		if (ds_readw(0x0095) == 0) {
+		if (ds_readw(CD_INIT_SUCCESSFUL) == 0) {
 			/* CD init failed */
 			cleanup_game();
 			exit(0);

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -4292,7 +4292,7 @@ void sub_hero_le(Bit8u *hero, signed short le)
 
 			/* in fight mode */
 			if (ds_readw(IN_FIGHT) != 0) {
-				ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHT_ID)));
+				ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHTER_ID)));
 
 				/* update looking dir and other  */
 				host_writeb(ptr + 2, host_readb(hero + HERO_VIEWDIR));
@@ -4375,7 +4375,7 @@ void sub_hero_le(Bit8u *hero, signed short le)
 				/* in fight mode */
 				if (ds_readw(IN_FIGHT) != 0) {
 
-					ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHT_ID)));
+					ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHTER_ID)));
 
 					host_writeb(ptr + 2,
 						ds_readb(0x11e4 + host_readbs(hero + HERO_SPRITE_NO) * 2) + host_readbs(hero + HERO_VIEWDIR));
@@ -4444,7 +4444,7 @@ void add_hero_le(Bit8u *hero, signed short le)
 
 			/* maybe if we are in a fight */
 			if (ds_readw(IN_FIGHT)) {
-				ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHT_ID)));
+				ptr = Real2Host(FIG_get_ptr(host_readb(hero + HERO_FIGHTER_ID)));
 				ret = FIG_get_range_weapon_type(hero);
 
 				if (ret != -1) {

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -1155,7 +1155,7 @@ void interrupt mouse_isr(void)
 		if (((ds_readb(DUNGEON_INDEX) != 0) || (ds_readb(CURRENT_TOWN) != 0)) &&
 				!ds_readbs(LOCATION) &&
 				!ds_readbs(0x2c98) &&
-				(ds_readbs(0x2845) == 0))
+				(ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK))
 		{
 
 			ds_writed(0xcecb, (Bit32u) (is_mouse_in_rect(68, 4, 171, 51) ? RealMake(datseg, 0x2888):
@@ -1818,7 +1818,7 @@ void game_loop(void)
 
 			ds_writeb(0x46df, 0);
 
-			if (ds_readbs(0x2845) == 0) {
+			if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 				draw_status_line();
 			}
 		}
@@ -2045,7 +2045,7 @@ void dawning(void)
 			/* unknown */
 			!ds_readbs(0x45b8) &&
 			/* unknown */
-			(ds_readbs(0x2845) == 0))
+			(ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK))
 		{
 			wait_for_vsync();
 
@@ -2087,7 +2087,7 @@ void nightfall(void)
 			/* unknown */
 			!ds_readbs(0x45b8) &&
 			/* unknown */
-			(ds_readbs(0x2845) == 0))
+			(ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK))
 		{
 			wait_for_vsync();
 
@@ -2546,8 +2546,8 @@ void sub_mod_timers(Bit32s val)
 					/* subtract the mod */
 					sub_ptr_bs(mp, host_readbs(sp + 7));
 
-					if (ds_readb(0x2845) == 20) {
-						ds_writew(0x2846, 1);
+					if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
+						ds_writew(REQUEST_REFRESH, 1);
 					}
 
 					/* reset target */
@@ -3039,8 +3039,8 @@ void herokeeping(void)
 
 					GUI_output((Bit8u*)buffer);
 
-					if (ds_readb(0x2845) == 20) {
-						ds_writew(0x2846, 1);
+					if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
+						ds_writew(REQUEST_REFRESH, 1);
 					}
 			}
 
@@ -3062,8 +3062,8 @@ void herokeeping(void)
 					/* print output */
 					GUI_output((Bit8u*)buffer);
 
-					if (ds_readb(0x2845) == 20) {
-						ds_writew(0x2846, 1);
+					if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
+						ds_writew(REQUEST_REFRESH, 1);
 					}
 			}
 
@@ -3469,7 +3469,7 @@ void dec_splash(void)
 			/* Check splash timer again if 0 */
 			/* I have no clue */
 			/* Could be in fight */
-			(ds_readb(0x2845) == 0) &&
+			(ds_readb(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) &&
 			/* check if hero is dead */
 			!hero_dead(get_hero(i)))
 		{
@@ -3488,7 +3488,7 @@ void dec_splash(void)
 void draw_splash(signed short hero_pos, signed short type)
 {
 	/* Could be in fight */
-	if (ds_readb(0x2845) == 0) {
+	if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 
 		Bit8u *splash = (type == 0) ? Real2Host(ds_readd(SPLASH_LE)) : Real2Host(ds_readd(SPLASH_AE));
 
@@ -3831,7 +3831,7 @@ void draw_loc_icons(signed short icons, ...)
 	if (icons_bak[i] != -1)
 		changed = 1;
 
-	if (changed && ds_readb(0x2845) == 0) {
+	if (changed && ds_readb(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 		draw_icons();
 	}
 }
@@ -4302,7 +4302,7 @@ void sub_hero_le(Bit8u *hero, signed short le)
 			/* unknown */
 			host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_UNKNOWN2);
 
-			if (ds_readb(0x2845) == 0) {
+			if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 				ds_writeb(0x46df, 1);
 			}
 

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -5308,7 +5308,7 @@ signed short copy_protection(void)
 	signed short tries;
 	signed short l1;
 
-	load_buffer_1(ARCHIVE_FILE_FIGHTTXT_LTX);
+	load_tx(ARCHIVE_FILE_FIGHTTXT_LTX);
 
 	ds_writew(TEXTBOX_WIDTH, 4);
 

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -4555,7 +4555,7 @@ signed short test_attrib(Bit8u* hero, signed short attrib, signed short bonus)
 		si += bonus;
 	}
 
-	tmp = host_readbs(hero + 3 * attrib + 0x35) + host_readbs(hero + 3 * attrib + 0x36);
+	tmp = host_readbs(hero + 3 * attrib + HERO_MU) + host_readbs(hero + 3 * attrib + 0x36);
 
 #if !defined(__BORLANDC__)
 	D1_INFO(" -> %s mit %d\n",
@@ -4929,7 +4929,7 @@ signed short get_item_pos(Bit8u *hero, signed short item)
 	signed short i;
 
 	for (i = 0; i < 23; i++) {
-		if (item == host_readws(hero + i * 14 + 0x196)) {
+		if (item == host_readws(hero + i * 14 + HERO_ITEM_HEAD)) {
 			return i;
 		}
 	}
@@ -4958,7 +4958,7 @@ signed short get_first_hero_with_item(signed short item)
 		{
 			/* Search inventar */
 			for (j = 0; j < 23; j++) {
-				if (host_readw(hero_i + j * 14 + 0x196) == item) {
+				if (host_readw(hero_i + j * 14 + HERO_ITEM_HEAD) == item) {
 					return i;
 				}
 			}
@@ -4990,7 +4990,7 @@ signed short get_first_hero_with_item_in_group(signed short item, signed short g
 		{
 			/* Search inventar */
 			for (j = 0; j < 23; j++) {
-				if (host_readws(hero_i + j * 14 + 0x196) == item) {
+				if (host_readws(hero_i + j * 14 + HERO_ITEM_HEAD) == item) {
 					return i;
 				}
 			}

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -2721,18 +2721,18 @@ void seg002_2f7a(Bit32s fmin)
 			}
 
 			/* Timer set after Staffspell */
-			if (host_readds(hero_i + HERO_MAGIC_TIMER) > 0) {
-				sub_ptr_ds(hero_i + HERO_MAGIC_TIMER, fmin * 450);
+			if (host_readds(hero_i + HERO_STAFFSPELL_TIMER) > 0) {
+				sub_ptr_ds(hero_i + HERO_STAFFSPELL_TIMER, fmin * 450);
 #if !defined(__BORLANDC__)
-				if (host_readds(hero_i + HERO_MAGIC_TIMER) <= 0) {
+				if (host_readds(hero_i + HERO_STAFFSPELL_TIMER) <= 0) {
 					D1_INFO("%s kann wieder einen Stabzauber versuchen\n",
 						(char*)(hero_i + HERO_NAME2));
 				}
 
 #endif
-				if (host_readds(hero_i + HERO_MAGIC_TIMER) < 0) {
+				if (host_readds(hero_i + HERO_STAFFSPELL_TIMER) < 0) {
 
-					host_writed(hero_i + HERO_MAGIC_TIMER, 0);
+					host_writed(hero_i + HERO_STAFFSPELL_TIMER, 0);
 				}
 			}
 
@@ -4193,7 +4193,7 @@ void sub_ae_splash(Bit8u *hero, signed short ae)
 		ds_writew(0xc3cb, 0);
 
 		/* If Mage has 4th Staffspell */
-		if ((host_readb(hero + HERO_TYPE) == 9) && (host_readbs(hero + HERO_WAND) >= 4)) {
+		if ((host_readb(hero + HERO_TYPE) == 9) && (host_readbs(hero + HERO_STAFFSPELL_LVL) >= 4)) {
 			ae -= 2;
 			if (ae < 0)
 				ae = 0;

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -4615,12 +4615,12 @@ signed short test_attrib3(Bit8u* hero, signed short attrib1, signed short attrib
 
 	si += bonus;
 
-	tmp = host_readbs(hero + 3 * attrib1 + 0x35) +
-		host_readbs(hero + 3 * attrib1 + 0x36) +
-		host_readbs(hero + 3 * attrib2 + 0x35) +
-		host_readbs(hero + 3 * attrib2 + 0x36) +
-		host_readbs(hero + 3 * attrib3 + 0x35) +
-		host_readbs(hero + 3 * attrib3 + 0x36);
+	tmp = host_readbs(hero + 3 * attrib1 + HERO_MU) +
+		host_readbs(hero + 3 * attrib1 + HERO_MU_MOD) +
+		host_readbs(hero + 3 * attrib2 + HERO_MU) +
+		host_readbs(hero + 3 * attrib2 + HERO_MU_MOD) +
+		host_readbs(hero + 3 * attrib3 + HERO_MU) +
+		host_readbs(hero + 3 * attrib3 + HERO_MU_MOD);
 
 #if !defined(__BORLANDC__)
 	D1_INFO(" -> %s mit %d\n",

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -1766,7 +1766,7 @@ void game_loop(void)
 			do_dungeon();
 		}
 
-		if (ds_readb(0x2d34) == 99) {
+		if (ds_readb(DATSEG_STATUS_START) == 99) {
 			ds_writew(0xc3c1, 5);
 		}
 
@@ -2582,7 +2582,7 @@ void sub_mod_timers(Bit32s val)
 
 			} else {
 				/* target affects the savegame */
-				mp = p_datseg + 0x2d34;
+				mp = p_datseg + DATSEG_STATUS_START;
 				mp += host_readw(sp + 4);
 				sub_ptr_bs(mp, host_readbs(sp + 7));
 			}
@@ -2642,7 +2642,7 @@ void set_mod_slot(signed short slot_nr, Bit32s timer_value, Bit8u *ptr,
 
 	if (who == -1) {
 		/* mod slot is on savegame */
-		mod_ptr = p_datseg + 0x2d34;
+		mod_ptr = p_datseg + DATSEG_STATUS_START;
 	} else {
 		/* mod slot is on a hero/npc */
 		mod_ptr = get_hero(who);

--- a/src/custom/schick/rewrite_m302de/seg004.cpp
+++ b/src/custom/schick/rewrite_m302de/seg004.cpp
@@ -321,7 +321,7 @@ void update_status_bars(void)
 
 	if (ds_readw(0xc3cb) != 0) {
 
-		if (ds_readbs(0x2845) == 20) {
+		if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
 			/* in the status menu */
 
 			hero = get_hero(ds_readws(STATUS_PAGE_HERO));
@@ -415,7 +415,7 @@ void update_status_bars(void)
 #else
 			asm { sti };
 #endif
-		} else if (ds_readbs(0x2845) == 0) {
+		} else if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 			/* in the screen with the playmask */
 
 			for (i = 0; i <= 6; i++) {
@@ -732,7 +732,7 @@ void update_wallclock(void)
 	Bit32s d;
 
 	if ((ds_readw(WALLCLOCK_UPDATE) != 0) &&
-		((ds_readb(0x2845) == 0) || (ds_readb(0x2845) == 5)) &&
+		((ds_readb(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) || (ds_readb(PP20_INDEX) == ARCHIVE_FILE_KARTE_DAT)) &&
 		!ds_readbs(0x2c98))
 	{
 
@@ -849,7 +849,7 @@ void draw_wallclock(signed short pos, signed short night)
 	*(struct dummy2*)(p_datseg + 0x2990) = fullscreen_bak;
 
 	/* happens in travel mode */
-	if (ds_readb(0x2845) == 5) {
+	if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_KARTE_DAT) {
 
 		/* set coordinates */
 		ds_writew(0xc011, ds_readws(WALLCLOCK_X) - 5);

--- a/src/custom/schick/rewrite_m302de/seg005.cpp
+++ b/src/custom/schick/rewrite_m302de/seg005.cpp
@@ -707,7 +707,7 @@ void draw_fight_screen(Bit16u val)
 
 												host_writew(hero + HERO_UNKNOWN9,
 													ds_readws(0xd325 + 2 * ((host_readbs(hero + HERO_VIEWDIR) == 3) ? 0 : (host_readbs(hero + HERO_VIEWDIR) + 1))));
-												w_arr[host_readbs(list_i + 0xe)] = host_readbs(hero + HERO_FIGHT_ID);
+												w_arr[host_readbs(list_i + 0xe)] = host_readbs(hero + HERO_FIGHTER_ID);
 
 											}
 										}

--- a/src/custom/schick/rewrite_m302de/seg006.cpp
+++ b/src/custom/schick/rewrite_m302de/seg006.cpp
@@ -25,27 +25,27 @@ namespace M302de {
 #endif
 
 /**
- * \brief	search in a DL-list for an element
- * \param	fight_id	fight_id
- * \return	a pointer to the list elemtent or to the list head in error case
+ * \brief	get the pointer to the fighter with id fighter_id
+ * \param	fighter_id	id of the fighter
+ * \return	a pointer to the fighter with id fighter_id
  */
-RealPt FIG_get_ptr(signed char fight_id)
+RealPt FIG_get_ptr(signed char fighter_id)
 {
-	RealPt ptr = (RealPt)ds_readd(FIG_LIST_HEAD);
+	RealPt fighter_ptr = (RealPt)ds_readd(FIG_LIST_HEAD);
 
-	while (host_readbs(Real2Host(ptr) + 0x10) != fight_id) {
+	while (host_readbs(Real2Host(fighter_ptr) + 0x10) != fighter_id) {
 
 		/* check if its the last element */
-		if (host_readd(Real2Host(ptr) + 0x1b) == 0) {
+		if (host_readd(Real2Host(fighter_ptr) + 0x1b) == 0) {
 			/* return list head */
 			return (RealPt)ds_readd(FIG_LIST_HEAD);
 		}
 
-		/* set ptr to the next element */
-		ptr = (RealPt)host_readd(Real2Host(ptr) + 0x1b);
+		/* set fighter_ptr to the next element */
+		fighter_ptr = (RealPt)host_readd(Real2Host(fighter_ptr) + 0x1b);
 	}
 
-	return ptr;
+	return fighter_ptr;
 }
 
 /* static */
@@ -178,7 +178,7 @@ RealPt FIG_get_hero_ptr(signed short v1)
 	signed short i;
 
 	for (i = 0; i <= 6; i++) {
-		if (host_readbs(Real2Host(ds_readd(HEROS)) + i * SIZEOF_HERO + HERO_FIGHT_ID) == v1)
+		if (host_readbs(Real2Host(ds_readd(HEROS)) + i * SIZEOF_HERO + HERO_FIGHTER_ID) == v1)
 			return (RealPt)ds_readd(HEROS) + i * SIZEOF_HERO;
 	}
 
@@ -201,11 +201,11 @@ RealPt seg006_033c(signed short v)
 	return 0;
 }
 
-void FIG_set_0e(signed char fight_id, signed char val)
+void FIG_set_0e(signed char fighter_id, signed char val)
 {
 	Bit8u *ptr = Real2Host(ds_readd(FIG_LIST_HEAD));
 
-	while (host_readbs(ptr + 0x10) != fight_id) {
+	while (host_readbs(ptr + 0x10) != fighter_id) {
 
 		/* check for end of list */
 		if (host_readd(ptr + 0x1b) == 0) {
@@ -223,13 +223,13 @@ void FIG_set_0e(signed char fight_id, signed char val)
 }
 
 /* Used by range attack and spells with more than 1 field distance */
-void FIG_reset_12_13(signed char fight_id)
+void FIG_reset_12_13(signed char fighter_id)
 {
 	Bit8u *ptr1, *ptr2;
 
 	ptr1 = Real2Host(ds_readd(FIG_LIST_HEAD));
 
-	while (host_readb(ptr1 + 0x10) != fight_id) {
+	while (host_readb(ptr1 + 0x10) != fighter_id) {
 
 		if (host_readd(ptr1 + 0x1b) == 0) {
 			return;
@@ -251,13 +251,13 @@ void FIG_reset_12_13(signed char fight_id)
 	}
 }
 
-void FIG_set_12_13(signed short fight_id)
+void FIG_set_12_13(signed short fighter_id)
 {
 	Bit8u *ptr1, *ptr2;
 
 	ptr1 = Real2Host(ds_readd(FIG_LIST_HEAD));
 
-	while (host_readb(ptr1 + 0x10) != (signed char)fight_id) {
+	while (host_readb(ptr1 + 0x10) != (signed char)fighter_id) {
 
 		if (host_readd(ptr1 + 0x1b) == 0){
 			return;
@@ -282,11 +282,11 @@ void FIG_set_12_13(signed short fight_id)
 	}
 }
 
-void FIG_set_0f(signed char fight_id, signed char val)
+void FIG_set_0f(signed char fighter_id, signed char val)
 {
 	Bit8u *ptr = Real2Host(ds_readd(FIG_LIST_HEAD));
 
-	while (host_readb(ptr + 0x10) != fight_id) {
+	while (host_readb(ptr + 0x10) != fighter_id) {
 
 		if (host_readd(ptr + 0x1b) == 0) {
 			return;
@@ -304,10 +304,10 @@ struct dummy {
 
 /**
  * \brief		removes an element from the FIG_LIST
- * \param fight_id		identificates the element to remove
+ * \param fighter_id		identificates the element to remove
  * \param keep_in_memory	whether to save the removed element in FIG_LIST_ELEM, useful for moving element to end of list
  */
-void FIG_remove_from_list(signed char fight_id, signed char keep_in_memory)
+void FIG_remove_from_list(signed char fighter_id, signed char keep_in_memory)
 {
 	Bit8u* p = Real2Host(ds_readd(FIG_LIST_HEAD));
 
@@ -315,7 +315,7 @@ void FIG_remove_from_list(signed char fight_id, signed char keep_in_memory)
 	if (!NOT_NULL(p))
 		return;
 
-	while (host_readb(p + 0x10) != fight_id) {
+	while (host_readb(p + 0x10) != fighter_id) {
 
 		/* if (ptr->next == NULL); */
 		if (host_readd(p + 0x1b) == 0) {
@@ -327,7 +327,7 @@ void FIG_remove_from_list(signed char fight_id, signed char keep_in_memory)
 	}
 
 	if (!keep_in_memory) {
-		ds_writeb(FIG_LIST_ARRAY + fight_id, 0);
+		ds_writeb(FIG_LIST_ARRAY + fighter_id, 0);
 	} else {
 //		struct_copy(p_datseg + FIG_LIST_ELEM, p, 35);
 		*((struct dummy*)(p_datseg + FIG_LIST_ELEM)) = *((struct dummy*)(p));
@@ -361,10 +361,10 @@ void FIG_remove_from_list(signed char fight_id, signed char keep_in_memory)
 
 /**
  * \brief		adds FIG_LIST_ELEM to FIG_LIST
- * \param fight_id		id to assign to the new element (-1 = assign a new id)
- * \return  the new element's fight_id (position in FIG_LIST_ARRAY)
+ * \param fighter_id		id to assign to the new element (-1 = assign a new id)
+ * \return  the new element's fighter_id (position in FIG_LIST_ARRAY)
  */
-signed char FIG_add_to_list(signed char fight_id)
+signed char FIG_add_to_list(signed char fighter_id)
 {
 	RealPt p1;
 	RealPt p2;
@@ -382,7 +382,7 @@ signed char FIG_add_to_list(signed char fight_id)
 //		struct_copy(Real2Host(ds_readd(FIG_LIST_HEAD)), p_datseg + FIG_LIST_ELEM, 35);
 		*((struct dummy*)(Real2Host(ds_readd(FIG_LIST_HEAD)))) = *((struct dummy*)(p_datseg + FIG_LIST_ELEM));
 
-		if (fight_id == -1) {
+		if (fighter_id == -1) {
 			host_writeb(Real2Host(ds_readd(FIG_LIST_HEAD)) + 0x10,
 				FIG_set_array());
 		}
@@ -404,10 +404,10 @@ signed char FIG_add_to_list(signed char fight_id)
 //	struct_copy(Real2Host(p1), p_datseg + FIG_LIST_ELEM, 35);
 	*((struct dummy*)(Real2Host(p1))) =	*((struct dummy*)(p_datseg + FIG_LIST_ELEM));
 
-	if (fight_id == -1) {
+	if (fighter_id == -1) {
 		host_writeb(Real2Host(p1) + 0x10, FIG_set_array());
 	} else {
-		host_writeb(Real2Host(p1) + 0x10, fight_id);
+		host_writeb(Real2Host(p1) + 0x10, fighter_id);
 	}
 
 	p2 = (RealPt)ds_readd(FIG_LIST_HEAD);

--- a/src/custom/schick/rewrite_m302de/seg024.cpp
+++ b/src/custom/schick/rewrite_m302de/seg024.cpp
@@ -56,7 +56,7 @@ void diary_show(void)
 	ds_writed(0xcecb, (Bit32u)RealMake(datseg, DEFAULT_MOUSE_CURSOR));
 
 	load_pp20(ARCHIVE_FILE_BUCH_DAT);
-	ds_writeb(0x2845, ARCHIVE_FILE_BUCH_DAT);
+	ds_writeb(PP20_INDEX, ARCHIVE_FILE_BUCH_DAT);
 
 	get_textcolor(&fg_bak, &bg_bak);
 

--- a/src/custom/schick/rewrite_m302de/seg025.cpp
+++ b/src/custom/schick/rewrite_m302de/seg025.cpp
@@ -94,17 +94,17 @@ void show_entrance(void)
  */
 void show_citizen(void)
 {
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	do {
 		handle_gui_input();
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(20);
-			init_ani(ds_writew(0x2846, 0));
+			init_ani(ds_writew(REQUEST_REFRESH, 0));
 
 			strcpy((char*)Real2Host((RealPt)ds_readd(TEXT_OUTPUT_BUF)),
 				(char*)get_dtp(ds_readw(CITYINDEX) * 4));
@@ -286,8 +286,8 @@ void show_treasure_map(void)
 		GUI_output(get_ltx(0x984));
 	} else {
 		ds_writeb(0x45b8, 1);
-		bak = ds_readbs(0x2845);
-		ds_writeb(0x2845, -1);
+		bak = ds_readbs(PP20_INDEX);
+		ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 		set_var_to_zero();
 
 		/* load SKARTE.NVF */
@@ -407,10 +407,10 @@ void show_treasure_map(void)
 
 			ds_writeb(0x4c3a, 0);
 			ds_writeb(0x45b8, 0);
-			ds_writeb(0x2845, bak);
+			ds_writeb(PP20_INDEX, bak);
 		} else {
 			ds_writew(CURRENT_ANI, -1);
-			ds_writew(0x2846, 1);
+			ds_writew(REQUEST_REFRESH, 1);
 			ds_writew(0x2ccb, -1);
 			ds_writeb(0x45b8, 0);
 			draw_main_screen();
@@ -440,7 +440,7 @@ signed short game_options(void)
 	ds_writed(0xcecb, (Bit32u)RealMake(datseg, DEFAULT_MOUSE_CURSOR));
 
 	load_pp20(ARCHIVE_FILE_BUCH_DAT);
-	ds_writeb(0x2845, ARCHIVE_FILE_BUCH_DAT);
+	ds_writeb(PP20_INDEX, ARCHIVE_FILE_BUCH_DAT);
 
 	get_textcolor(&fg_bak, &bg_bak);
 
@@ -608,8 +608,8 @@ signed short game_options(void)
 
 	ds_writed(0xbff9, ds_readd(BUFFER1_PTR));
 
-	ds_writews(FIG_FIGURE1, ds_writews(FIG_FIGURE2, ds_writews(CURRENT_ANI, ds_writebs(0x2845, -1))));
-	ds_writew(0x2846, 1);
+	ds_writews(FIG_FIGURE1, ds_writews(FIG_FIGURE2, ds_writews(CURRENT_ANI, ds_writebs(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13)))));
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writeb(0x45b8, 0);
 
 	if (ds_readbs(CURRENT_TOWN) != 0) {
@@ -758,7 +758,7 @@ void turnaround(void)
 
 	set_to_ff();
 
-	ds_writew(0x2846, ds_writebs(0x45b8, 1));
+	ds_writew(REQUEST_REFRESH, ds_writebs(0x45b8, 1));
 }
 
 void leave_dungeon(void)
@@ -784,7 +784,7 @@ void leave_dungeon(void)
 	ds_writeb(0x2dad, ds_readb(DUNGEON_INDEX));
 	ds_writeb(DUNGEON_INDEX, ds_writeb(DUNGEON_LEVEL, ds_writeb(DUNGEON_LIGHT, 0)));
 	ds_writebs(0x2ca7, -1);
-	ds_writeb(0x4475, ds_writew(0x2846, 1));
+	ds_writeb(0x4475, ds_writew(REQUEST_REFRESH, 1));
 
 	do_fill_rect((RealPt)ds_readd(BUFFER1_PTR), 0, 0, 319, 199, 0);
 

--- a/src/custom/schick/rewrite_m302de/seg025.cpp
+++ b/src/custom/schick/rewrite_m302de/seg025.cpp
@@ -377,7 +377,7 @@ void show_treasure_map(void)
 			/* */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 				(char*)get_ltx(0xb5c),
-				(char*)get_hero(get_random_hero()) + 0x10);
+				(char*)get_hero(get_random_hero()) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 

--- a/src/custom/schick/rewrite_m302de/seg025.cpp
+++ b/src/custom/schick/rewrite_m302de/seg025.cpp
@@ -471,11 +471,11 @@ signed short game_options(void)
 
 	if (ds_readbs(CURRENT_TOWN) != 0) {
 		/* if the party is in a town */
-		load_buffer_1(ARCHIVE_FILE_MAPTEXT_LTX);
+		load_tx(ARCHIVE_FILE_MAPTEXT_LTX);
 
 		GUI_print_header(get_dtp(4 * (ds_readbs(CURRENT_TOWN) - 1)));
 
-		load_buffer_1(ds_readbs(CURRENT_TOWN) + (ARCHIVE_FILE_CITY_DAT-1));
+		load_tx(ds_readbs(CURRENT_TOWN) + (ARCHIVE_FILE_CITY_DAT-1));
 
 		ds_writew(0xc011, 0);
 		ds_writew(0xc013, 0);
@@ -661,7 +661,7 @@ signed short show_storytext(void)
 	signed short person;
 	signed short icon;
 
-	load_buffer_1(ARCHIVE_FILE_STORY_LTX);
+	load_tx(ARCHIVE_FILE_STORY_LTX);
 
 	person = random_schick(17) - 1;
 

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -272,18 +272,18 @@ signed short load_game_state(void)
 		bc__read(handle_gs, (Bit8u*)&version[0], 1);
 		bc__read(handle_gs, (Bit8u*)&version[1], 1);
 
-		bc__read(handle_gs, p_datseg + 0x2d34, 4);
+		bc__read(handle_gs, p_datseg + DATSEG_STATUS_START, 4);
 
 		/* read game status */
-		p_status_start = (HugePt)RealMake(datseg, 0x2d34);
-		p_status_end = (HugePt)RealMake(datseg, 0x4474);
+		p_status_start = (HugePt)RealMake(datseg, DATSEG_STATUS_START);
+		p_status_end = (HugePt)RealMake(datseg, DATSEG_STATUS_END);
 #if !defined(__BORLANDC__)
 		status_length = (signed short)F_PSUB(p_status_end, p_status_start);
 #else
 		status_length = (signed short)(p_status_end - p_status_start);
 #endif
 
-		bc__read(handle_gs, p_datseg + 0x2d34, status_length);
+		bc__read(handle_gs, p_datseg + DATSEG_STATUS_START, status_length);
 
 		ds_writeb(0x45b8, 1);
 
@@ -555,8 +555,8 @@ signed short save_game_state(void)
 
 		load_area_description(1);
 
-		p_status_start = (HugePt)RealMake(datseg, 0x2d34);
-		p_status_end = (HugePt)RealMake(datseg, 0x4474);
+		p_status_start = (HugePt)RealMake(datseg, DATSEG_STATUS_START);
+		p_status_end = (HugePt)RealMake(datseg, DATSEG_STATUS_END);
 #if !defined(__BORLANDC__)
 		status_len = (signed short)F_PSUB(p_status_end, p_status_start);
 #else

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -262,8 +262,8 @@ signed short load_game_state(void)
 		}
 
 		/* init */
-		ds_writed(0xe2d2, ds_readd(DTP2));
-		memset(Real2Host(ds_readd(0xe2d2)), 0, 286 * 4);
+		ds_writed(SAVED_FILES_BUF, ds_readd(DTP2));
+		memset(Real2Host(ds_readd(SAVED_FILES_BUF)), 0, 286 * 4);
 
 		/* read version info */
 		bc__read(handle_gs, Real2Host(ds_readd(TEXT_OUTPUT_BUF)), 12);
@@ -288,12 +288,12 @@ signed short load_game_state(void)
 		ds_writeb(0x45b8, 1);
 
 		/* read file table */
-		bc__read(handle_gs, Real2Host(ds_readd(0xe2d2)), 286 * 4);
+		bc__read(handle_gs, Real2Host(ds_readd(SAVED_FILES_BUF)), 286 * 4);
 
 		/* create for each saved file in gam a file in TEMP */
 		for (i = 0; i < 286; i++) {
 
-			if (host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * i)) {
+			if (host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * i)) {
 
 				/* write file content to TEMP */
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
@@ -302,8 +302,8 @@ signed short load_game_state(void)
 
 				handle = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0);
 
-				bc__read(handle_gs, Real2Host(ds_readd(BUFFER1_PTR)), (unsigned short)host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * i));
-				bc__write(handle, (RealPt)ds_readd(BUFFER1_PTR), (unsigned short)host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * i));
+				bc__read(handle_gs, Real2Host(ds_readd(BUFFER1_PTR)), (unsigned short)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * i));
+				bc__write(handle, (RealPt)ds_readd(BUFFER1_PTR), (unsigned short)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * i));
 				bc_close(handle);
 			}
 		}
@@ -489,8 +489,8 @@ signed short save_game_state(void)
 
 	ds_writew(TEXTBOX_WIDTH, tw_bak);
 
-	ds_writed(0xe2d2, ds_readd(DTP2));
-	memset(Real2Host(ds_readd(0xe2d2)), 0, 4 * 286);
+	ds_writed(SAVED_FILES_BUF, ds_readd(DTP2));
+	memset(Real2Host(ds_readd(SAVED_FILES_BUF)), 0, 4 * 286);
 
 	if (slot != -2 && slot != 5) {
 
@@ -572,9 +572,9 @@ signed short save_game_state(void)
 		}
 
 #if !defined(__BORLANDC__)
-		bc_time_dosbox((RealPt)RealMake(datseg, 0xe2d6));
+		bc_time_dosbox((RealPt)RealMake(datseg, LAST_SAVE_TIME));
 #else
-		bc_time((Bit32s*)RealMake(datseg, 0xe2d6));
+		bc_time((Bit32s*)RealMake(datseg, LAST_SAVE_TIME));
 #endif
 
 		filepos = 0;
@@ -618,7 +618,7 @@ signed short save_game_state(void)
 		}
 
 		filepos2 = filepos;
-		len = (Bit16u)bc__write(l_di, (RealPt)ds_readd(0xe2d2), 4 * 286);
+		len = (Bit16u)bc__write(l_di, (RealPt)ds_readd(SAVED_FILES_BUF), 4 * 286);
 		filepos += len;
 
 		if (len != 4 * 286) {
@@ -640,14 +640,14 @@ signed short save_game_state(void)
 			if (l1 == 0) {
 
 				handle = load_archive_file(tw_bak + 0x8000);
-				host_writed(Real2Host(ds_readd(0xe2d2)) + 4 * tw_bak, get_readlength2(handle));
-				bc__read(handle, Real2Host(ds_readd(BUFFER1_PTR)), (unsigned short)host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * tw_bak));
+				host_writed(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * tw_bak, get_readlength2(handle));
+				bc__read(handle, Real2Host(ds_readd(BUFFER1_PTR)), (unsigned short)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * tw_bak));
 				bc_close(handle);
 
-				len = (Bit16u)bc__write(l_di, (RealPt)ds_readd(BUFFER1_PTR), (unsigned short)host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * tw_bak));
+				len = (Bit16u)bc__write(l_di, (RealPt)ds_readd(BUFFER1_PTR), (unsigned short)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * tw_bak));
 				filepos += len;
 
-				if ((Bit16u)host_readd(Real2Host(ds_readd(0xe2d2)) + 4 * tw_bak) != len) {
+				if ((Bit16u)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * tw_bak) != len) {
 					GUI_output(get_ltx(0x570));
 					bc_close(l_di);
 					return 0;
@@ -678,7 +678,7 @@ signed short save_game_state(void)
 
 		/* write the file table */
 		bc_lseek(l_di, filepos2, 0);
-		bc__write(l_di, (RealPt)ds_readd(0xe2d2), 4 * 286);
+		bc__write(l_di, (RealPt)ds_readd(SAVED_FILES_BUF), 4 * 286);
 
 		/* append all CHR files */
 		bc_lseek(l_di, filepos, 0);

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -241,7 +241,7 @@ signed short load_game_state(void)
 		/* delete every file in TEMP */
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 			/* "TEMP\\%s" */
-			(char*)Real2Host(ds_readd(0x4c88)),
+			(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 			/* "*.*" */
 			(char*)p_datseg + ALL_FILES_WILDCARD);
 
@@ -251,7 +251,7 @@ signed short load_game_state(void)
 
 			do {
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)Real2Host(ds_readd(0x4c88)),
+					(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 					((char*)(&blk))+ 30);
 
 				bc_unlink((RealPt)ds_readd(TEXT_OUTPUT_BUF));
@@ -297,7 +297,7 @@ signed short load_game_state(void)
 
 				/* write file content to TEMP */
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)Real2Host(ds_readd(0x4c88)),
+					(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 					(char*)Real2Host(ds_readd(FNAMES + 4 * i)));
 
 				handle = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0);
@@ -325,7 +325,7 @@ signed short load_game_state(void)
 
 				/* write file content to TEMP */
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)Real2Host(ds_readd(0x4c88)),
+					(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 					name);
 
 				handle = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0);
@@ -363,7 +363,7 @@ signed short load_game_state(void)
 		while (l2 == 0) {
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 				((char*)(&blk)) + 30);
 
 			if ((handle_gs = bc__open((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0x8004)) == -1) {
@@ -631,7 +631,7 @@ signed short save_game_state(void)
 		for (tw_bak = 0; tw_bak < 286; tw_bak++) {
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 				(char*)Real2Host(ds_readd(FNAMES + 4 * tw_bak)));
 
 			l1 = bc_findfirst((RealPt)ds_readd(TEXT_OUTPUT_BUF), &blk, 0);
@@ -683,14 +683,14 @@ signed short save_game_state(void)
 		/* append all CHR files */
 		bc_lseek(l_di, filepos, 0);
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)Real2Host(ds_readd(0x4c88)),
+			(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 			(char*)p_datseg + ALL_CHR_WILDCARD2);
 
 		l1 = bc_findfirst((RealPt)ds_readd(TEXT_OUTPUT_BUF), &blk, 0);
 		do {
 			/* create the CHR filename */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 				((char*)(&blk)) + 30);
 
 			/* read the CHR file from temp */
@@ -738,7 +738,7 @@ signed short read_chr_temp(RealPt fname, signed short hero_pos, signed short a2)
 	Bit8u *hero;
 
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)Real2Host(ds_readd(0x4c88)),
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 		(char*)Real2Host(fname));
 
 	if ((handle = bc__open((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0x8004)) == -1) {
@@ -797,7 +797,7 @@ void write_chr_temp(unsigned short hero_pos)
 	prepare_chr_name(fname, (char*)get_hero(hero_pos));
 
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)Real2Host(ds_readd(0x4c88)),		/* "TEMP\\%s" */
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),		/* "TEMP\\%s" */
 		fname);
 
 	fd = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0);
@@ -821,7 +821,7 @@ signed short copy_chr_names(Bit8u *ptr, signed short temple_id)
 
 	buf = Real2Host(ds_readd(BUFFER1_PTR)) + 60000;
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)Real2Host(ds_readd(0x4c88)),
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 		(char*)p_datseg + ALL_CHR_WILDCARD3);
 
 	l_di = bc_findfirst((RealPt)ds_readd(TEXT_OUTPUT_BUF), &blk, 0);
@@ -831,7 +831,7 @@ signed short copy_chr_names(Bit8u *ptr, signed short temple_id)
 		do {
 			/* create the CHR filename */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 				((char*)(&blk)) + 30);
 
 			/* read the CHR file from temp */

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -51,23 +51,23 @@ void init_text(void)
 
 }
 
-void load_buffer_1(signed short index)
+void load_tx(signed short index)
 {
-	Bit32s len;
-	signed short fd;
+	Bit32s archive_file_len;
+	signed short archive_file_handle;
 
 	if (index == -1)
 		return;
 
-	fd = load_archive_file(index);
+	archive_file_handle = load_archive_file(index);
 
-	len = (signed short)read_archive_file(fd, Real2Host(ds_readd(BUFFER7_PTR)), 64000);
+	archive_file_len = (signed short)read_archive_file(archive_file_handle, Real2Host(ds_readd(BUFFER7_PTR)), 64000);
 
-	bc_close(fd);
+	bc_close(archive_file_handle);
 
-	split_textbuffer(Real2Host(ds_readd(DIALOG_TEXT)), (RealPt)ds_readd(BUFFER7_PTR), len);
+	split_textbuffer(Real2Host(ds_readd(DIALOG_TEXT)), (RealPt)ds_readd(BUFFER7_PTR), archive_file_len);
 
-	ds_writew(BUF1_FILE_INDEX, index);
+	ds_writew(TX_FILE_INDEX, index);
 }
 
 void load_city_ltx(signed short index)

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -405,7 +405,7 @@ signed short load_game_state(void)
 		}
 
 		ds_writew(0x2ccb, -1);
-		ds_writew(0x2846, retval = 1);
+		ds_writew(REQUEST_REFRESH, retval = 1);
 		ds_writew(CHECK_DISEASE, 0);
 		ds_writew(CHECK_POISON, 0);
 		ds_writeb(0x4475, 3);

--- a/src/custom/schick/rewrite_m302de/seg026.h
+++ b/src/custom/schick/rewrite_m302de/seg026.h
@@ -23,7 +23,7 @@ void load_in_head(signed short);
 //0x4d
 void load_city_ltx(signed short);
 //0x57
-void load_buffer_1(signed short);
+void load_tx(signed short);
 //0x57
 void load_ltx(unsigned short);
 //0x61

--- a/src/custom/schick/rewrite_m302de/seg027.cpp
+++ b/src/custom/schick/rewrite_m302de/seg027.cpp
@@ -542,34 +542,39 @@ void load_ani(const signed short nr)
 	}
 }
 
-void load_scenario(signed short nr)
+/**
+ * \brief	reads an entry in SCENARIO.LST and stores it in SCENARIO_BUF
+ *
+ * \param scenario_id  number of the scenario in SCENARIO.LST
+ */
+void load_scenario(signed short scenario_id)
 {
-	unsigned short fd;
-	signed short buf;
+	unsigned short scenario_lst_handle;
+	signed short scenario_lst_buf;
 
 	/* load SCENARIO.LST */
-	fd = load_archive_file(ARCHIVE_FILE_SCENARIO_LST);
+	scenario_lst_handle = load_archive_file(ARCHIVE_FILE_SCENARIO_LST);
 
-	/* read the first two bytes == nr of scenarios */
-	read_archive_file(fd, (Bit8u*)&buf, 2);
+	/* read the first two bytes == scenario_id of scenarios */
+	read_archive_file(scenario_lst_handle, (Bit8u*)&scenario_lst_buf, 2);
 
 #if !defined(__BORLANDC__)
 	/* BE-fix: */
-	buf = host_readw((Bit8u*)&buf);
+	scenario_lst_buf = host_readw((Bit8u*)&scenario_lst_buf);
 #endif
 
-	/* check if scenario nr is valid */
-	if ((nr > buf) || (nr < 1))
-		nr = 1;
+	/* check if scenario_id is valid */
+	if ((scenario_id > scenario_lst_buf) || (scenario_id < 1))
+		scenario_id = 1;
 
 	/* seek to the scenario */
-	seek_archive_file(fd, 621L * (nr - 1) + 2, 0);
+	seek_archive_file(scenario_lst_handle, 621L * (scenario_id - 1) + 2, 0);
 
 	/* read scenario */
-	read_archive_file(fd, Real2Host(ds_readd(SCENARIO_BUF)), 621);
+	read_archive_file(scenario_lst_handle, Real2Host(ds_readd(SCENARIO_BUF)), 621);
 
 	/* close archive */
-	bc_close(fd);
+	bc_close(scenario_lst_handle);
 }
 
 signed short count_fight_enemies(signed short nr)

--- a/src/custom/schick/rewrite_m302de/seg027.cpp
+++ b/src/custom/schick/rewrite_m302de/seg027.cpp
@@ -634,33 +634,38 @@ signed short count_fight_enemies(signed short fight_id)
 	return enemy_count;
 }
 
+/**
+ * \brief	reads an entry in FIGHT.LST and stores it in CURRENT_FIGHT
+ *
+ * \param fight_id  number of the fight in FIGHT.LST
+ */
 void read_fight_lst(signed short fight_id)
 {
-	unsigned short fd;
-	signed short max;
+	unsigned short fight_lst_handle;
+	signed short fight_count;
 
 	/* load FIGHT.LST from TEMP dir */
-	fd = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
+	fight_lst_handle = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
 
-	/* read the first 2 bytes (max number of fights) */
-	bc__read(fd, (Bit8u*)&max, 2);
+	/* read the first 2 bytes (fight_count number of fights) */
+	bc__read(fight_lst_handle, (Bit8u*)&fight_count, 2);
 
 #if !defined(__BORLANDC__)
 	/* BE-fix: */
-	max = host_readw((Bit8u*)&max);
+	fight_count = host_readw((Bit8u*)&fight_count);
 #endif
 	/* sanity check for parameter fight_id */
-	if ((max - 1) < fight_id || fight_id < 0)
+	if ((fight_count - 1) < fight_id || fight_id < 0)
 		fight_id = 0;
 
 	/* write the fight number to a global var */
 	ds_writew(CURRENT_FIGHT_ID, fight_id);
 
 	/* seek to file position */
-	bc_lseek(fd, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
+	bc_lseek(fight_lst_handle, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
 
 	/* read the fight entry */
-	bc__read(fd, Real2Host(ds_readd(CURRENT_FIGHT)), SIZEOF_FIGHT);
+	bc__read(fight_lst_handle, Real2Host(ds_readd(CURRENT_FIGHT)), SIZEOF_FIGHT);
 
 #if !defined(__BORLANDC__)
 	char fight_name[21];
@@ -672,7 +677,7 @@ void read_fight_lst(signed short fight_id)
 #endif
 
 	/* close FIGHT.LST */
-	bc_close(fd);
+	bc_close(fight_lst_handle);
 }
 
 void write_fight_lst(void)

--- a/src/custom/schick/rewrite_m302de/seg027.cpp
+++ b/src/custom/schick/rewrite_m302de/seg027.cpp
@@ -680,24 +680,27 @@ void read_fight_lst(signed short fight_id)
 	bc_close(fight_lst_handle);
 }
 
+/**
+ * \brief	writes the data in CURRENT_FIGHT to FIGHT.LST
+ */
 void write_fight_lst(void)
 {
 	signed short fight_id;
-	unsigned short fd;
+	unsigned short fight_lst_handle;
 
 	fight_id = ds_readw(CURRENT_FIGHT_ID);
 
 	/* load FIGHT.LST from TEMP dir */
-	fd = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
+	fight_lst_handle = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
 
 	/* seek to the entry */
-	bc_lseek(fd, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
+	bc_lseek(fight_lst_handle, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
 
 	/* write it */
-	bc__write(fd, (RealPt)ds_readd(CURRENT_FIGHT), SIZEOF_FIGHT);
+	bc__write(fight_lst_handle, (RealPt)ds_readd(CURRENT_FIGHT), SIZEOF_FIGHT);
 
 	/* close the file */
-	bc_close(fd);
+	bc_close(fight_lst_handle);
 }
 
 void init_common_buffers(void)

--- a/src/custom/schick/rewrite_m302de/seg027.cpp
+++ b/src/custom/schick/rewrite_m302de/seg027.cpp
@@ -577,53 +577,61 @@ void load_scenario(signed short scenario_id)
 	bc_close(scenario_lst_handle);
 }
 
-signed short count_fight_enemies(signed short nr)
+/**
+ * \brief	counts the number of enemies that are present in the first round
+ *          according to the information stored in FIGHT.LST
+ *
+ * \param fight_id  number of the fight in FIGHT.LST
+ *
+ * \return  number of enemies present in first round
+ */
+signed short count_fight_enemies(signed short fight_id)
 {
-	signed short i;
-	signed short retval;
-	Bit8u *buf;
-	unsigned short fd;
-	signed short max;
+	signed short enemy_i;
+	signed short enemy_count;
+	Bit8u *fight_lst_buf;
+	unsigned short fight_lst_handle;
+	signed short fight_count;
 
-	retval = 0;
+	enemy_count = 0;
 
-	buf = Real2Host(ds_readd(DTP2));
+	fight_lst_buf = Real2Host(ds_readd(DTP2));
 
 	/* load FIGHT.LST from TEMP dir */
-	fd = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
+	fight_lst_handle = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
 
-	/* read the first 2 bytes (max number of fights) */
-	bc__read(fd, (Bit8u*)&max, 2);
+	/* read the first 2 bytes (fight_count number of fights) */
+	bc__read(fight_lst_handle, (Bit8u*)&fight_count, 2);
 
 #if !defined(__BORLANDC__)
 	/* BE-fix: */
-	max = host_readw((Bit8u*)&max);
+	fight_count = host_readw((Bit8u*)&fight_count);
 #endif
-	/* sanity check for parameter nr */
-	if ((nr > (max - 1)) || (nr < 0))
-		nr = 0;
+	/* sanity check for parameter fight_id */
+	if ((fight_id > (fight_count - 1)) || (fight_id < 0))
+		fight_id = 0;
 
 	/* seek to file position */
-	bc_lseek(fd, (long)SIZEOF_FIGHT * nr + 2, SEEK_SET);
+	bc_lseek(fight_lst_handle, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
 
 	/* read the fight entry */
-	bc__read(fd, buf, SIZEOF_FIGHT);
+	bc__read(fight_lst_handle, fight_lst_buf, SIZEOF_FIGHT);
 
 	/* close FIGHT.LST */
-	bc_close(fd);
+	bc_close(fight_lst_handle);
 
 	/* check all enemies */
-	for (i = 0; i < 20; i++) {
+	for (enemy_i = 0; enemy_i < 20; enemy_i++) {
 		/* no enemy and enemy does not appear in the first round */
-		if ((host_readb(buf + 0x16 + i * 5) != 0)
-			&& (!host_readbs(buf + 0x1a + i * 5)))
+		if ((host_readb(fight_lst_buf + FIGHT_MONSTERS_ID + enemy_i * 5) != 0)
+			&& (!host_readbs(fight_lst_buf + FIGHT_MONSTERS_ROUND_APPEAR + enemy_i * 5)))
 		{
 			/* increment counter */
-			retval++;
+			enemy_count++;
 		}
 	}
 
-	return retval;
+	return enemy_count;
 }
 
 void read_fight_lst(signed short fight_id)

--- a/src/custom/schick/rewrite_m302de/seg027.cpp
+++ b/src/custom/schick/rewrite_m302de/seg027.cpp
@@ -626,7 +626,7 @@ signed short count_fight_enemies(signed short nr)
 	return retval;
 }
 
-void read_fight_lst(signed short nr)
+void read_fight_lst(signed short fight_id)
 {
 	unsigned short fd;
 	signed short max;
@@ -641,15 +641,15 @@ void read_fight_lst(signed short nr)
 	/* BE-fix: */
 	max = host_readw((Bit8u*)&max);
 #endif
-	/* sanity check for parameter nr */
-	if ((max - 1) < nr || nr < 0)
-		nr = 0;
+	/* sanity check for parameter fight_id */
+	if ((max - 1) < fight_id || fight_id < 0)
+		fight_id = 0;
 
 	/* write the fight number to a global var */
-	ds_writew(CURRENT_FIGHT_NR, nr);
+	ds_writew(CURRENT_FIGHT_ID, fight_id);
 
 	/* seek to file position */
-	bc_lseek(fd, (long)SIZEOF_FIGHT * nr + 2, SEEK_SET);
+	bc_lseek(fd, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
 
 	/* read the fight entry */
 	bc__read(fd, Real2Host(ds_readd(CURRENT_FIGHT)), SIZEOF_FIGHT);
@@ -659,7 +659,7 @@ void read_fight_lst(signed short nr)
 	/* Improvement */
 	strncpy(fight_name, (char*)Real2Host(ds_readd(CURRENT_FIGHT)), 20);
 	fight_name[20] = '\0';
-	D1_INFO("Lade Kampf Nr %3d\t Name \"%s\"\n", nr, fight_name);
+	D1_INFO("Lade Kampf fight_id %3d\t Name \"%s\"\n", fight_id, fight_name);
 	/* Improvement end */
 #endif
 
@@ -669,16 +669,16 @@ void read_fight_lst(signed short nr)
 
 void write_fight_lst(void)
 {
-	signed short nr;
+	signed short fight_id;
 	unsigned short fd;
 
-	nr = ds_readw(CURRENT_FIGHT_NR);
+	fight_id = ds_readw(CURRENT_FIGHT_ID);
 
 	/* load FIGHT.LST from TEMP dir */
 	fd = load_archive_file(0x8000 | ARCHIVE_FILE_FIGHT_LST);
 
 	/* seek to the entry */
-	bc_lseek(fd, (long)SIZEOF_FIGHT * nr + 2, SEEK_SET);
+	bc_lseek(fd, (long)SIZEOF_FIGHT * fight_id + 2, SEEK_SET);
 
 	/* write it */
 	bc__write(fd, (RealPt)ds_readd(CURRENT_FIGHT), SIZEOF_FIGHT);

--- a/src/custom/schick/rewrite_m302de/seg028.cpp
+++ b/src/custom/schick/rewrite_m302de/seg028.cpp
@@ -452,7 +452,7 @@ void load_map(void)
 
 	array_add(Real2Host(F_PADD((RealPt)ds_readd(BUFFER9_PTR), 18000)), 3003, 0xe0, 2);
 
-	ds_writeb(0x2845, 5);
+	ds_writeb(PP20_INDEX, ARCHIVE_FILE_KARTE_DAT);
 
 	/* if the ems_map_hanlder exists */
 	if (ds_readw(0xbd90) != 0) {

--- a/src/custom/schick/rewrite_m302de/seg028.cpp
+++ b/src/custom/schick/rewrite_m302de/seg028.cpp
@@ -47,7 +47,7 @@ void prepare_dungeon_area(void)
 		load_dungeon_ddt();
 	}
 
-	load_buffer_1(index);
+	load_tx(index);
 
 	if ((ds_readws(0x2ccb) == -1) || (ds_readws(0x2ccb) == 1)) {
 
@@ -136,7 +136,7 @@ void seg028_0224(void)
 		ds_writeb(0x2ca6, -1);
 	}
 
-	load_buffer_1(l1);
+	load_tx(l1);
 
 	if ((ds_readws(0x2ccb) == -1) || (ds_readws(0x2ccb) == 0)) {
 
@@ -254,7 +254,7 @@ void load_special_textures(signed short arg)
 
 void call_load_buffer(void)
 {
-	load_buffer_1(ds_readws(BUF1_FILE_INDEX));
+	load_tx(ds_readws(TX_FILE_INDEX));
 }
 
 void seg028_0555(signed short town)
@@ -499,7 +499,7 @@ void load_map(void)
 	read_archive_file(fd, Real2Host(F_PADD(ds_readd(BUFFER9_PTR), 11400)), 5900);
 	bc_close(fd);
 
-	load_buffer_1(ARCHIVE_FILE_MAPTEXT_LTX);
+	load_tx(ARCHIVE_FILE_MAPTEXT_LTX);
 
 	ds_writew(WALLCLOCK_UPDATE, bak);
 }

--- a/src/custom/schick/rewrite_m302de/seg029.cpp
+++ b/src/custom/schick/rewrite_m302de/seg029.cpp
@@ -57,7 +57,7 @@ void draw_playmask(void)
 	else
 		load_pp20(ARCHIVE_FILE_PLAYM_UK);
 
-	ds_writeb(0x2845, 0);
+	ds_writeb(PP20_INDEX, ARCHIVE_FILE_PLAYM_UK);
 
 	wait_for_vsync();
 
@@ -282,7 +282,7 @@ void draw_icons(void)
 {
 	signed short i;
 
-	if (ds_readb(0x2845) != 0)
+	if (ds_readb(PP20_INDEX) != ARCHIVE_FILE_PLAYM_UK)
 		return;
 
 	update_mouse_cursor();
@@ -320,7 +320,7 @@ void draw_main_screen(void)
 
 	set_var_to_zero();
 
-	if (ds_readb(0x2845))
+	if (ds_readb(PP20_INDEX))
 		draw_playmask();
 
 	clear_loc_line();

--- a/src/custom/schick/rewrite_m302de/seg030.cpp
+++ b/src/custom/schick/rewrite_m302de/seg030.cpp
@@ -204,48 +204,48 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 						l_si == 27 || l_si == 28)
 					{
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 0)),
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 1)));
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 0)),
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 1)));
 
 					} else if (l_si == 19) {
 
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10);
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2);
 
 					} else if (l_si == 23) {
 
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 2)))
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 2)))
 ;
 					} else if (l_si == 29) {
 
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 0)),
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 1)),
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 2)));
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 0)),
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 1)),
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 2)));
 
 					} else if (l_si == 30) {
 
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 1)),
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 2)));
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 1)),
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 2)));
 
 					} else if (l_si == 31) {
 
 						sprintf(dst, fmt,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 3)));
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 3)));
 
 					} else if (l_si == 32) {
 
 						sprintf(dst, fmt,
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 0)),
-							Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10);
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 0)),
+							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2);
 
 					} else {
 						strcpy(dst, fmt);
@@ -368,27 +368,27 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 						if (!l_si || l_si == 3 || l_si == 4) {
 
 							sprintf(dst, fmt,
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 0)));
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 0)));
 
 						} else if (l_si == 5) {
 
 							sprintf(dst, fmt,
-								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 0)),
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10);
+								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 0)),
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2);
 
 						} else if (l_si == 6) {
 
 							sprintf(dst, fmt,
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x22), 1)),
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10);
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+								Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 1)),
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2);
 
 						} else if (l_si == 8) {
 
 							sprintf(dst, fmt,
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10,
-								Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x10);
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
+								Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2);
 
 						} else {
 							strcpy(dst, fmt);

--- a/src/custom/schick/rewrite_m302de/seg030.cpp
+++ b/src/custom/schick/rewrite_m302de/seg030.cpp
@@ -176,7 +176,7 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 	ptr3 = (RealPt)RealMake(datseg, INFORMER_ARRAY);
 	ptr2 = Real2Host(host_readd(Real2Host(ptr3) + 38 * tlk_informer));
 	l_di = host_readws(Real2Host(ptr3) + 38 * tlk_informer + 4);
-	ds_writed(0xe308, (Bit32u)(tlk_informer * 38 + ptr3 + 6));
+	ds_writed(DIALOG_TITLE, (Bit32u)(tlk_informer * 38 + ptr3 + 6));
 
 	load_in_head(host_readws(Real2Host(ptr3) + 38 * tlk_informer + 0x24));
 	dst = (char*)Real2Host(ds_readd(DTP2)) + 0x400;
@@ -218,8 +218,7 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 
 						sprintf(dst, fmt,
 							Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_NAME2,
-							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 2)))
-;
+							Real2Host(GUI_get_ptr(host_readbs(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_SEX), 2)));
 					} else if (l_si == 29) {
 
 						sprintf(dst, fmt,
@@ -493,20 +492,20 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 				}
 			}
 
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), Real2Host(ds_readd(0xe308)), (Bit8u*)dst, options,
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), Real2Host(ds_readd(DIALOG_TITLE)), (Bit8u*)dst, options,
 					get_city(4 * (host_readb(ptr1 + 2) + l_di)),
 					get_city(4 * (host_readb(ptr1 + 3) + l_di)),
 					get_city(4 * (host_readb(ptr1 + 4) + l_di)));
 		}
 
 
-		ds_writews(0xe30e, -1);
+		ds_writews(DIALOG_NEXT_STATE, -1);
 
 		if (host_readws(ptr1) & 0x8000 || host_readws(ptr1) == -1) {
 			talk_switch();
 		}
 
-		ds_writew(DIALOG_STATE, ds_readws(0xe30e) == -1 ? host_readb(ptr1 + 5) : ds_readws(0xe30e));
+		ds_writew(DIALOG_STATE, ds_readws(DIALOG_NEXT_STATE) == -1 ? host_readb(ptr1 + 5) : ds_readws(DIALOG_NEXT_STATE));
 
 		if (ds_readws(DIALOG_DONE) == 0) {
 

--- a/src/custom/schick/rewrite_m302de/seg031.cpp
+++ b/src/custom/schick/rewrite_m302de/seg031.cpp
@@ -177,12 +177,12 @@ void do_random_talk(signed short talk_id, signed short informer_id)
 			arr[0].b = host_readb(p1 + 5);
 		}
 
-		ds_writews(0xe30e, -1);
+		ds_writews(DIALOG_NEXT_STATE, -1);
 		if ((host_readw(p1) & 0x8000) || host_readws(p1) == -1) {
 			talk_switch();
 		}
 
-		ds_writew(DIALOG_STATE, ds_readws(0xe30e) == -1 ? arr[0].b : ds_readws(0xe30e));
+		ds_writew(DIALOG_STATE, ds_readws(DIALOG_NEXT_STATE) == -1 ? arr[0].b : ds_readws(DIALOG_NEXT_STATE));
 
 		if (ds_readws(DIALOG_DONE) == 0) {
 

--- a/src/custom/schick/rewrite_m302de/seg031.cpp
+++ b/src/custom/schick/rewrite_m302de/seg031.cpp
@@ -207,7 +207,7 @@ void do_random_talk(signed short talk_id, signed short informer_id)
 	} while (ds_readws(DIALOG_DONE) == 0);
 
 	ds_writews(TEXT_FILE_INDEX, ds_writews(CURRENT_ANI, -1));
-	load_buffer_1(ds_readws(BUF1_FILE_INDEX));
+	load_tx(ds_readws(TX_FILE_INDEX));
 }
 
 /* This function is dead code */

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -916,7 +916,7 @@ signed short do_fight(signed short fight_id)
 		ds_writew(FIG_DROPPED_WEAPONS + 2 * l_di, 0);
 	}
 
-	load_buffer_1(ARCHIVE_FILE_FIGHTTXT_LTX);
+	load_tx(ARCHIVE_FILE_FIGHTTXT_LTX);
 
 	/* open OBJECTS.NVF */
 	fd = load_archive_file(ARCHIVE_FILE_OBJECTS_NVF);

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -538,7 +538,7 @@ void FIG_do_round(void)
 
 					and_ptr_bs(Real2Host(hero) + HERO_STATUS1, 0xfd);
 
-					p1 = Real2Host(FIG_get_ptr(host_readbs(Real2Host(hero) + HERO_FIGHT_ID)));
+					p1 = Real2Host(FIG_get_ptr(host_readbs(Real2Host(hero) + HERO_FIGHTER_ID)));
 
 					host_writeb(p1 + 0x02, host_readbs(Real2Host(hero) + HERO_VIEWDIR));
 					host_writeb(p1 + 0x0d, -1);
@@ -564,7 +564,7 @@ void FIG_do_round(void)
 						dec_ptr_bs(Real2Host(hero) + HERO_ECLIPTIFACTUS);
 					}
 
-					/* save the fight_id of this hero */
+					/* save the fighter_id of this hero */
 					ds_writew(FIG_CHAR_PIC, pos + 1);
 
 					/* select a fight action */
@@ -613,7 +613,7 @@ void FIG_do_round(void)
 						herokeeping();
 					}
 
-					/* set fight_id of the hero to 0 */
+					/* set fighter_id of the hero to 0 */
 					ds_writew(FIG_CHAR_PIC, 0);
 				}
 			}
@@ -660,18 +660,18 @@ void FIG_do_round(void)
 
 						FIG_do_monster_action(monster, pos);
 
-						if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) >= 10) {
+						if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) >= 10) {
 
-							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) >= 30) {
-								sub_ptr_bs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID, 20);
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) >= 30) {
+								sub_ptr_bs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID, 20);
 							}
 
-							if (test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)))
+							if (test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)))
 							{
-								if (is_in_byte_array(host_readbs(p_datseg + (0xd0df + 1) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)), p_datseg + TWO_FIELDED_SPRITE_ID))
+								if (is_in_byte_array(host_readbs(p_datseg + (0xd0df + 1) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)), p_datseg + TWO_FIELDED_SPRITE_ID))
 								{
 
-									FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) + 20, &x, &y);
+									FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) + 20, &x, &y);
 
 #if !defined(__BORLANDC__)
 									/* BE-fix */
@@ -679,7 +679,7 @@ void FIG_do_round(void)
 									y = host_readws((Bit8u*)&y);
 #endif
 
-									p1 = Real2Host(FIG_get_ptr(host_readbs(p_datseg + (0xd0df + 38) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID))));
+									p1 = Real2Host(FIG_get_ptr(host_readbs(p_datseg + (0xd0df + 38) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID))));
 									p1 = Real2Host(FIG_get_ptr(ds_readbs(0xe35a + host_readbs(p1 + 0x13))));
 
 									if (host_readbs(p1 + 0x14) >= 0) {

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -666,7 +666,7 @@ void FIG_do_round(void)
 								sub_ptr_bs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID, 20);
 							}
 
-							if (test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + 0x2d)))
+							if (test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)))
 							{
 								if (is_in_byte_array(host_readbs(p_datseg + (0xd0df + 1) + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)), p_datseg + TWO_FIELDED_SPRITE_ID))
 								{

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -76,7 +76,7 @@ void draw_fight_screen_pal(signed short mode)
 	FIG_draw_pic();
 
 	/* check for palette update */
-	if (ds_readbs(0x2845) != -1) {
+	if (ds_readb(PP20_INDEX) != (ARCHIVE_FILE_DNGS + 13)) {
 
 		update_mouse_cursor();
 
@@ -96,7 +96,7 @@ void draw_fight_screen_pal(signed short mode)
 		set_palette(p_datseg + 0x7d0e, 0x80, 0x14);
 		set_palette(Real2Host((RealPt)ds_readd(BUFFER8_PTR) + 0xfa02), 0x60, 0x20);
 
-		ds_writeb(0x2845, -1);
+		ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 
 		refresh_screen_size();
 	}
@@ -899,7 +899,7 @@ signed short do_fight(signed short fight_nr)
 	ds_writew(FIG_FIGURE1, ds_writew(FIG_FIGURE2, -1));
 	ds_writew(FIGHT_FIGS_INDEX, -1);
 
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	ds_writed(ACTION_TABLE_PRIMARY, (Bit32u)RealMake(datseg, ACTION_TABLE_MENU));
 
@@ -967,9 +967,9 @@ signed short do_fight(signed short fight_nr)
 	/* the fight happens in this loop */
 	while (ds_readws(IN_FIGHT) != 0) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 			draw_fight_screen_pal(0);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		/* TODO: isnt that bogus? */
@@ -1177,14 +1177,14 @@ signed short do_fight(signed short fight_nr)
 	ds_writew(FIG_DISCARD, 0);
 	ds_writew(MAX_ENEMIES, 0);
 	ds_writew(IN_FIGHT, 0);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writew(CURRENT_ANI, -1);
 	ds_writew(0x2ccb, -1);
 	ds_writew(TIMERS_DISABLED, 0);
 	ds_writew(AUTOFIGHT, 0);
 	ds_writeb(CHECK_PARTY, 1);
 	ds_writew(TEXTBOX_WIDTH, bak5);
-	ds_writeb(0x2845, -2);
+	ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 12));
 
 	update_mouse_cursor();
 

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -824,11 +824,11 @@ void FIG_load_ship_sprites(void)
 /**
  * \brief	the heros encounter a fight
  *
- * \param	fight_nr	number of the fight
+ * \param	fight_id	number of the fight
  *
  * \return 0 = ???, 1 = no monsters in the fight, 2 = , 3 = sneaked arround
  */
-signed short do_fight(signed short fight_nr)
+signed short do_fight(signed short fight_id)
 {
 	signed short l_di;
 
@@ -859,12 +859,12 @@ signed short do_fight(signed short fight_nr)
 		return 0;
 	}
 
-	if (!count_fight_enemies(fight_nr)) {
+	if (!count_fight_enemies(fight_id)) {
 		return 1;
 	}
 
 	ds_writew(TIMERS_DISABLED, 1);
-	ds_writew(CURRENT_FIG_NR, fight_nr);
+	ds_writew(CURRENT_FIG_NR, fight_id);
 
 	bak5 = ds_readws(TEXTBOX_WIDTH);
 	ds_writew(TEXTBOX_WIDTH, 3);
@@ -874,12 +874,12 @@ signed short do_fight(signed short fight_nr)
 	ds_writed(MONSTER_DAT_BUF, (Bit32u)F_PADD(ds_readd(SCENARIO_BUF), 621));
 	ds_writed(CURRENT_FIGHT, (Bit32u)F_PADD(ds_readd(MONSTER_DAT_BUF), 3476));
 
-	read_fight_lst(fight_nr);
+	read_fight_lst(fight_id);
 
 	load_scenario(host_readws(Real2Host(ds_readd(CURRENT_FIGHT)) + FIGHT_SCENARIO));
 
 	if (!host_readbs(Real2Host(ds_readd(CURRENT_FIGHT)) + FIGHT_INTRO_SEEN)) {
-		GUI_print_fight_intro_msg(fight_nr);
+		GUI_print_fight_intro_msg(fight_id);
 
 		host_writeb(Real2Host(ds_readd(CURRENT_FIGHT)) + FIGHT_INTRO_SEEN, 1);
 	}
@@ -986,7 +986,7 @@ signed short do_fight(signed short fight_nr)
 				FIG_latecomers();
 			}
 
-			if ((fight_nr == 138) && (ds_readws(FIGHT_ROUND) >= 10)) {
+			if ((fight_id == 138) && (ds_readws(FIGHT_ROUND) >= 10)) {
 				/* This fight ends after 9 rounds */
 				ds_writew(IN_FIGHT, 0);
 			}
@@ -1025,7 +1025,7 @@ signed short do_fight(signed short fight_nr)
 
 		if (ds_readws(0xc3c1) != 0) {
 
-			if ((fight_nr != 192) && count_heros_available()) {
+			if ((fight_id != 192) && count_heros_available()) {
 
 				ds_writew(0xc3c1, 0);
 

--- a/src/custom/schick/rewrite_m302de/seg033.cpp
+++ b/src/custom/schick/rewrite_m302de/seg033.cpp
@@ -648,7 +648,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 								if (rwt1 != rwt2) {
 
-									ptr = Real2Host(FIG_get_ptr(host_readbs(hero + HERO_FIGHT_ID)));
+									ptr = Real2Host(FIG_get_ptr(host_readbs(hero + HERO_FIGHTER_ID)));
 
 									if (rwt2 != -1) {
 										host_writeb(ptr + 2,
@@ -911,7 +911,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					(host_readbs(hero + HERO_ACTION_ID) == FIG_ACTION_RANGE_ATTACK)) && (host_readbs(hero + HERO_ENEMY_ID) > 0))
 				{
 
-					/* TODO: check fight_id upper bound */
+					/* TODO: check fighter_id upper bound */
 					if (((host_readbs(hero + HERO_ENEMY_ID) >= 10)
 						&& (test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * host_readbs(hero + HERO_ENEMY_ID)))) ||
 						((host_readbs(hero + HERO_ENEMY_ID) < 10)
@@ -923,7 +923,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 						host_writebs(hero + HERO_ENEMY_ID, 0);
 						done = 0;
 
-					/* TODO: check fight_id upper bound */
+					/* TODO: check fighter_id upper bound */
 					} else if (((host_readbs(hero + HERO_ENEMY_ID) >= 10)
 						&& (test_bit2(p_datseg + 0xd0df + 0x32 + SIZEOF_ENEMY_SHEET * host_readbs(hero + HERO_ENEMY_ID)))) ||
 						((host_readbs(hero + HERO_ENEMY_ID) < 10)

--- a/src/custom/schick/rewrite_m302de/seg033.cpp
+++ b/src/custom/schick/rewrite_m302de/seg033.cpp
@@ -363,7 +363,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 							host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_MOVE);
 							host_writeb(hero + HERO_ENEMY_ID, 0);
 
-							spell = p_datseg + 0x099d + 10 * host_readbs(hero + HERO_SPELL_ID);
+							spell = p_datseg + SPELL_DESCRIPTIONS + 10 * host_readbs(hero + HERO_SPELL_ID);
 
 							if (host_readbs(spell + 5) == -1) {
 

--- a/src/custom/schick/rewrite_m302de/seg034.cpp
+++ b/src/custom/schick/rewrite_m302de/seg034.cpp
@@ -42,33 +42,33 @@ signed short seg034_000(signed short x_hero, signed short y_hero,
 			signed short x_diff, signed short y_diff,
 			signed short max_range)
 {
-	signed short fight_id_target;
-	signed short fight_id;
+	signed short fighter_id_target;
+	signed short fighter_id;
 	signed short beeline;
 
-	fight_id = get_cb_val(x, y);
-	fight_id_target = get_cb_val(x + x_diff, y + y_diff);
+	fighter_id = get_cb_val(x, y);
+	fighter_id_target = get_cb_val(x + x_diff, y + y_diff);
 
 	beeline = calc_beeline(x + x_diff, y + y_diff, x_hero, y_hero);
 
-	if ((fight_id != 0) && (calc_beeline(x, y, x_hero, y_hero) < beeline) && (beeline <= max_range)) {
+	if ((fighter_id != 0) && (calc_beeline(x, y, x_hero, y_hero) < beeline) && (beeline <= max_range)) {
 
 		if ((x_hero == x) && (y_hero == y)) {
 
-			if ((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
+			if ((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
 			{
 				return 1;
 			} else {
 				return 0;
 			}
 
-		} else if (((fight_id >= 50) ||
-				((fight_id >= 10) && (fight_id < 30) && test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * fight_id)) ||
-				((fight_id >= 30) && (fight_id < 50) && test_bit0(p_datseg + (0xcc07 + 49) + SIZEOF_ENEMY_SHEET * fight_id)) ||
-				((fight_id < 10) && hero_dead(get_hero(fight_id - 1))))
+		} else if (((fighter_id >= 50) ||
+				((fighter_id >= 10) && (fighter_id < 30) && test_bit0(p_datseg + (0xd0df + 49) + SIZEOF_ENEMY_SHEET * fighter_id)) ||
+				((fighter_id >= 30) && (fighter_id < 50) && test_bit0(p_datseg + (0xcc07 + 49) + SIZEOF_ENEMY_SHEET * fighter_id)) ||
+				((fighter_id < 10) && hero_dead(get_hero(fighter_id - 1))))
 				&&
-				((fight_id_target >= 0) &&
-				 ((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))))
+				((fighter_id_target >= 0) &&
+				 ((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))))
 			{
 
 				if (((((x_diff == 1) || (x_diff == -1)) && (y_hero != y))) ||
@@ -85,8 +85,8 @@ signed short seg034_000(signed short x_hero, signed short y_hero,
 	}
 
 	if (x_diff == 1) {
-		if ((fight_id_target >= 0) &&
-			((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
+		if ((fighter_id_target >= 0) &&
+			((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
 			&& ((x < 23) && (y == y_hero) && (calc_beeline(x_hero, y_hero, x + 1, y) <= max_range)))
 		{
 			return 1;
@@ -98,8 +98,8 @@ signed short seg034_000(signed short x_hero, signed short y_hero,
 	}
 
 	if (x_diff == -1) {
-		if ((fight_id_target >= 0) &&
-			((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
+		if ((fighter_id_target >= 0) &&
+			((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
 			&& ((x > 0) && (y == y_hero) && (calc_beeline(x_hero, y_hero, x - 1, y) <= max_range)))
 		{
 			return 1;
@@ -112,8 +112,8 @@ signed short seg034_000(signed short x_hero, signed short y_hero,
 	}
 
 	if (y_diff == 1) {
-		if ((fight_id_target >= 0) &&
-			((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
+		if ((fighter_id_target >= 0) &&
+			((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
 			&& ((y < 23) && (x == x_hero) && (calc_beeline(x_hero, y_hero, x, y + 1) <= max_range)))
 		{
 			return 1;
@@ -126,8 +126,8 @@ signed short seg034_000(signed short x_hero, signed short y_hero,
 	}
 
 	if (y_diff == -1) {
-		if ((fight_id_target >= 0) &&
-			((fight_id_target < 50) || ((fight_id_target >= 50) && is_in_word_array(fight_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
+		if ((fighter_id_target >= 0) &&
+			((fighter_id_target < 50) || ((fighter_id_target >= 50) && is_in_word_array(fighter_id_target - 50, (signed short*)(p_datseg + 0x5f46))))
 			&& ((y > 0) && (x == x_hero) && (calc_beeline(x_hero, y_hero, x, y - 1) <= max_range)))
 		{
 			return 1;
@@ -154,7 +154,7 @@ signed char FIG_cb_select_target(Bit8u *px, Bit8u *py, const signed short max_ra
 	signed short y_diff;
 	signed short x;
 	signed short y;
-	signed short fight_id;
+	signed short fighter_id;
 	signed short x_screen;
 	signed short y_screen;
 	signed short from_kbd;
@@ -300,18 +300,18 @@ signed char FIG_cb_select_target(Bit8u *px, Bit8u *py, const signed short max_ra
 
 			refresh_screen_size();
 			FIG_call_draw_pic();
-			fight_id = get_cb_val(host_readws(px), host_readws(py));
+			fighter_id = get_cb_val(host_readws(px), host_readws(py));
 
-			if ((fight_id > 0) && (fight_id < 50)) {
+			if ((fighter_id > 0) && (fighter_id < 50)) {
 
-				if (fight_id < 10) {
-					FIG_draw_char_pic(1, fight_id);
+				if (fighter_id < 10) {
+					FIG_draw_char_pic(1, fighter_id);
 				} else {
 
-					if (fight_id >= 30) {
-						FIG_draw_enemy_pic(1, fight_id - 20);
+					if (fighter_id >= 30) {
+						FIG_draw_enemy_pic(1, fighter_id - 20);
 					} else {
-						FIG_draw_enemy_pic(1, fight_id);
+						FIG_draw_enemy_pic(1, fighter_id);
 					}
 				}
 			}

--- a/src/custom/schick/rewrite_m302de/seg036.cpp
+++ b/src/custom/schick/rewrite_m302de/seg036.cpp
@@ -511,7 +511,7 @@ signed short KI_get_spell(signed short spell, signed short cursed)
 	signed short retval = -1;
 
 	/* make a pointer to the spell description */
-	p = p_datseg + spell * 10 + 0x99d;
+	p = p_datseg + spell * 10 + SPELL_DESCRIPTIONS;
 
 	if (cursed == 0) {
 		if (host_readb(p + 7) == 2)
@@ -587,7 +587,7 @@ signed short seg036_8cf(Bit8u *hero, signed short hero_pos, signed short cursed,
 			/* get a spell from an array */
 			spell = ds_readbs(AF_SPELL_LIST + l_si);
 
-			if ((ds_readbs(0x9a5 + 10 * spell) == 1) && (random_schick(100) < 50))
+			if ((ds_readbs((SPELL_DESCRIPTIONS + 8) + 10 * spell) == 1) && (random_schick(100) < 50))
 			{
 				decided = 1;
 				break;
@@ -618,7 +618,7 @@ signed short seg036_8cf(Bit8u *hero, signed short hero_pos, signed short cursed,
 				done = 1;
 			} else {
 
-				if (!ds_readbs(0x9a5 + 10 * spell)) {
+				if (!ds_readbs((SPELL_DESCRIPTIONS + 8) + 10 * spell)) {
 
 					while ((host_readbs(hero + HERO_BP_LEFT) != 0) && (done == 0)) {
 

--- a/src/custom/schick/rewrite_m302de/seg036.cpp
+++ b/src/custom/schick/rewrite_m302de/seg036.cpp
@@ -162,7 +162,7 @@ void seg036_00ae(Bit8u *hero, signed short hero_pos)
 	FIG_call_draw_pic();
 	FIG_remove_from_list(ds_readbs(0xe38e), 0);
 	ds_writeb(0xe38e, -1);
-	FIG_set_0e(host_readbs(hero + HERO_FIGHT_ID), 0);
+	FIG_set_0e(host_readbs(hero + HERO_FIGHTER_ID), 0);
 	draw_fight_screen(0);
 	memset(p_datseg + 0xd8ce, -1, 0xf3);
 	FIG_init_list_elem(hero_pos + 1);
@@ -219,7 +219,7 @@ signed short KI_change_hero_weapon(Bit8u *hero)
 		has_new_weapon = 0;
 	}
 
-	ptr = Real2Host(FIG_get_ptr(host_readbs(hero + HERO_FIGHT_ID)));
+	ptr = Real2Host(FIG_get_ptr(host_readbs(hero + HERO_FIGHTER_ID)));
 	host_writeb(ptr + 0x2, host_readbs(hero + HERO_VIEWDIR));
 	host_writeb(ptr + 0xd, -1);
 	draw_fight_screen_pal(0);

--- a/src/custom/schick/rewrite_m302de/seg037.cpp
+++ b/src/custom/schick/rewrite_m302de/seg037.cpp
@@ -395,7 +395,7 @@ signed short test_foe_range_attack(signed short x, signed short y, const signed 
 signed short get_foe_attack_mode(signed short a1, signed short a2)
 {
 	signed short retval = 0;
-	Bit8u *ptr = p_datseg + 0xf13 + a1 * 8;
+	Bit8u *ptr = p_datseg + MON_SPELL_DESCRIPTIONS + a1 * 8;
 
 	if (a2 == 0) {
 
@@ -457,7 +457,7 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 	retval = 0;
 
 	available_spells = l_si = 0;
-	while ((l_si < 5) && (ds_readbs(0xf8b + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + l_si++) != -1))
+	while ((l_si < 5) && (ds_readbs(MON_SPELL_REPERTOIRE + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + l_si++) != -1))
 	{
 		available_spells++;
 	}
@@ -469,9 +469,9 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 
 		for (l_si = 0; l_si < available_spells; l_si++) {
 
-			l2 = ds_readbs(0xf8b + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + l_si);
+			l2 = ds_readbs(MON_SPELL_REPERTOIRE + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + l_si);
 
-			if (ds_readbs(0xf15 + l2 * 8) == 1) {
+			if (ds_readbs((MON_SPELL_DESCRIPTIONS + 2) + l2 * 8) == 1) {
 
 				if (random_schick(100) < 75) {
 					l7 = 1;
@@ -481,7 +481,7 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 		}
 
 		if (l7 == 0) {
-			l2 = ds_readbs(0xf8b + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + random_interval(0, available_spells - 1));
+			l2 = ds_readbs(MON_SPELL_REPERTOIRE + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + random_interval(0, available_spells - 1));
 		}
 
 		host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, 0);
@@ -495,7 +495,7 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 				done = 1;
 			} else {
 
-				if (!ds_readbs(0xf15 + l2 * 8)) {
+				if (!ds_readbs((MON_SPELL_DESCRIPTIONS + 2) + l2 * 8)) {
 
 					while ((host_readbs(enemy + ENEMY_SHEET_BP) != 0) && (done == 0)) {
 

--- a/src/custom/schick/rewrite_m302de/seg037.cpp
+++ b/src/custom/schick/rewrite_m302de/seg037.cpp
@@ -484,12 +484,12 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 			l2 = ds_readbs(MON_SPELL_REPERTOIRE + host_readbs(enemy + ENEMY_SHEET_MAG_ID) * 5 + random_interval(0, available_spells - 1));
 		}
 
-		host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, 0);
+		host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, 0);
 
 		if ( (mode = get_foe_attack_mode(l2, attack_foe)) > 0) {
 
 			if (mode == 3) {
-				host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, enemy_nr + 10);
+				host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, enemy_nr + 10);
 				host_writeb(enemy + ENEMY_SHEET_CUR_SPELL, (signed char)l2);
 				retval = 1;
 				done = 1;
@@ -502,10 +502,10 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 						l_si = host_readbs(enemy + ENEMY_SHEET_VIEWDIR);
 						l_di = 0;
 
-						while (!host_readbs(enemy + ENEMY_SHEET_FIGHT_ID) && (l_di < 4)) {
+						while (!host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID) && (l_di < 4)) {
 
 							if (test_foe_melee_attack(x, y, diff.d[l_si].x, diff.d[l_si].y, mode)) {
-								host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, get_cb_val(x + diff.d[l_si].x, y + diff.d[l_si].y));
+								host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, get_cb_val(x + diff.d[l_si].x, y + diff.d[l_si].y));
 							}
 
 							l_di++;
@@ -514,7 +514,7 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 							}
 						}
 
-						if (host_readbs(enemy + ENEMY_SHEET_FIGHT_ID)) {
+						if (host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID)) {
 							host_writeb(enemy + ENEMY_SHEET_CUR_SPELL, (signed char)l2);
 							retval = 1;
 							done = 1;
@@ -553,9 +553,9 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 						l_si = host_readbs(enemy + ENEMY_SHEET_VIEWDIR);
 						l_di = 0;
 
-						while (!host_readbs(enemy + ENEMY_SHEET_FIGHT_ID) && (l_di < 4)) {
+						while (!host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID) && (l_di < 4)) {
 
-							host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, (signed char)test_foe_range_attack(x, y, l_si, mode));
+							host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, (signed char)test_foe_range_attack(x, y, l_si, mode));
 
 							l_di++;
 							if (++l_si == 4) {
@@ -563,7 +563,7 @@ signed short seg037_0791(Bit8u* enemy, signed short enemy_nr, signed short attac
 							}
 						}
 
-						if (host_readbs(enemy + ENEMY_SHEET_FIGHT_ID)) {
+						if (host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID)) {
 							host_writeb(enemy + ENEMY_SHEET_CUR_SPELL, (signed char)l2);
 							retval = 1;
 							done = 1;
@@ -627,7 +627,7 @@ signed short seg037_0b3e(Bit8u* enemy, signed short enemy_nr, signed short attac
 	while ((done == 0) && (host_readbs(enemy + ENEMY_SHEET_BP) > 0)) {
 
 		/* reset the attackee ID */
-		host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, 0);
+		host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, 0);
 
 		while ( (done == 0) && (host_readbs(enemy + ENEMY_SHEET_BP) > 0)) {
 
@@ -635,9 +635,9 @@ signed short seg037_0b3e(Bit8u* enemy, signed short enemy_nr, signed short attac
 			cnt = 0;
 
 			/* check clockwise for someone to attack */
-			while ( !host_readbs(enemy + ENEMY_SHEET_FIGHT_ID) && (cnt < 4)) {
+			while ( !host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID) && (cnt < 4)) {
 
-				host_writeb(enemy + ENEMY_SHEET_FIGHT_ID,
+				host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID,
 					(signed char)test_foe_range_attack(x, y, dir, attack_foe));
 				cnt++;
 				if (++dir == 4) {
@@ -645,7 +645,7 @@ signed short seg037_0b3e(Bit8u* enemy, signed short enemy_nr, signed short attac
 				}
 			}
 
-			if (host_readbs(enemy + ENEMY_SHEET_FIGHT_ID) != 0) {
+			if (host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID) != 0) {
 				/* found someone to attack */
 				retval = 1;
 				done = 1;
@@ -754,7 +754,7 @@ void enemy_turn(Bit8u *enemy, signed short enemy_nr, signed short x, signed shor
 
 		draw_fight_screen_pal(0);
 
-		host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, 0);
+		host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, 0);
 		host_writeb(enemy + ENEMY_SHEET_DUMMY4, 1);
 
 		/* should I flee */
@@ -819,10 +819,10 @@ void enemy_turn(Bit8u *enemy, signed short enemy_nr, signed short x, signed shor
 				return;
 			}
 
-			host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, 0);
+			host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, 0);
 			dir = host_readbs(enemy + ENEMY_SHEET_VIEWDIR);
 			l3 = 0;
-			while (!(host_readbs(enemy + ENEMY_SHEET_FIGHT_ID)) && (l3 < 4)) {
+			while (!(host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID)) && (l3 < 4)) {
 
 				if (test_foe_melee_attack(x, y, diff.d[dir].x, diff.d[dir].y, attack_foe)) {
 
@@ -845,7 +845,7 @@ void enemy_turn(Bit8u *enemy, signed short enemy_nr, signed short x, signed shor
 					}
 
 					if (l5 != 0) {
-						host_writeb(enemy + ENEMY_SHEET_FIGHT_ID, get_cb_val(x + diff.d[dir].x, y + diff.d[dir].y));
+						host_writeb(enemy + ENEMY_SHEET_FIGHTER_ID, get_cb_val(x + diff.d[dir].x, y + diff.d[dir].y));
 					}
 				}
 
@@ -856,7 +856,7 @@ void enemy_turn(Bit8u *enemy, signed short enemy_nr, signed short x, signed shor
 			}
 		}
 
-		if (host_readbs(enemy + ENEMY_SHEET_FIGHT_ID) != 0) {
+		if (host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID) != 0) {
 			host_writeb(enemy + ENEMY_SHEET_DUMMY4, 2);
 			host_writeb(enemy + ENEMY_SHEET_BP, host_readbs(enemy + ENEMY_SHEET_BP) -3);
 			done = 1;

--- a/src/custom/schick/rewrite_m302de/seg039.cpp
+++ b/src/custom/schick/rewrite_m302de/seg039.cpp
@@ -413,10 +413,10 @@ void FIG_init_heroes(void)
 
 	for (l_si = 0; l_si <= 6; l_si++) {
 
-		if (host_readbs(get_hero(l_si) + HERO_FIGHT_ID) != -1) {
+		if (host_readbs(get_hero(l_si) + HERO_FIGHTER_ID) != -1) {
 
-			FIG_remove_from_list(host_readb(get_hero(l_si) + HERO_FIGHT_ID), 0);
-			host_writeb(get_hero(l_si) + HERO_FIGHT_ID, 0xff);
+			FIG_remove_from_list(host_readb(get_hero(l_si) + HERO_FIGHTER_ID), 0);
+			host_writeb(get_hero(l_si) + HERO_FIGHTER_ID, 0xff);
 		}
 	}
 
@@ -521,7 +521,7 @@ void FIG_init_heroes(void)
 		ds_writeb((FIG_LIST_ELEM+19), 0xff);
 
 
-		host_writeb(get_hero(l_si) + HERO_FIGHT_ID, FIG_add_to_list(-1));
+		host_writeb(get_hero(l_si) + HERO_FIGHTER_ID, FIG_add_to_list(-1));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg040.cpp
+++ b/src/custom/schick/rewrite_m302de/seg040.cpp
@@ -114,7 +114,7 @@ void FIG_preload_gfx(void)
 
 	/* set something in the hero charactersheet to -1 */
 	for (i = 0; i <= 6; i++) {
-		host_writeb(get_hero(i) + HERO_FIGHT_ID, -1);
+		host_writeb(get_hero(i) + HERO_FIGHTER_ID, -1);
 	}
 
 	for (i = 0; i < 20; i++) {

--- a/src/custom/schick/rewrite_m302de/seg041.cpp
+++ b/src/custom/schick/rewrite_m302de/seg041.cpp
@@ -259,7 +259,7 @@ signed short FIG_get_hero_melee_attack_damage(Bit8u* hero, Bit8u* target, signed
 
 	if (v11 != -1) {
 
-		p2 = p_datseg + 0x6b0 + host_readbs(item_p_rh + 4) * 7;
+		p2 = p_datseg + 0x06b0+ host_readbs(item_p_rh + 4) * 7;
 
 		damage = dice_roll(host_readbs(p2), 6, host_readbs(p2 + 1));
 
@@ -295,7 +295,7 @@ signed short FIG_get_hero_melee_attack_damage(Bit8u* hero, Bit8u* target, signed
 				v4 = 6;
 			}
 
-			p3 = p_datseg + 0x668 + host_readbs(p2 + 4) * 8;
+			p3 = p_datseg + 0x0668+ host_readbs(p2 + 4) * 8;
 
 			if (attack_hero != 0) {
 				if (host_readbs(target + 0x21) == 6) {
@@ -312,7 +312,7 @@ signed short FIG_get_hero_melee_attack_damage(Bit8u* hero, Bit8u* target, signed
 			l_di = (test_skill(hero,
 					(host_readbs(item_p_rh + 3) == 8 ? 8 : 7),
 					host_readbs(p3 + 7) + 2 * v4 - 2 * target_size) > 0)
-				? ds_readbs(0x668 + 8 * host_readbs(p2 + 4) + v4)
+				? ds_readbs(0x0668 + 8 * host_readbs(p2 + 4) + v4)
 				: -damage;
 
 			if (l_di != 0) {

--- a/src/custom/schick/rewrite_m302de/seg042.cpp
+++ b/src/custom/schick/rewrite_m302de/seg042.cpp
@@ -667,7 +667,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 					ds_writew(0xe3a8, 1);
 				}
 
-				l6 = ds_readbs((0x99d + 6) + 10 * host_readbs(Real2Host(hero) + HERO_SPELL_ID));
+				l6 = ds_readbs((SPELL_DESCRIPTIONS + 6) + 10 * host_readbs(Real2Host(hero) + HERO_SPELL_ID));
 
 				host_writeb(Real2Host(ds_readd(DTP2)), 0);
 

--- a/src/custom/schick/rewrite_m302de/seg042.cpp
+++ b/src/custom/schick/rewrite_m302de/seg042.cpp
@@ -46,7 +46,7 @@ struct msg {
  * \brief	executes the fight action of hero
  *
  * \param hero		pointer to the hero
- * \param hero_pos	position in the group (fight_id = hero_pos + 1)
+ * \param hero_pos	position in the group (fighter_id = hero_pos + 1)
  */
 void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 {
@@ -74,7 +74,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 	signed short height;
 	signed short l16 = 0;
 	signed short l17 = 0;
-	signed short fight_id;
+	signed short fighter_id;
 	struct dummy dst = *(struct dummy*)(p_datseg + 0x6178);
 	signed short hero_x;
 	signed short hero_y;
@@ -155,14 +155,14 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 
 				if (host_readbs(target_monster + ENEMY_SHEET_VIEWDIR) != dir) {
 
-					fight_id = get_cb_val(hero_x + dst.a[dir].x, hero_y + dst.a[dir].y);
+					fighter_id = get_cb_val(hero_x + dst.a[dir].x, hero_y + dst.a[dir].y);
 
-					if (fight_id != 0) {
+					if (fighter_id != 0) {
 
-						if ((fight_id >= 50) ||
-							((fight_id < 10) && !hero_dead(get_hero(fight_id - 1))) ||
-							((fight_id >= 10) && (fight_id < 30) && !enemy_dead((p_datseg + 0xd0df) + (SIZEOF_ENEMY_SHEET * fight_id))) ||
-							((fight_id >= 30) && (fight_id < 50) && !enemy_dead((p_datseg + 0xcc07) + (SIZEOF_ENEMY_SHEET * fight_id))))
+						if ((fighter_id >= 50) ||
+							((fighter_id < 10) && !hero_dead(get_hero(fighter_id - 1))) ||
+							((fighter_id >= 10) && (fighter_id < 30) && !enemy_dead((p_datseg + 0xd0df) + (SIZEOF_ENEMY_SHEET * fighter_id))) ||
+							((fighter_id >= 30) && (fighter_id < 50) && !enemy_dead((p_datseg + 0xcc07) + (SIZEOF_ENEMY_SHEET * fighter_id))))
 						{
 							l16 = 1;
 						}
@@ -184,7 +184,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 
 					and_ptr_bs(target_hero + HERO_STATUS1, 0xfd);
 
-					p4 = Real2Host(FIG_get_ptr(host_readbs(target_hero + HERO_FIGHT_ID)));
+					p4 = Real2Host(FIG_get_ptr(host_readbs(target_hero + HERO_FIGHTER_ID)));
 
 					host_writeb(p4 + 0x02, host_readbs(target_hero + HERO_VIEWDIR));
 					host_writeb(p4 + 0x0d, -1);
@@ -614,13 +614,13 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 						l17 == 0 ? host_readbs(Real2Host(hero) + HERO_ENEMY_ID) : host_readbs(Real2Host(hero) + HERO_ENEMY_ID) + 20,
 						host_readbs(Real2Host(hero) + HERO_VIEWDIR));
 
-					FIG_set_0e(host_readbs(Real2Host(hero) + HERO_FIGHT_ID), 0);
+					FIG_set_0e(host_readbs(Real2Host(hero) + HERO_FIGHTER_ID), 0);
 
 					draw_fight_screen_pal(0);
 
 					if (FIG_get_range_weapon_type(Real2Host(hero)) == -1) {
 
-						p4 = Real2Host(FIG_get_ptr(host_readbs(Real2Host(hero) + HERO_FIGHT_ID)));
+						p4 = Real2Host(FIG_get_ptr(host_readbs(Real2Host(hero) + HERO_FIGHTER_ID)));
 
 						host_writeb(p4 + 0x02, host_readbs(Real2Host(hero) + HERO_VIEWDIR));
 						host_writeb(p4 + 0x0d, -1);
@@ -759,7 +759,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 
 					if (l15 != -1) {
 
-						FIG_set_0e(host_readbs(Real2Host(hero) + HERO_FIGHT_ID), 0);
+						FIG_set_0e(host_readbs(Real2Host(hero) + HERO_FIGHTER_ID), 0);
 						draw_fight_screen_pal(1);
 					}
 
@@ -829,7 +829,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 
 								if (host_readbs(Real2Host(hero) + HERO_ENEMY_ID) > 0) {
 
-									FIG_set_0e(host_readbs(target_hero + HERO_FIGHT_ID), 1);
+									FIG_set_0e(host_readbs(target_hero + HERO_FIGHTER_ID), 1);
 								}
 							}
 						}
@@ -857,7 +857,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 							} else {
 								if (host_readbs(Real2Host(hero) + HERO_ENEMY_ID) > 0) {
 
-									FIG_reset_12_13(host_readbs(target_hero + HERO_FIGHT_ID));
+									FIG_reset_12_13(host_readbs(target_hero + HERO_FIGHTER_ID));
 								}
 							}
 						}

--- a/src/custom/schick/rewrite_m302de/seg043.cpp
+++ b/src/custom/schick/rewrite_m302de/seg043.cpp
@@ -44,7 +44,7 @@ struct msg {
  * \brief	execute the fight action of a monster
  *
  * \param	monster		pointer to a monster datasheet
- * \param	monster_pos	position of the monster (fight_id = monster_pos + 10)
+ * \param	monster_pos	position of the monster (fighter_id = monster_pos + 10)
  */
 void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 {
@@ -69,7 +69,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 	signed short l15;
 	Bit8u *l16;
 	signed short l17 = 0;
-	signed short fight_id;
+	signed short fighter_id;
 	signed short hero_x;
 	signed short hero_y;
 	signed short target_x;
@@ -89,13 +89,13 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 		ds_writew(FIG_ACTOR_GRAMMAR_TYPE, 1);
 		ds_writew(FIG_ACTOR_GRAMMAR_ID, host_readbs(Real2Host(monster)));
 
-		if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
+		if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) < 10) {
 
 			/* monster attacks hero */
-			hero = get_hero(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) - 1);
+			hero = get_hero(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) - 1);
 
 			ds_writew(FIG_TARGET_GRAMMAR_TYPE, 2);
-			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) - 1);
+			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) - 1);
 
 			if (hero_dead(hero) || !host_readbs(hero + HERO_TYPE)) {
 				return;
@@ -104,7 +104,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			attack_hero = 1;
 		} else {
 
-			mon = p_datseg + 0xd0df + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID);
+			mon = p_datseg + 0xd0df + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID);
 
 			ds_writew(FIG_TARGET_GRAMMAR_TYPE, 1);
 			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(mon));
@@ -118,7 +118,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			if ((is_in_byte_array(host_readbs(mon + 1), p_datseg + TWO_FIELDED_SPRITE_ID)) &&
 				(l17 == 0))
 			{
-				FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), &target_x, &target_y);
+				FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), &target_x, &target_y);
 				FIG_search_obj_on_cb(monster_pos + 10, &hero_x, &hero_y);
 
 #if !defined(__BORLANDC__)
@@ -145,14 +145,14 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				if (host_readbs(mon + ENEMY_SHEET_VIEWDIR) != dir) {
 
-					fight_id = get_cb_val(hero_x + dst.a[dir].x, hero_y + dst.a[dir].y);
+					fighter_id = get_cb_val(hero_x + dst.a[dir].x, hero_y + dst.a[dir].y);
 
-					if (fight_id != 0) {
+					if (fighter_id != 0) {
 
-						if ((fight_id >= 50) ||
-							((fight_id < 10) && !hero_dead(get_hero(fight_id - 1))) ||
-							((fight_id >= 10) && (fight_id < 30) && !enemy_dead((p_datseg + 0xd0df) + (SIZEOF_ENEMY_SHEET * fight_id))) ||
-							((fight_id >= 30) && (fight_id < 50) && !enemy_dead((p_datseg + 0xcc07) + (SIZEOF_ENEMY_SHEET * fight_id))))
+						if ((fighter_id >= 50) ||
+							((fighter_id < 10) && !hero_dead(get_hero(fighter_id - 1))) ||
+							((fighter_id >= 10) && (fighter_id < 30) && !enemy_dead((p_datseg + 0xd0df) + (SIZEOF_ENEMY_SHEET * fighter_id))) ||
+							((fighter_id >= 30) && (fighter_id < 50) && !enemy_dead((p_datseg + 0xcc07) + (SIZEOF_ENEMY_SHEET * fighter_id))))
 						{
 							l17 = 1;
 						}
@@ -164,7 +164,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 		if (host_readbs(Real2Host(monster) + ENEMY_SHEET_DUMMY4) == 2) {
 
-			if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
+			if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) < 10) {
 
 				/* attack a hero */
 
@@ -218,7 +218,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			if (attack_hero != 0) {
 
 				/* TODO */
-				if (ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) == 1) {
+				if (ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)) == 1) {
 					l7 += 2;
 				}
 
@@ -233,7 +233,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 				}
 			} else {
 				/* TODO */
-				if (ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) == 1) {
+				if (ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)) == 1) {
 					l7 += 2;
 				}
 			}
@@ -296,8 +296,8 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				if (randval <= l7) {
 
-					if (((attack_hero != 0) && !ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) && check_hero(hero)) ||
-						(!attack_hero && (!ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)))))
+					if (((attack_hero != 0) && !ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)) && check_hero(hero)) ||
+						(!attack_hero && (!ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID)))))
 					{
 
 						l6 = random_schick(20);
@@ -445,16 +445,16 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				if (check_hero(hero) || (ds_readws(0xe3a6) != 0)) {
 
-					FIG_prepare_hero_fight_ani(0, hero, weapon_type, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+					FIG_prepare_hero_fight_ani(0, hero, weapon_type, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 				}
 
 			} else if (l17 == 0) {
-					FIG_prepare_enemy_fight_ani(0, mon, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+					FIG_prepare_enemy_fight_ani(0, mon, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 			} else if (ds_readws(0xe3a6) != 0) {
-					FIG_prepare_enemy_fight_ani(0, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+					FIG_prepare_enemy_fight_ani(0, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 			}
 
-			FIG_prepare_enemy_fight_ani(1, Real2Host(monster), 2, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
+			FIG_prepare_enemy_fight_ani(1, Real2Host(monster), 2, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), 0);
 			ds_writew(0x26b1, 1);
 			draw_fight_screen_pal(0);
 			seg041_8c8();
@@ -519,9 +519,9 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				FIG_call_draw_pic();
 
-				FIG_prepare_enemy_fight_ani(0, Real2Host(monster), 15, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
+				FIG_prepare_enemy_fight_ani(0, Real2Host(monster), 15, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), 0);
 
-				l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
+				l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
 
 				FIG_set_0e(host_readbs(Real2Host(monster) + ENEMY_SHEET_LIST_POS), 0);
 
@@ -542,10 +542,10 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 					if (attack_hero != 0) {
 
-						FIG_prepare_hero_fight_ani(1, hero, -1, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+						FIG_prepare_hero_fight_ani(1, hero, -1, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 					} else {
 
-						FIG_prepare_enemy_fight_ani(1, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+						FIG_prepare_enemy_fight_ani(1, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 					}
 				}
 
@@ -565,7 +565,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				seg041_8c8();
 
-				if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) != 0) {
+				if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) != 0) {
 
 					l11 = l12 = 0;
 
@@ -573,7 +573,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 						l11 = 1;
 					}
 
-					if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
+					if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) < 10) {
 						l11 = 2;
 					}
 
@@ -581,7 +581,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 					if (l13 != -1) {
 
-						seg044_002f(0, Real2Host(monster), 4, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
+						seg044_002f(0, Real2Host(monster), 4, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), 0);
 					}
 
 					if (l13 > 0) {
@@ -592,16 +592,16 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 						} else {
 
-							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) > 0) {
 
 								if (!attack_hero) {
 
-									seg044_002f(1, mon, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
+									seg044_002f(1, mon, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), monster_pos + 10, 1);
 								} else {
 
 									if (check_hero(hero) || (ds_readws(0xe3a6) != 0)) {
 
-										seg044_002a(1, hero, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0, -1, 1);
+										seg044_002a(1, hero, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), 0, -1, 1);
 									}
 								}
 							}
@@ -609,9 +609,9 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 						if ((host_readbs(Real2Host(monster) + ENEMY_SHEET_GFX_ID) != 0x12) &&
 							(host_readbs(Real2Host(monster) + ENEMY_SHEET_GFX_ID) != 7) &&
-							(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0))
+							(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) > 0))
 						{
-							l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
+							l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
 						}
 
 					}
@@ -650,9 +650,9 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 							}
 						} else {
 
-							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) > 0) {
 
-								FIG_set_0e(host_readbs(hero + HERO_FIGHT_ID), 1);
+								FIG_set_0e(host_readbs(hero + HERO_FIGHTER_ID), 1);
 							}
 						}
 
@@ -698,7 +698,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 						if (ds_readws(0xe3a4) != 0) {
 
-							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) >= 10) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) >= 10) {
 
 								FIG_reset_12_13(host_readbs(mon + ENEMY_SHEET_LIST_POS));
 
@@ -710,9 +710,9 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 								}
 							} else {
 
-								if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
+								if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHTER_ID) > 0) {
 
-									FIG_reset_12_13(host_readbs(hero + HERO_FIGHT_ID));
+									FIG_reset_12_13(host_readbs(hero + HERO_FIGHTER_ID));
 								}
 							}
 						}

--- a/src/custom/schick/rewrite_m302de/seg043.cpp
+++ b/src/custom/schick/rewrite_m302de/seg043.cpp
@@ -557,7 +557,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				/* spellcast */
 
-				l14 = ds_readbs((0x0f13 + 0x7) + 8 * host_readbs(Real2Host(monster) + 0x2c));
+				l14 = ds_readbs((MON_SPELL_DESCRIPTIONS + 0x7) + 8 * host_readbs(Real2Host(monster) + 0x2c));
 
 				host_writebs(Real2Host(ds_readd(DTP2)), 0);
 

--- a/src/custom/schick/rewrite_m302de/seg043.cpp
+++ b/src/custom/schick/rewrite_m302de/seg043.cpp
@@ -89,13 +89,13 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 		ds_writew(FIG_ACTOR_GRAMMAR_TYPE, 1);
 		ds_writew(FIG_ACTOR_GRAMMAR_ID, host_readbs(Real2Host(monster)));
 
-		if (host_readbs(Real2Host(monster) + 0x2d) < 10) {
+		if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
 
 			/* monster attacks hero */
-			hero = get_hero(host_readbs(Real2Host(monster) + 0x2d) - 1);
+			hero = get_hero(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) - 1);
 
 			ds_writew(FIG_TARGET_GRAMMAR_TYPE, 2);
-			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(Real2Host(monster) + 0x2d) - 1);
+			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) - 1);
 
 			if (hero_dead(hero) || !host_readbs(hero + HERO_TYPE)) {
 				return;
@@ -104,7 +104,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			attack_hero = 1;
 		} else {
 
-			mon = p_datseg + 0xd0df + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + 0x2d);
+			mon = p_datseg + 0xd0df + SIZEOF_ENEMY_SHEET * host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID);
 
 			ds_writew(FIG_TARGET_GRAMMAR_TYPE, 1);
 			ds_writew(FIG_TARGET_GRAMMAR_ID, host_readbs(mon));
@@ -118,7 +118,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			if ((is_in_byte_array(host_readbs(mon + 1), p_datseg + TWO_FIELDED_SPRITE_ID)) &&
 				(l17 == 0))
 			{
-				FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + 0x2d), &target_x, &target_y);
+				FIG_search_obj_on_cb(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), &target_x, &target_y);
 				FIG_search_obj_on_cb(monster_pos + 10, &hero_x, &hero_y);
 
 #if !defined(__BORLANDC__)
@@ -162,9 +162,9 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			}
 		}
 
-		if (host_readbs(Real2Host(monster) + 0x2b) == 2) {
+		if (host_readbs(Real2Host(monster) + ENEMY_SHEET_DUMMY4) == 2) {
 
-			if (host_readbs(Real2Host(monster) + 0x2d) < 10) {
+			if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
 
 				/* attack a hero */
 
@@ -210,7 +210,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 				pa -= 4;
 			}
 
-			l7 = host_readbs(Real2Host(monster) + 0x1c);
+			l7 = host_readbs(Real2Host(monster) + ENEMY_SHEET_AT);
 			if (ds_readds(INGAME_TIMERS + 0x24)) {
 				l7 -= 4;
 			}
@@ -218,7 +218,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 			if (attack_hero != 0) {
 
 				/* TODO */
-				if (ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + 0x2d)) == 1) {
+				if (ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) == 1) {
 					l7 += 2;
 				}
 
@@ -233,7 +233,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 				}
 			} else {
 				/* TODO */
-				if (ds_readbs(0xd82d + host_readbs(Real2Host(monster) + 0x2d)) == 1) {
+				if (ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) == 1) {
 					l7 += 2;
 				}
 			}
@@ -296,8 +296,8 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				if (randval <= l7) {
 
-					if (((attack_hero != 0) && !ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + 0x2d)) && check_hero(hero)) ||
-						(!attack_hero && (!ds_readbs(0xd82d + host_readbs(Real2Host(monster) + 0x2d)))))
+					if (((attack_hero != 0) && !ds_readbs((HERO_IS_TARGET-1) + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)) && check_hero(hero)) ||
+						(!attack_hero && (!ds_readbs(0xd82d + host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID)))))
 					{
 
 						l6 = random_schick(20);
@@ -445,37 +445,37 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				if (check_hero(hero) || (ds_readws(0xe3a6) != 0)) {
 
-					FIG_prepare_hero_fight_ani(0, hero, weapon_type, 100, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+					FIG_prepare_hero_fight_ani(0, hero, weapon_type, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 				}
 
 			} else if (l17 == 0) {
-					FIG_prepare_enemy_fight_ani(0, mon, 100, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+					FIG_prepare_enemy_fight_ani(0, mon, 100, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 			} else if (ds_readws(0xe3a6) != 0) {
-					FIG_prepare_enemy_fight_ani(0, mon, 0, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+					FIG_prepare_enemy_fight_ani(0, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 			}
 
-			FIG_prepare_enemy_fight_ani(1, Real2Host(monster), 2, monster_pos + 10, host_readbs(Real2Host(monster) + 0x2d), 0);
+			FIG_prepare_enemy_fight_ani(1, Real2Host(monster), 2, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
 			ds_writew(0x26b1, 1);
 			draw_fight_screen_pal(0);
 			seg041_8c8();
 
 		} else {
 
-			if (host_readbs(Real2Host(monster) + 0x2b) == 15) {
+			if (host_readbs(Real2Host(monster) + ENEMY_SHEET_DUMMY4) == 15) {
 
-				if (host_readbs(Real2Host(monster) + 0x37) > 0) {
+				if (host_readbs(Real2Host(monster) + ENEMY_SHEET_SHOTS) > 0) {
 					l15 = 3;
-					dec_ptr_bs(Real2Host(monster) + 0x37);
+					dec_ptr_bs(Real2Host(monster) + ENEMY_SHEET_SHOTS);
 				} else {
 					l15 = 4;
-					dec_ptr_bs(Real2Host(monster) + 0x3a);
+					dec_ptr_bs(Real2Host(monster) + ENEMY_SHEET_THROWS);
 				}
 
 				if (attack_hero != 0) {
 
 					/* attack_hero */
 
-					damage = dice_template(l15 == 3 ? host_readws(Real2Host(monster) + 0x38) : host_readws(Real2Host(monster) + 0x3b));
+					damage = dice_template(l15 == 3 ? host_readws(Real2Host(monster) + ENEMY_SHEET_SHOT_DAM) : host_readws(Real2Host(monster) + ENEMY_SHEET_THROW_DAM));
 
 					damage = (damage * 8) / 10;
 
@@ -497,7 +497,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 					/* attack monster */
 
-					damage = dice_template(l15 == 3 ? host_readws(Real2Host(monster) + 0x38) : host_readws(Real2Host(monster) + 0x3b))
+					damage = dice_template(l15 == 3 ? host_readws(Real2Host(monster) + ENEMY_SHEET_SHOT_DAM) : host_readws(Real2Host(monster) + ENEMY_SHEET_THROW_DAM))
 							- host_readbs(mon + ENEMY_SHEET_RS);
 
 					if (damage > 0) {
@@ -519,11 +519,11 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				FIG_call_draw_pic();
 
-				FIG_prepare_enemy_fight_ani(0, Real2Host(monster), 15, monster_pos + 10, host_readbs(Real2Host(monster) + 0x2d), 0);
+				FIG_prepare_enemy_fight_ani(0, Real2Host(monster), 15, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
 
-				l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + 0x2d), host_readbs(Real2Host(monster) + 0x27));
+				l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
 
-				FIG_set_0e(host_readbs(Real2Host(monster) + 0x26), 0);
+				FIG_set_0e(host_readbs(Real2Host(monster) + ENEMY_SHEET_LIST_POS), 0);
 
 				draw_fight_screen_pal(0);
 
@@ -542,10 +542,10 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 					if (attack_hero != 0) {
 
-						FIG_prepare_hero_fight_ani(1, hero, -1, 0, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+						FIG_prepare_hero_fight_ani(1, hero, -1, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 					} else {
 
-						FIG_prepare_enemy_fight_ani(1, mon, 0, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+						FIG_prepare_enemy_fight_ani(1, mon, 0, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 					}
 				}
 
@@ -553,11 +553,11 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 				draw_fight_screen(0);
 				seg041_8c8();
 
-			} else if (host_readbs(Real2Host(monster) + 0x2b) == 4) {
+			} else if (host_readbs(Real2Host(monster) + ENEMY_SHEET_DUMMY4) == 4) {
 
 				/* spellcast */
 
-				l14 = ds_readbs((MON_SPELL_DESCRIPTIONS + 0x7) + 8 * host_readbs(Real2Host(monster) + 0x2c));
+				l14 = ds_readbs((MON_SPELL_DESCRIPTIONS + 0x7) + 8 * host_readbs(Real2Host(monster) + ENEMY_SHEET_CUR_SPELL));
 
 				host_writebs(Real2Host(ds_readd(DTP2)), 0);
 
@@ -565,7 +565,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				seg041_8c8();
 
-				if (host_readbs(Real2Host(monster) + 0x2d) != 0) {
+				if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) != 0) {
 
 					l11 = l12 = 0;
 
@@ -573,7 +573,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 						l11 = 1;
 					}
 
-					if (host_readbs(Real2Host(monster) + 0x2d) < 10) {
+					if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) < 10) {
 						l11 = 2;
 					}
 
@@ -581,7 +581,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 					if (l13 != -1) {
 
-						seg044_002f(0, Real2Host(monster), 4, monster_pos + 10, host_readbs(Real2Host(monster) + 0x2d), 0);
+						seg044_002f(0, Real2Host(monster), 4, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0);
 					}
 
 					if (l13 > 0) {
@@ -592,32 +592,32 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 						} else {
 
-							if (host_readbs(Real2Host(monster) + 0x2d) > 0) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
 
 								if (!attack_hero) {
 
-									seg044_002f(1, mon, 99, host_readbs(Real2Host(monster) + 0x2d), monster_pos + 10, 1);
+									seg044_002f(1, mon, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), monster_pos + 10, 1);
 								} else {
 
 									if (check_hero(hero) || (ds_readws(0xe3a6) != 0)) {
 
-										seg044_002a(1, hero, 99, host_readbs(Real2Host(monster) + 0x2d), 0, -1, 1);
+										seg044_002a(1, hero, 99, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), 0, -1, 1);
 									}
 								}
 							}
 						}
 
-						if ((host_readbs(Real2Host(monster) + 0x01) != 0x12) &&
-							(host_readbs(Real2Host(monster) + 0x01) != 7) &&
-							(host_readbs(Real2Host(monster) + 0x2d) > 0))
+						if ((host_readbs(Real2Host(monster) + ENEMY_SHEET_GFX_ID) != 0x12) &&
+							(host_readbs(Real2Host(monster) + ENEMY_SHEET_GFX_ID) != 7) &&
+							(host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0))
 						{
-							l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + 0x2d), host_readbs(Real2Host(monster) + 0x27));
+							l12 = seg045_01a0(7, l11, monster_pos + 10, host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID), host_readbs(Real2Host(monster) + ENEMY_SHEET_VIEWDIR));
 						}
 
 					}
 					if (l13 != -1) {
 
-						FIG_set_0e(host_readbs(Real2Host(monster) + 0x26), 0);
+						FIG_set_0e(host_readbs(Real2Host(monster) + ENEMY_SHEET_LIST_POS), 0);
 
 						draw_fight_screen_pal(1);
 					}
@@ -650,7 +650,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 							}
 						} else {
 
-							if (host_readbs(Real2Host(monster) + 0x2d) > 0) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
 
 								FIG_set_0e(host_readbs(hero + HERO_FIGHT_ID), 1);
 							}
@@ -698,7 +698,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 						if (ds_readws(0xe3a4) != 0) {
 
-							if (host_readbs(Real2Host(monster) + 0x2d) >= 10) {
+							if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) >= 10) {
 
 								FIG_reset_12_13(host_readbs(mon + ENEMY_SHEET_LIST_POS));
 
@@ -710,7 +710,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 								}
 							} else {
 
-								if (host_readbs(Real2Host(monster) + 0x2d) > 0) {
+								if (host_readbs(Real2Host(monster) + ENEMY_SHEET_FIGHT_ID) > 0) {
 
 									FIG_reset_12_13(host_readbs(hero + HERO_FIGHT_ID));
 								}

--- a/src/custom/schick/rewrite_m302de/seg044.cpp
+++ b/src/custom/schick/rewrite_m302de/seg044.cpp
@@ -316,14 +316,14 @@ void FIG_prepare_hero_fight_ani(signed short a1, Bit8u *hero, signed short weapo
 		((ds_readw(0xe3a8) != 0) && (a7 == 0)) ||
 		((ds_readw(0xe3a6) != 0) && (a7 == 1)))
 	{
-		FIG_set_0e(host_readb(hero + HERO_FIGHT_ID), (signed char)a1);
+		FIG_set_0e(host_readb(hero + HERO_FIGHTER_ID), (signed char)a1);
 		host_writebs(p1, -1);
 
 		if ( (weapon_type != -1) && (weapon_type < 3) &&
 			(host_readb(hero + HERO_TYPE) != 9) &&
 			(host_readb(hero + HERO_TYPE) != 8))
 		{
-			FIG_set_0f(host_readb(hero + HERO_FIGHT_ID), a1 + 4);
+			FIG_set_0f(host_readb(hero + HERO_FIGHTER_ID), a1 + 4);
 			host_writeb(p2, 0xff);
 		}
 	}

--- a/src/custom/schick/rewrite_m302de/seg045.cpp
+++ b/src/custom/schick/rewrite_m302de/seg045.cpp
@@ -18,13 +18,13 @@
 namespace M302de {
 #endif
 
-void seg045_0000(signed short fight_id, signed short type, signed short a3)
+void seg045_0000(signed short fighter_id, signed short type, signed short a3)
 {
 	signed short obj_x;
 	signed short obj_y;
 	struct nvf_desc nvf;
 
-	FIG_search_obj_on_cb(fight_id, &obj_x, &obj_y);
+	FIG_search_obj_on_cb(fighter_id, &obj_x, &obj_y);
 
 #if !defined(__BORLANDC__)
 	/* BE-fix */
@@ -110,7 +110,7 @@ signed short FIG_copy_it(Bit8u *dst, Bit8u *src, signed char term)
 	return i;
 }
 
-signed short seg045_01a0(signed short a1, signed short a2, signed short fight_id1, signed short fight_id2, signed short a5)
+signed short seg045_01a0(signed short a1, signed short a2, signed short fighter_id1, signed short fighter_id2, signed short a5)
 {
 	signed short i;
 	Bit8u *ptr;
@@ -120,8 +120,8 @@ signed short seg045_01a0(signed short a1, signed short a2, signed short fight_id
 	signed short id2_y;
 	signed short beeline;
 
-	FIG_search_obj_on_cb(fight_id2, &id2_x, &id2_y);
-	FIG_search_obj_on_cb(fight_id1, &id1_x, &id1_y);
+	FIG_search_obj_on_cb(fighter_id2, &id2_x, &id2_y);
+	FIG_search_obj_on_cb(fighter_id1, &id1_x, &id1_y);
 
 #if !defined(__BORLANDC__)
 	/* BE-fix */
@@ -146,7 +146,7 @@ signed short seg045_01a0(signed short a1, signed short a2, signed short fight_id
 	}
 	host_writeb(ptr, -1);
 
-	seg045_0000(fight_id1, a2, a5);
+	seg045_0000(fighter_id1, a2, a5);
 
 	return 1;
 }
@@ -257,7 +257,7 @@ void seg045_041b(signed short a1, Bit8u *enemy, signed short spell_ani_id)
 #endif
 
 	/* search the target on the chessboard */
-	FIG_search_obj_on_cb(host_readbs(enemy + ENEMY_SHEET_FIGHT_ID), &x, &y);
+	FIG_search_obj_on_cb(host_readbs(enemy + ENEMY_SHEET_FIGHTER_ID), &x, &y);
 
 	ptr = p_datseg + a1 * 0xf3 + (0xd8ce + 1);
 

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -90,12 +90,12 @@ void status_show_talent(Bit8u *hero, unsigned short talent, unsigned short ftig,
 
 /**
  *	status_show_talents -	shows all talents and their values
- *	@hero:	the hero which talents should be shown
+ *	@hero:	the hero whose talents should be shown
  */
 /* Borlandified and identical */
 void status_show_talents(Bit8u *hero) {
 
-	signed short i, j;
+	signed short skill_category, skill_nr;
 
 	set_textcolor(0xff, 2);
 
@@ -123,15 +123,15 @@ void status_show_talents(Bit8u *hero) {
 
 	set_textcolor(0, 2);
 
-	for (i = 0; i < 7; i++) {
-		j = ds_readbs(0x10ce + i * 2);
-		while (ds_readbs(0x10ce + i * 2) + ds_readbs(0x10cf + i * 2) > j) {
-			status_show_talent(hero, j,
-				ds_readbs(0x10ce + i * 2),
-				ds_readw(0x6476 + i * 6),
-				ds_readw((0x6476 + 2) + i * 6),
-				ds_readw((0x6476 + 4) + i * 6));
-			j++;
+	for (skill_category = 0; skill_category < 7; skill_category++) {
+		skill_nr = ds_readbs(SKILLS_INDEX + skill_category * 2);
+		while (ds_readbs(SKILLS_INDEX + skill_category * 2) + ds_readbs((SKILLS_INDEX + 1) + skill_category * 2) > skill_nr) {
+			status_show_talent(hero, skill_nr,
+				ds_readbs(SKILLS_INDEX + skill_category * 2),
+				ds_readw(0x6476 + skill_category * 6),
+				ds_readw((0x6476 + 2) + skill_category * 6),
+				ds_readw((0x6476 + 4) + skill_category * 6));
+			skill_nr++;
 		}
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -240,12 +240,12 @@ void status_show(Bit16u index)
 
 		for (i = 0; i < 23; i++) {
 
-			if (host_readw(Real2Host(hero) + i * 14 + 0x196) == 0)
+			if (host_readw(Real2Host(hero) + i * 14 + HERO_ITEM_HEAD) == 0)
 				continue;
 
 			nvf.dst = Real2Host(ds_readd(ICON));
 			/* set nr */
-			nvf.nr = host_readw(get_itemsdat(host_readw(Real2Host(hero) + i * 14 + 0x196)));
+			nvf.nr = host_readw(get_itemsdat(host_readw(Real2Host(hero) + i * 14 + HERO_ITEM_HEAD)));
 
 			process_nvf(&nvf);
 
@@ -262,15 +262,15 @@ void status_show(Bit16u index)
 
 			/* check if stackable */
 			/* TODO: bit flags operation */
-			if (item_stackable(get_itemsdat(host_readw(Real2Host(hero) + i * 14 + 0x196)))) {
+			if (item_stackable(get_itemsdat(host_readw(Real2Host(hero) + i * 14 + HERO_ITEM_HEAD)))) {
 
 				set_textcolor(0xff, 0);
 				/* originally itoa() */
 #if !defined(__BORLANDC__)
 				sprintf((char*)Real2Host(ds_readd(DTP2)), "%d",
-					host_readw(Real2Host(hero) + i * 14 + 0x196 + 2));
+					host_readw(Real2Host(hero) + i * 14 + HERO_ITEM_HEAD + 2));
 #else
-				itoa(host_readw(Real2Host(hero) + i * 14 + 0x196 + 2),
+				itoa(host_readw(Real2Host(hero) + i * 14 + HERO_ITEM_HEAD + 2),
 					(char*)Real2Host(ds_readd(DTP2)), 10);
 #endif
 
@@ -384,7 +384,7 @@ void status_show(Bit16u index)
 
 			for (i = 0; i <= 13; i++) {
 
-				val = host_readbs(Real2Host(hero) + i * 3 + 0x35)
+				val = host_readbs(Real2Host(hero) + i * 3 + HERO_MU)
 					+ host_readbs(Real2Host(hero) + i * 3 + 0x36);
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + i * 10,
@@ -557,10 +557,10 @@ void status_show(Bit16u index)
 			ds_writew(TXT_TABPOS1, 275);
 			ds_writew(TXT_TABPOS2, 295);
 
-			j = (host_readbs(Real2Host(hero) + 0x38) +
-				host_readbs(Real2Host(hero) + 0x39) +
-				host_readbs(Real2Host(hero) + 0x41) +
-				host_readbs(Real2Host(hero) + 0x42) +
+			j = (host_readbs(Real2Host(hero) + HERO_KL) +
+				host_readbs(Real2Host(hero) + HERO_KL_MOD) +
+				host_readbs(Real2Host(hero) + HERO_GE) +
+				host_readbs(Real2Host(hero) + HERO_GE_MOD) +
 				host_readbs(Real2Host(hero) + HERO_KK) +
 				host_readbs(Real2Host(hero) + HERO_KK_MOD)) / 4;
 
@@ -598,36 +598,36 @@ void status_show(Bit16u index)
 				host_readbs(Real2Host(hero) + HERO_PA) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xc4)),
 
-				host_readbs(Real2Host(hero) + 0x69) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x70) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 1)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 1)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xc8)),
 
-				host_readbs(Real2Host(hero) + 0x6a) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x71) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 2)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 2)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xcc)),
 
-				host_readbs(Real2Host(hero) + 0x6b) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x72) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 3)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 3)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xd0)),
 
-				host_readbs(Real2Host(hero) + 0x6c) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x73) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 4)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 4)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xd4)),
 
-				host_readbs(Real2Host(hero) + 0x6d) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x74) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 5)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 5)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xd8)),
 
-				host_readbs(Real2Host(hero) + 0x6e) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
-				host_readbs(Real2Host(hero) + 0x75) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_AT + 6)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
+				host_readbs(Real2Host(hero) + (HERO_PA + 6)) - host_readbs(Real2Host(hero) + HERO_RS_BE) / 2,
 				at,
 				pa,
 
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xdc)),
-				host_readbs(Real2Host(hero) + 0x10f) + j,
+				host_readbs(Real2Host(hero) + (HERO_TA_FIGHT + 7)) + j,
 
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX)) + 0xe0)),
-				host_readbs(Real2Host(hero) + 0x110) + j);
+				host_readbs(Real2Host(hero) + (HERO_TA_FIGHT + 8)) + j);
 
 			GUI_print_string(Real2Host(ds_readd(DTP2)), 200, 60);
 			break;

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -201,9 +201,9 @@ void status_show(Bit16u index)
 	set_var_to_zero();
 	update_mouse_cursor();
 
-	if (ds_readb(0x2845) != 20) {
+	if (ds_readb(PP20_INDEX) != ARCHIVE_FILE_ZUSTA_UK) {
 		ds_writew(0xc3cb, 0);
-		ds_writeb(0x2845, 20);
+		ds_writeb(PP20_INDEX, ARCHIVE_FILE_ZUSTA_UK);
 		do_fill_rect((RealPt)ds_readd(0xd2ff), 0, 0, 319, 199, 0);
 		wait_for_vsync();
 		set_palette(p_datseg + 0x6372, 0, 0x20);

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -58,30 +58,30 @@ void status_show_spell(Bit8u *hero, unsigned short spell, unsigned short fsig,
 }
 
 /**
- *	status_show_talent -	prints talentname and value
- *	@hero:	the hero the talent is from
- *	@talen:	talentnumber
- *	@ftig:	the first talent in the talentgroup
+ *	status_show_skill -	prints skillname and value
+ *	@hero:	the hero the skill is from
+ *	@talen:	skillnumber
+ *	@ftig:	the first skill in the skillgroup
  *	@x1:	the leftmost x coordinate
  *	@x2:	the rightmost x coordinate
- *	@gy:	the upper y coordinate of this talentgroup
+ *	@gy:	the upper y coordinate of this skillgroup
  */
 /* Borlandified and identical */
-void status_show_talent(Bit8u *hero, unsigned short talent, unsigned short ftig,
+void status_show_skill(Bit8u *hero, unsigned short skill, unsigned short ftig,
 			unsigned short x1, unsigned short x2, unsigned short gy) {
 	unsigned short group;
 	char str[10];
 
-	group = talent - ftig;
+	group = skill - ftig;
 
-	/* print talentname */
-	GUI_print_string(get_ltx((talent + 0x30) * 4), x1, gy + group * 7);
+	/* print skillname */
+	GUI_print_string(get_ltx((skill + 0x30) * 4), x1, gy + group * 7);
 
 	/* convert value to string */
 #if !defined(__BORLANDC__)
-	sprintf(str, "%d", host_readbs(hero + HERO_TA_FIGHT + talent));
+	sprintf(str, "%d", host_readbs(hero + HERO_TA_FIGHT + skill));
 #else
-	itoa(host_readbs(hero + HERO_TA_FIGHT + talent) , str, 10);
+	itoa(host_readbs(hero + HERO_TA_FIGHT + skill) , str, 10);
 #endif
 
 	/* print value */
@@ -89,17 +89,17 @@ void status_show_talent(Bit8u *hero, unsigned short talent, unsigned short ftig,
 }
 
 /**
- *	status_show_talents -	shows all talents and their values
- *	@hero:	the hero whose talents should be shown
+ *	status_show_skills -	shows all skills and their values
+ *	@hero:	the hero whose skills should be shown
  */
 /* Borlandified and identical */
-void status_show_talents(Bit8u *hero) {
+void status_show_skills(Bit8u *hero) {
 
 	signed short skill_category, skill_nr;
 
 	set_textcolor(0xff, 2);
 
-	/* print talent category names */
+	/* print skill category names */
 	GUI_print_string(get_ltx(0x190),
 		GUI_get_first_pos_centered(get_ltx(0x190), 5, 100, 0), 55);
 
@@ -126,7 +126,7 @@ void status_show_talents(Bit8u *hero) {
 	for (skill_category = 0; skill_category < 7; skill_category++) {
 		skill_nr = ds_readbs(SKILLS_INDEX + skill_category * 2);
 		while (ds_readbs(SKILLS_INDEX + skill_category * 2) + ds_readbs((SKILLS_INDEX + 1) + skill_category * 2) > skill_nr) {
-			status_show_talent(hero, skill_nr,
+			status_show_skill(hero, skill_nr,
 				ds_readbs(SKILLS_INDEX + skill_category * 2),
 				ds_readw(0x6476 + skill_category * 6),
 				ds_readw((0x6476 + 2) + skill_category * 6),
@@ -634,7 +634,7 @@ void status_show(Bit16u index)
 		}
 		/* skills */
 		case 3: {
-			status_show_talents(Real2Host(hero));
+			status_show_skills(Real2Host(hero));
 			break;
 		}
 		/* spells */

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -687,13 +687,13 @@ void status_show(Bit16u index)
 
 			for (j = 0; j < 8; j++) {
 
-				i = ds_readbs(0xd03 + j * 2);
+				i = ds_readbs(SPELLS_INDEX + j * 2);
 
-				while (ds_readbs(0xd03 + j * 2) + ds_readbs(0xd03 + 1 + j * 2) > i) {
+				while (ds_readbs(SPELLS_INDEX + j * 2) + ds_readbs(SPELLS_INDEX + 1 + j * 2) > i) {
 
 					status_show_spell(Real2Host(hero),
 						i,
-						ds_readbs(0xd03 + j * 2),
+						ds_readbs(SPELLS_INDEX + j * 2),
 						ds_readws(0x642e + 0 + j * 6),
 						ds_readws(0x642e + 2 + j * 6),
 						ds_readws(0x642e + 4 + j * 6));
@@ -733,13 +733,13 @@ void status_show(Bit16u index)
 
 			for (j = 0; j < 4; j++) {
 
-				i = ds_readbs(0xd13 + j * 2);
+				i = ds_readbs(SPELLS_INDEX2 + j * 2);
 
-				while (ds_readbs(0xd13 + j * 2) + ds_readbs(0xd13 + 1 + j * 2) > i) {
+				while (ds_readbs(SPELLS_INDEX2 + j * 2) + ds_readbs(SPELLS_INDEX2 + 1 + j * 2) > i) {
 
 					status_show_spell(Real2Host(hero),
 						i,
-						ds_readbs(0xd13 + j * 2),
+						ds_readbs(SPELLS_INDEX2 + j * 2),
 						ds_readws(0x645e + 0 + j * 6),
 						ds_readws(0x645e + 2 + j * 6),
 						ds_readws(0x645e + 4 + j * 6));

--- a/src/custom/schick/rewrite_m302de/seg046.h
+++ b/src/custom/schick/rewrite_m302de/seg046.h
@@ -5,9 +5,9 @@ namespace M302de {
 void status_show(Bit16u);
 void status_show_spell(Bit8u *, unsigned short, unsigned short, unsigned short,
 				unsigned short, unsigned short);
-void status_show_talent(Bit8u *, unsigned short, unsigned short, unsigned short,
+void status_show_skill(Bit8u *, unsigned short, unsigned short, unsigned short,
 				unsigned short, unsigned short);
-void status_show_talents(Bit8u *);
+void status_show_skills(Bit8u *);
 
 #if !defined(__BORLANDC__)
 }

--- a/src/custom/schick/rewrite_m302de/seg047.cpp
+++ b/src/custom/schick/rewrite_m302de/seg047.cpp
@@ -675,8 +675,8 @@ void hero_get_drunken(Bit8u *hero)
 		add_ptr_bs(hero + HERO_JZ, 1);
 
 		/* do a burp FX2.VOC */
-		if (ds_readb(0x2845) == 20) {
-			ds_writew(0x2846, 1);
+		if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
+			ds_writew(REQUEST_REFRESH, 1);
 		}
 
 		play_voc_delay(ARCHIVE_FILE_FX2_VOC);
@@ -719,8 +719,8 @@ void hero_get_sober(Bit8u *hero) {
 	sub_ptr_bs(hero + HERO_NG, 1);
 	sub_ptr_bs(hero + HERO_JZ, 1);
 
-	if (ds_readb(0x2845) == 20)
-		ds_writew(0x2846, 1);
+	if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK)
+		ds_writew(REQUEST_REFRESH, 1);
 }
 
 #if !defined(__BORLANDC__)

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -141,7 +141,7 @@ void status_menu(signed short hero_pos)
 						Real2Host(GUI_name_singular((Bit8u*)get_itemname(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))),
 						!is_in_word_array(
 						    host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370)),
-						    (signed short*)Real2Host(ds_readd(0x634 + 4 * host_readbs(hero2 + HERO_TYPE)))
+						    (signed short*)Real2Host(ds_readd(0x0634 + 4 * host_readbs(hero2 + HERO_TYPE)))
                         ) ? p_datseg + EMPTY_STRING8 : get_city(0x108));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))) {
@@ -326,7 +326,7 @@ void status_menu(signed short hero_pos)
 						Real2Host(GUI_name_singular((Bit8u*)get_itemname(host_readws(hero2 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))),
 						!is_in_word_array(
 						    host_readws(hero2 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370)),
-						    (signed short*)Real2Host(ds_readd(0x634 + 4 * host_readbs(hero2 + HERO_TYPE)))
+						    (signed short*)Real2Host(ds_readd(0x0634 + 4 * host_readbs(hero2 + HERO_TYPE)))
                         ) ? p_datseg + EMPTY_STRING9 : get_city(0x108));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))) {

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -103,13 +103,13 @@ void status_menu(signed short hero_pos)
 
 	load_ggsts_nvf();
 
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writew(ACTION, 0);
 	ds_writew(STATUS_PAGE_MODE, 1);
 
 	while (flag1 == 0) {
 
-		if (ds_readw(0x2846) != 0 || flag2 != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0 || flag2 != 0) {
 
 			ds_writew(STATUS_PAGE_HERO, hero_pos);
 
@@ -165,7 +165,7 @@ void status_menu(signed short hero_pos)
 
 			refresh_screen_size();
 
-			ds_writew(0x2846, flag2 = 0);
+			ds_writew(REQUEST_REFRESH, flag2 = 0);
 		}
 
 		handle_input();
@@ -200,7 +200,7 @@ void status_menu(signed short hero_pos)
 				reset_item_selector();
 			}
 
-			ds_writew(0x2846, 1);
+			ds_writew(REQUEST_REFRESH, 1);
 		}
 
 		/* LEFT_KEY */
@@ -233,7 +233,7 @@ void status_menu(signed short hero_pos)
 				reset_item_selector();
 			}
 
-			ds_writew(0x2846, 1);
+			ds_writew(REQUEST_REFRESH, 1);
 		}
 
 		if (ds_readws(STATUS_PAGE_MODE) < 3) {
@@ -378,7 +378,7 @@ void status_menu(signed short hero_pos)
 
 						if (ds_readbs(0x6371) < 23) {
 							pass_item(hero1, ds_readbs(0x6370), hero2, ds_readbs(0x6371));
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						} else if (ds_readbs(0x6371) == 23) {
 							print_item_description(hero1, ds_readbs(0x6370));
 						} else if (ds_readbs(0x6371) == 24) {
@@ -399,7 +399,7 @@ void status_menu(signed short hero_pos)
 					} else {
 						if (ds_readbs(0x6371) < 23) {
 							move_item(ds_readbs(0x6370), ds_readbs(0x6371), hero2);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						} else if (ds_readbs(0x6371) == 23) {
 							print_item_description(hero2, ds_readbs(0x6370));
 						} else if (ds_readbs(0x6371) == 24) {
@@ -518,7 +518,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							GUI_input(get_city(0x118), 15);
 							strcpy((char*)hero2 + HERO_NAME2, (char*)Real2Host(ds_readd(TEXT_INPUT_BUF)));
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -529,7 +529,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							use_item(ds_readbs(0x6370), hero_pos);
 							reset_item_selector();
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -540,7 +540,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							drop_item(hero2, ds_readbs(0x6370), -1);
 							reset_item_selector();
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -561,7 +561,7 @@ void status_menu(signed short hero_pos)
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
 							reset_item_selector();
 						}
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 6: {
@@ -578,7 +578,7 @@ void status_menu(signed short hero_pos)
 								GUI_output(Real2Host(ds_readd(DTP2)));
 						} else {
 							ds_writew(STATUS_PAGE_MODE, 2);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -590,7 +590,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							reset_item_selector();
 							ds_writew(STATUS_PAGE_MODE, 3);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -601,7 +601,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							reset_item_selector();
 							ds_writew(STATUS_PAGE_MODE, 4);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -658,7 +658,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							drop_item(hero2, ds_readbs(0x6370), -1);
 							reset_item_selector();
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -678,20 +678,20 @@ void status_menu(signed short hero_pos)
 						if (select_magic_user() != -2) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
 							reset_item_selector();
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
 					case 5: {
 						/* TODO: different code is generated here */
 						ds_writew(STATUS_PAGE_MODE, 1);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 6: {
 						reset_item_selector();
 						ds_writew(STATUS_PAGE_MODE, 3);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 7: {
@@ -700,7 +700,7 @@ void status_menu(signed short hero_pos)
 						} else {
 							reset_item_selector();
 							ds_writew(STATUS_PAGE_MODE, 4);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -738,12 +738,12 @@ void status_menu(signed short hero_pos)
 					}
 					case 2: {
 						ds_writew(STATUS_PAGE_MODE, 1);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 3: {
 						ds_writew(STATUS_PAGE_MODE, 2);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 4: {
@@ -751,7 +751,7 @@ void status_menu(signed short hero_pos)
 							GUI_output(get_ltx(0x35c));
 						} else {
 							ds_writew(STATUS_PAGE_MODE, 4);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -759,7 +759,7 @@ void status_menu(signed short hero_pos)
 						/* cast spell */
 						if (select_magic_user() != -2) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
@@ -788,23 +788,23 @@ void status_menu(signed short hero_pos)
 						/* cast spell */
 						if (select_magic_user() != -2) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						}
 						break;
 					}
 					case 2: {
 						ds_writew(STATUS_PAGE_MODE, 1);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 3: {
 						ds_writew(STATUS_PAGE_MODE, 2);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 4: {
 						ds_writew(STATUS_PAGE_MODE, 3);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 5: {
@@ -812,7 +812,7 @@ void status_menu(signed short hero_pos)
 							ds_writew(STATUS_PAGE_MODE, 5);
 						else
 							ds_writew(STATUS_PAGE_MODE, 4);
-						ds_writew(0x2846, 1);
+						ds_writew(REQUEST_REFRESH, 1);
 						break;
 					}
 					case 6: {
@@ -838,7 +838,7 @@ void status_menu(signed short hero_pos)
 		load_city_ltx(file_bak);
 	}
 
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writew(TEXTBOX_WIDTH, tw_bak);
 	dec_ds_ws(TIMERS_DISABLED);
 

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -550,7 +550,7 @@ void status_menu(signed short hero_pos)
 						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
-						if (ds_readws(BUF1_FILE_INDEX) == 19) {
+						if (ds_readws(TX_FILE_INDEX) == 19) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
 						}
 						break;
@@ -668,7 +668,7 @@ void status_menu(signed short hero_pos)
 						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
-						if (ds_readws(BUF1_FILE_INDEX) == 19) {
+						if (ds_readws(TX_FILE_INDEX) == 19) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
 						}
 						break;
@@ -731,7 +731,7 @@ void status_menu(signed short hero_pos)
 						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
-						if (ds_readws(BUF1_FILE_INDEX) == 19) {
+						if (ds_readws(TX_FILE_INDEX) == 19) {
 							load_city_ltx(ARCHIVE_FILE_CHARTEXT_LTX);
 						}
 						break;

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -545,9 +545,9 @@ void status_menu(signed short hero_pos)
 						break;
 					}
 					case 4: {
-						/* use talent */
+						/* use skill */
 						ds_writew(0x6532, 1);
-						GUI_use_talent(hero_pos, 0);
+						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
 						if (ds_readws(BUF1_FILE_INDEX) == 19) {
@@ -583,7 +583,7 @@ void status_menu(signed short hero_pos)
 						break;
 					}
 					case 7: {
-						/* show talents */
+						/* show skills */
 						if (l1 == 7) {
 							flag1 = 1;
 							reset_item_selector();
@@ -663,9 +663,9 @@ void status_menu(signed short hero_pos)
 						break;
 					}
 					case 3: {
-						/* use talent */
+						/* use skill */
 						ds_writew(0x6532, 1);
-						GUI_use_talent(hero_pos, 0);
+						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
 						if (ds_readws(BUF1_FILE_INDEX) == 19) {
@@ -714,7 +714,7 @@ void status_menu(signed short hero_pos)
 				break;
 			}
 			case 3: {
-				/* from talents-page */
+				/* from skills-page */
 				l_di = GUI_radio((Bit8u*)0, 6,
 						get_ltx(0x350),
 						get_city(0x60),
@@ -726,9 +726,9 @@ void status_menu(signed short hero_pos)
 				if (l_di != -1) {
 					switch (l_di) {
 					case 1: {
-						/* use talent */
+						/* use skill */
 						ds_writew(0x6532, 1);
-						GUI_use_talent(hero_pos, 0);
+						GUI_use_skill(hero_pos, 0);
 						ds_writew(0x6532, 0);
 
 						if (ds_readws(BUF1_FILE_INDEX) == 19) {

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -141,7 +141,7 @@ void status_menu(signed short hero_pos)
 						Real2Host(GUI_name_singular((Bit8u*)get_itemname(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))),
 						!is_in_word_array(
 						    host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370)),
-						    (signed short*)Real2Host(ds_readd(0x0634 + 4 * host_readbs(hero2 + HERO_TYPE)))
+						    (signed short*)Real2Host(ds_readd(WEARABLE_ITEMS + 4 * host_readbs(hero2 + HERO_TYPE)))
                         ) ? p_datseg + EMPTY_STRING8 : get_city(0x108));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))) {
@@ -326,7 +326,7 @@ void status_menu(signed short hero_pos)
 						Real2Host(GUI_name_singular((Bit8u*)get_itemname(host_readws(hero2 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))),
 						!is_in_word_array(
 						    host_readws(hero2 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370)),
-						    (signed short*)Real2Host(ds_readd(0x0634 + 4 * host_readbs(hero2 + HERO_TYPE)))
+						    (signed short*)Real2Host(ds_readd(WEARABLE_ITEMS + 4 * host_readbs(hero2 + HERO_TYPE)))
                         ) ? p_datseg + EMPTY_STRING9 : get_city(0x108));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(0x6370))))) {

--- a/src/custom/schick/rewrite_m302de/seg049.cpp
+++ b/src/custom/schick/rewrite_m302de/seg049.cpp
@@ -625,7 +625,7 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 	signed short tmp;
 
 	if (!hero_dead(hero) &&
-		(host_readd(hero + HERO_MAGIC_TIMER) == 0) &&
+		(host_readd(hero + HERO_STAFFSPELL_TIMER) == 0) &&
 		(host_readbs(hero + HERO_RECIPE_TIMER) == 0))
 	{
 

--- a/src/custom/schick/rewrite_m302de/seg049.cpp
+++ b/src/custom/schick/rewrite_m302de/seg049.cpp
@@ -378,7 +378,7 @@ void GRP_switch_to_next(signed short mode)
 			ds_writeb(FOOD_MESSAGE + group, ds_writeb(UNCONSCIOUS_MESSAGE + group, 0));
 		}
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	}
 }
 
@@ -696,7 +696,7 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 							hero + HERO_NAME2,
 							le_regen,
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
-						if (ds_readbs(0x2845) == 0) {
+						if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 							GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 							delay_or_keypress(200);
 						} else {
@@ -731,7 +731,7 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 								ae_regen,
 								(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
-							if (ds_readbs(0x2845) == 0) {
+							if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 								GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 								delay_or_keypress(200);
 							} else {

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -116,7 +116,7 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 			GUI_output(get_city(0x94));
 
 			/* increment spell value */
-			inc_ptr_bs(hero + spell + 0x13d);
+			inc_ptr_bs(hero + spell + HERO_SPELLS);
 
 			/* set the try counter to 0 */
 			host_writebs(Real2Host(ds_readd(INC_SPELLS_COUNTER)) + 2 * spell, 0);
@@ -174,7 +174,7 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 			GUI_output(get_city(0x94));
 
 			/* increment spell value */
-			inc_ptr_bs(hero + skill + 0x108);
+			inc_ptr_bs(hero + skill + HERO_TA_FIGHT);
 
 			/* set the try counter to 0 */
 			host_writebs(Real2Host(ds_readd(INC_SKILLS_COUNTER)) + 2 * skill, 0);

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -880,7 +880,7 @@ void level_up(signed short hero_pos)
 
 		while (host_readbs(hero + HERO_TA_RISE) != 0) {
 
-			l_si = LVL_select_talent(hero, 1);
+			l_si = LVL_select_skill(hero, 1);
 
 			if (l_si >= 0) {
 

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -912,7 +912,7 @@ void level_up(signed short hero_pos)
 	}
 
 	ds_writew(0x2ca2, 0);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writew(TIMERS_DISABLED, 0);
 
 	ds_writews(CURRENT_ANI, -1);

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -142,7 +142,7 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 	signed short randval;
 	signed short max_incs;
 
-	max_incs = ds_readbs(0x0ffe + 4 * skill + 3);
+	max_incs = ds_readbs(SKILLS_EXTRA + 4 * skill + 3);
 
 
 	if (host_readbs(Real2Host(ds_readd(INC_SKILLS_COUNTER)) + 2 * skill + 1) >= max_incs) {

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -46,23 +46,23 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 	struct dummy a = *(struct dummy*)(p_datseg + 0x6682);
 
 	if ((host_readbs(hero + HERO_TYPE) == 7) &&
-		(ds_readbs((0x099d + 0) + 10 * spell) == 2))
+		(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 2))
 	{
 		/* spell is a warlock spell */
 		l_di = 2;
 	}
 
 	if ((host_readbs(hero + HERO_TYPE) >= 10) &&
-		((ds_readbs((0x099d + 0) + 10 * spell) == 3) ||
-			(ds_readbs((0x099d + 0) + 10 * spell) == 5) ||
-			(ds_readbs((0x099d + 0) + 10 * spell) == 4)))
+		((ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 3) ||
+			(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 5) ||
+			(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 4)))
 	{
 		/* elven spell */
 		l_di = 2;
 	}
 
 	if ((host_readbs(hero + HERO_TYPE) == 8) &&
-		(ds_readbs((0x099d + 0) + 10 * spell) == 0))
+		(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 0))
 	{
 		/* spell is a druid spell */
 		l_di = 2;
@@ -71,7 +71,7 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 	if (host_readbs(hero + HERO_TYPE) == 9) {
 
 		/* mages */
-		if (ds_readbs((0x099d + 0) + 10 * spell) == 1) {
+		if (ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 1) {
 			/* spell is a mage spell */
 			l_di = 2;
 		}
@@ -81,7 +81,7 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 			l_di = 2;
 		}
 
-		if (is_in_word_array(spell, (signed short*)Real2Host(ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))))
+		if (is_in_word_array(spell, (signed short*)Real2Host(ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))))
 		{
 			l_di = 3;
 		}
@@ -142,7 +142,7 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 	signed short randval;
 	signed short max_incs;
 
-	max_incs = ds_readbs(SKILLS_EXTRA + 4 * skill + 3);
+	max_incs = ds_readbs(SKILL_DESCRIPTIONS + 4 * skill + 3);
 
 
 	if (host_readbs(Real2Host(ds_readd(INC_SKILLS_COUNTER)) + 2 * skill + 1) >= max_incs) {
@@ -670,7 +670,7 @@ void level_up(signed short hero_pos)
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 2 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 2 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -689,7 +689,7 @@ void level_up(signed short hero_pos)
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 0 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 0 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -709,13 +709,13 @@ void level_up(signed short hero_pos)
 						i = 0;
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 &&
-							(host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) != -1) {
+							(host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) != -1) {
 
 							if (host_readbs(hero + HERO_SPELLS +
-									host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) < 11)
+									host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) < 11)
 							{
 								inc_spell_novice(hero,
-									host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i));
+									host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i));
 							}
 							i++;
 						}
@@ -735,13 +735,13 @@ void level_up(signed short hero_pos)
 
 						i = 0;
 						while (host_readbs(hero + HERO_SP_RISE) != 0 &&
-							(host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) != -1) {
+							(host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) != -1) {
 
 							if (host_readbs(hero + HERO_SPELLS +
-									host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) < 11)
+									host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i)) < 11)
 							{
 								inc_spell_novice(hero,
-									host_readws(Real2Host((ds_readd(0x0d97 + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i));
+									host_readws(Real2Host((ds_readd(MAGIC_SCHOOL_DESCRIPTIONS + 4 * host_readbs(hero + HERO_MAGIC_SCHOOL)))) + 2 * i));
 							}
 							i++;
 						}
@@ -752,7 +752,7 @@ void level_up(signed short hero_pos)
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x099d + 0 + 10 * i) == 3 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 3 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -768,7 +768,7 @@ void level_up(signed short hero_pos)
 						i = 1;
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x099d + 0 + 10 * i) == 3 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 3 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -780,7 +780,7 @@ void level_up(signed short hero_pos)
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 4 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 4 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -796,7 +796,7 @@ void level_up(signed short hero_pos)
 						i = 1;
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 4 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 4 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -807,7 +807,7 @@ void level_up(signed short hero_pos)
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 5 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 5 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;
@@ -823,7 +823,7 @@ void level_up(signed short hero_pos)
 						i = 1;
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
-							if (ds_readbs(0x99d + 0 + 10 * i) == 5 && host_readbs(hero + HERO_SPELLS + i) < 11) {
+							if (ds_readbs(SPELL_DESCRIPTIONS + 0 + 10 * i) == 5 && host_readbs(hero + HERO_SPELLS + i) < 11) {
 								inc_spell_novice(hero, i);
 							}
 							i++;

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -54,7 +54,7 @@ void do_wildcamp(void)
 	done = 0;
 	stock_tries = 0;
 	herb_tries = 0;
-	l_di = ds_writews(0x2846, 1);
+	l_di = ds_writews(REQUEST_REFRESH, 1);
 
 	for (i = 0; i <= 6; i++) {
 		ds_writebs(WILDCAMP_HERBSTATUS + i, ds_writebs(WILDCAMP_REPLSTATUS + i, ds_writebs(WILDCAMP_MAGICSTATUS + i , ds_writeb(WILDCAMP_GUARDSTATUS + i, 0))));
@@ -69,14 +69,14 @@ void do_wildcamp(void)
 
 	while (done == 0) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(2);
 			init_ani(0);
 			GUI_print_loc_line(get_ltx(0x4c8));
 			set_audio_track(ARCHIVE_FILE_CAMP_XMI);
-			ds_writew(0x2846, l_di = 0);
+			ds_writew(REQUEST_REFRESH, l_di = 0);
 		}
 
 		if (l_di) {
@@ -350,7 +350,7 @@ void do_wildcamp(void)
 						GUI_print_loc_line(get_ltx(0x4c8));
 						set_audio_track(ARCHIVE_FILE_CAMP_XMI);
 
-						ds_writew(0x2846, l_di = 0);
+						ds_writew(REQUEST_REFRESH, l_di = 0);
 
 						if (l6 > 0) {
 							ds_writeb(FOOD_MOD, 1);
@@ -562,7 +562,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 						/* the group may get three food packages */
 						if (!get_item(45, 1, 3)) {
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ltx(0x4c8));
-							ds_writew(0x2846, 1);
+							ds_writew(REQUEST_REFRESH, 1);
 						} else {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
 								(char*)get_ltx(0x514),

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -528,9 +528,9 @@ signed short replenish_stocks(signed short mod, signed short tries)
 								host_writebs(hero2 + HERO_THIRST, 0);
 
 								for (j = 0; j < 23; j++) {
-									if (host_readws(hero2 + 14 * j + 0x196) == 30) {
-										and_ptr_bs(hero2 + 14 * j + 0x196 + 4, 0xfb);
-										and_ptr_bs(hero2 + 14 * j + 0x196 + 4, 0xfd);
+									if (host_readws(hero2 + 14 * j + HERO_ITEM_HEAD) == 30) {
+										and_ptr_bs(hero2 + 14 * j + HERO_ITEM_HEAD + 4, 0xfb);
+										and_ptr_bs(hero2 + 14 * j + HERO_ITEM_HEAD + 4, 0xfd);
 									}
 								}
 							}

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -163,7 +163,7 @@ void do_wildcamp(void)
 
 		} else if (ds_readws(ACTION) == 131) {
 
-			GUI_use_talent2(0, get_ltx(0x62c));
+			GUI_use_skill2(0, get_ltx(0x62c));
 
 		} else if (ds_readws(ACTION) == 132) {
 

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -267,11 +267,11 @@ void do_wildcamp(void)
 				l_si = 0;
 				have_guards = 0;
 
-				if (ds_readws(0x434f) == -1) {
+				if (ds_readws(CAMP_INCIDENT) == -1) {
 
 					if ((ds_readbs(WILDCAMP_GUARDS) == -1 ? 60 : 10) > random_schick(100) && !ds_readds(INGAME_TIMERS + 0x10))
 					{
-						ds_writews(0x434f, random_schick(3) - 1);
+						ds_writews(CAMP_INCIDENT, random_schick(3) - 1);
 					}
 				} else {
 					have_guards = 1;
@@ -298,7 +298,7 @@ void do_wildcamp(void)
 					l8++;
 					l6--;
 
-					if (l_si == ds_readws(0x434f) && l4 / 2 >= l5) {
+					if (l_si == ds_readws(CAMP_INCIDENT) && l4 / 2 >= l5) {
 						done = 1;
 					}
 
@@ -335,7 +335,7 @@ void do_wildcamp(void)
 
 				} else if (!have_guards) {
 
-					ds_writews(0x434f, -1);
+					ds_writews(CAMP_INCIDENT, -1);
 					ds_writeb(FIG_INITIATIVE, 1);
 					ds_writew(FIG_DISCARD, 1);
 
@@ -359,7 +359,7 @@ void do_wildcamp(void)
 						}
 					}
 				} else {
-					ds_writews(0x434f, ds_readbs(WILDCAMP_GUARDS + ds_readws(0x434f)));
+					ds_writews(CAMP_INCIDENT, ds_readbs(WILDCAMP_GUARDS + ds_readws(CAMP_INCIDENT)));
 				}
 
 				done = 1;

--- a/src/custom/schick/rewrite_m302de/seg052.cpp
+++ b/src/custom/schick/rewrite_m302de/seg052.cpp
@@ -140,7 +140,7 @@ void do_citycamp(void)
 
 		} else if (ds_readws(ACTION) == 130) {
 
-			GUI_use_talent2(0, get_ltx(0x62c));
+			GUI_use_skill2(0, get_ltx(0x62c));
 
 		} else if (ds_readws(ACTION) == 131) {
 

--- a/src/custom/schick/rewrite_m302de/seg052.cpp
+++ b/src/custom/schick/rewrite_m302de/seg052.cpp
@@ -48,7 +48,7 @@ void do_citycamp(void)
 
 	done = 0;
 
-	l3 = ds_writew(0x2846, 1);
+	l3 = ds_writew(REQUEST_REFRESH, 1);
 
 	for (l_si = 0; l_si <= 6; l_si++) {
 		ds_writeb(CITYCAMP_MAGICSTATUS + l_si, ds_writeb(CITYCAMP_GUARDSTATUS + l_si, 0));
@@ -62,14 +62,14 @@ void do_citycamp(void)
 
 	while (done == 0) {
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(36);
 			init_ani(0);
 			GUI_print_loc_line(get_ltx(0x4c8));
 			set_audio_track(ARCHIVE_FILE_CAMP_XMI);
-			ds_writew(0x2846, l3 = 0);
+			ds_writew(REQUEST_REFRESH, l3 = 0);
 		}
 
 		if (l3 != 0) {
@@ -248,7 +248,7 @@ void do_citycamp(void)
 								init_ani(0);
 								GUI_print_loc_line(get_ltx(0x4c8));
 								set_audio_track(ARCHIVE_FILE_CAMP_XMI);
-								ds_writew(0x2846, l3 = 0);
+								ds_writew(REQUEST_REFRESH, l3 = 0);
 							}
 
 						} else {

--- a/src/custom/schick/rewrite_m302de/seg052.cpp
+++ b/src/custom/schick/rewrite_m302de/seg052.cpp
@@ -181,9 +181,9 @@ void do_citycamp(void)
 					l6 = l5;
 					l_di = 0;
 
-					if (ds_readws(0x434f) == -1) {
+					if (ds_readws(CAMP_INCIDENT) == -1) {
 						if ((ds_readbs(CITYCAMP_GUARDS) == -1 ? 4 * hours : hours) > random_schick(100)) {
-							ds_writews(0x434f, random_schick(3) - 1);
+							ds_writews(CAMP_INCIDENT, random_schick(3) - 1);
 						}
 					}
 
@@ -208,7 +208,7 @@ void do_citycamp(void)
 						l8++;
 						l7--;
 
-						if (l_di == ds_readws(0x434f) && (l5 / 2) >= l6) {
+						if (l_di == ds_readws(CAMP_INCIDENT) && (l5 / 2) >= l6) {
 							done = 1;
 						}
 
@@ -231,7 +231,7 @@ void do_citycamp(void)
 
 					if (done != 0) {
 
-						ds_writew(0x434f, -1);
+						ds_writew(CAMP_INCIDENT, -1);
 
 						if (ds_readb(0xbd27) == 0) {
 							/* in a dungeon */

--- a/src/custom/schick/rewrite_m302de/seg053.cpp
+++ b/src/custom/schick/rewrite_m302de/seg053.cpp
@@ -60,13 +60,13 @@ void do_healer(void)
 	motivation = 0;
 	leave_healer = 0;
 
-	v6 = ds_writew(0x2846, 1);
+	v6 = ds_writew(REQUEST_REFRESH, 1);
 	info = p_datseg + 0x66ea + ds_readw(TYPEINDEX) * 2;
 	draw_loc_icons(4, 0x1e, 0x1f, 0x20, 8);
 
 	while (leave_healer == 0) {
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(23);
@@ -76,7 +76,7 @@ void do_healer(void)
 
 			set_audio_track(ARCHIVE_FILE_HEALER_XMI);
 
-			ds_writew(0x2846, v6 = 0);
+			ds_writew(REQUEST_REFRESH, v6 = 0);
 
 			if (!motivation) {
 

--- a/src/custom/schick/rewrite_m302de/seg054.cpp
+++ b/src/custom/schick/rewrite_m302de/seg054.cpp
@@ -456,7 +456,7 @@ void TLK_herberg(signed short state)
 	Bit8u *hero = Real2Host(get_first_hero_available_in_group());
 
 	if (!state) {
-		ds_writews(0xe30e, ds_readb(0x3400 + ds_readws(TYPEINDEX)) != 0 ? 1 : 2);
+		ds_writews(DIALOG_NEXT_STATE, ds_readb(0x3400 + ds_readws(TYPEINDEX)) != 0 ? 1 : 2);
 	} else if (state == 1 || state == 14) {
 		ds_writeb(0x3400 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 11) {
@@ -465,13 +465,13 @@ void TLK_herberg(signed short state)
 		ds_writeb(0x3400 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 12) {
 		/* CH + 5 */
-		ds_writews(0xe30e, test_attrib(hero, 2, 5) > 0 ? 14 : 11);
+		ds_writews(DIALOG_NEXT_STATE, test_attrib(hero, 2, 5) > 0 ? 14 : 11);
 	} else if (state == 13) {
 		/* CH + 0 */
-		ds_writews(0xe30e, test_attrib(hero, 2, 0) > 0 ? 14 : 7);
+		ds_writews(DIALOG_NEXT_STATE, test_attrib(hero, 2, 0) > 0 ? 14 : 7);
 	} else if (state == 15) {
 		/* CH - 3 */
-		ds_writews(0xe30e, test_attrib(hero, 2, -3) > 0 ? 16 : 17);
+		ds_writews(DIALOG_NEXT_STATE, test_attrib(hero, 2, -3) > 0 ? 16 : 17);
 	} else if (state == 17) {
 		ds_writew(ACTION, 130);
 	}

--- a/src/custom/schick/rewrite_m302de/seg054.cpp
+++ b/src/custom/schick/rewrite_m302de/seg054.cpp
@@ -147,7 +147,7 @@ void do_inn(void)
 
 	if (done == 0) {
 
-		refresh = ds_writews(0x2846, 1);
+		refresh = ds_writews(REQUEST_REFRESH, 1);
 
 		draw_loc_icons(ds_readws(COMBO_MODE) == 0 ? 7 : 8, 21, 13, 19, 25, 11, 17, 8, 50);
 
@@ -158,7 +158,7 @@ void do_inn(void)
 
 	while (done == 0) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			draw_main_screen();
 
@@ -170,7 +170,7 @@ void do_inn(void)
 
 			GUI_print_loc_line(get_dtp(4 * ds_readws(CITYINDEX)));
 
-			ds_writews(0x2846, refresh = 0);
+			ds_writews(REQUEST_REFRESH, refresh = 0);
 		}
 
 		if (refresh != 0) {
@@ -199,7 +199,7 @@ void do_inn(void)
 
 		if (ds_readws(ACTION) == 129) {
 			talk_inn();
-			ds_writews(0x2846, 1);
+			ds_writews(REQUEST_REFRESH, 1);
 		} else if (ds_readws(ACTION) == 130) {
 
 			price = count_heroes_in_group() * (6L - host_readws(inn_ptr) / 4L);

--- a/src/custom/schick/rewrite_m302de/seg054.cpp
+++ b/src/custom/schick/rewrite_m302de/seg054.cpp
@@ -329,7 +329,7 @@ void do_inn(void)
 		} else if (ds_readws(ACTION) == 132) {
 
 			if (ds_readbs(SLEEP_QUALITY) != -1) {
-				GUI_use_talent2(0, get_ltx(0x62c));
+				GUI_use_skill2(0, get_ltx(0x62c));
 				refresh = 1;
 			} else {
 				GUI_output(get_ltx(0x568));

--- a/src/custom/schick/rewrite_m302de/seg055.cpp
+++ b/src/custom/schick/rewrite_m302de/seg055.cpp
@@ -83,7 +83,7 @@ void do_merchant(void)
 	}
 
 	load_ggsts_nvf();
-	refresh = ds_writews(0x2846, 1);
+	refresh = ds_writews(REQUEST_REFRESH, 1);
 
 	ds_writed(BUYITEMS, ds_readd(FIG_FIGURE1_BUF));
 	memset(Real2Host(ds_readd(BUYITEMS)), 0, 3500);
@@ -157,7 +157,7 @@ void do_merchant(void)
 
 	while (done == 0 && !ds_readb(0x3592 + ds_readws(TYPEINDEX))) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			draw_loc_icons(4, 22, 24, 21, 8);
 
@@ -173,7 +173,7 @@ void do_merchant(void)
 
 			GUI_print_loc_line(ds_readbs(LOCATION) == 9 ? get_ltx(0xa9c) : (ds_readws(TYPEINDEX) == 93 ?  get_ltx(0xb8) : get_dtp(4 * ds_readws(CITYINDEX))));
 
-			ds_writew(0x2846, refresh = 0);
+			ds_writew(REQUEST_REFRESH, refresh = 0);
 
 		}
 

--- a/src/custom/schick/rewrite_m302de/seg055.cpp
+++ b/src/custom/schick/rewrite_m302de/seg055.cpp
@@ -283,21 +283,21 @@ void talk_merchant(void)
 void TLK_ghandel(signed short state)
 {
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 1 : 4);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 1 : 4);
 	} else if (state == 1) {
-		ds_writew(0xe30e, ds_readb(0x3534 + ds_readws(TYPEINDEX)) != 0 ? 2 : 3);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3534 + ds_readws(TYPEINDEX)) != 0 ? 2 : 3);
 	} else if (state == 6 && ds_readws(TYPEINDEX) != 90) {
 		ds_writeb(0x34d6 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 10) {
 		/* test CH+0 */
-		ds_writew(0xe30e, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 0) > 0 ? 11 : 12);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 0) > 0 ? 11 : 12);
 	}
 }
 
 void TLK_khandel(signed short state)
 {
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 1 : 2);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 1 : 2);
 	} else if (state == 5) {
 		tumult();
 		if (ds_readws(TYPEINDEX) != 90) {
@@ -307,19 +307,19 @@ void TLK_khandel(signed short state)
 	} else if (state == 7 && ds_readws(TYPEINDEX) != 90) {
 		ds_writeb(0x34d6 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 8) {
-		ds_writew(0xe30e, random_schick(20) <= 3 ? 9 : -1);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(20) <= 3 ? 9 : -1);
 	} else if (state == 11) {
 		ds_writew(PRICE_MODIFICATOR, 3);
 	} else if (state == 12) {
 		/* test CH+4 */
-		ds_writew(0xe30e, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 4) > 0 ? 13 : 10);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 4) > 0 ? 13 : 10);
 	}
 }
 
 void TLK_whandel(signed short state)
 {
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 26 : 1);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x34d6 + ds_readws(TYPEINDEX)) != 0 ? 26 : 1);
 	} else if (state == 7 || state == 13) {
 		tumult();
 		if (ds_readws(TYPEINDEX) != 90) {
@@ -330,14 +330,14 @@ void TLK_whandel(signed short state)
 		ds_writeb(0x34d6 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 18) {
 		/* test CH+0 */
-		ds_writew(0xe30e, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 0) > 0 ? 19 : -1);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(Real2Host(get_first_hero_available_in_group()), 2, 0) > 0 ? 19 : -1);
 	} else if (state == 25) {
 
 		if (test_skill(Real2Host(get_first_hero_available_in_group()), 21, 0) > 0) {
-			ds_writew(0xe30e, 23);
+			ds_writew(DIALOG_NEXT_STATE, 23);
 			ds_writew(PRICE_MODIFICATOR, 3);
 		} else {
-			ds_writew(0xe30e, 24);
+			ds_writew(DIALOG_NEXT_STATE, 24);
 		}
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg056.cpp
+++ b/src/custom/schick/rewrite_m302de/seg056.cpp
@@ -125,11 +125,11 @@ void buy_screen(void)
 	ds_writed(BUY_SHOPPING_CART, (Bit32u)((RealPt)ds_readd(FIG_FIGURE1_BUF) + 2800));
 	memset(Real2Host(ds_readd(BUY_SHOPPING_CART)), 0, 250);
 
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	while (done == 0) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			free_slots = 0;
 			hero2 = get_hero(0);
@@ -148,7 +148,7 @@ void buy_screen(void)
 
 			set_var_to_zero();
 
-			ds_writeb(0x2845, -1);
+			ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 			draw_loc_icons(4, 23, 26, 27, 8);
 			draw_main_screen();
 
@@ -177,7 +177,7 @@ void buy_screen(void)
 				26);
 
 			l8 = 1;
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		if (l8 != 0) {
@@ -616,8 +616,8 @@ void buy_screen(void)
 	}
 
 	set_textcolor(fg_bak, bg_bak);
-	ds_writew(0x2846, 1);
-	ds_writeb(0x2845, -1);
+	ds_writew(REQUEST_REFRESH, 1);
+	ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 }
 
 /**

--- a/src/custom/schick/rewrite_m302de/seg056.cpp
+++ b/src/custom/schick/rewrite_m302de/seg056.cpp
@@ -317,7 +317,7 @@ void buy_screen(void)
 						set_textcolor(111, 0);
 					} else {
 
-						if (!is_in_word_array(item_id, (short*)Real2Host((ds_readds(0x634 + 4 * host_readbs(hero1 + HERO_TYPE)))))) {
+						if (!is_in_word_array(item_id, (short*)Real2Host((ds_readds(0x0634 + 4 * host_readbs(hero1 + HERO_TYPE)))))) {
 							set_textcolor(201, 0);
 						}
 					}

--- a/src/custom/schick/rewrite_m302de/seg056.cpp
+++ b/src/custom/schick/rewrite_m302de/seg056.cpp
@@ -317,7 +317,7 @@ void buy_screen(void)
 						set_textcolor(111, 0);
 					} else {
 
-						if (!is_in_word_array(item_id, (short*)Real2Host((ds_readds(0x0634 + 4 * host_readbs(hero1 + HERO_TYPE)))))) {
+						if (!is_in_word_array(item_id, (short*)Real2Host((ds_readds(WEARABLE_ITEMS + 4 * host_readbs(hero1 + HERO_TYPE)))))) {
 							set_textcolor(201, 0);
 						}
 					}

--- a/src/custom/schick/rewrite_m302de/seg057.cpp
+++ b/src/custom/schick/rewrite_m302de/seg057.cpp
@@ -92,15 +92,15 @@ void sell_screen(Bit8u *shop_ptr)
 
 
 	ds_writew(0x29b4, 0);
-	l8 = ds_writews(0x2846, 1);
+	l8 = ds_writews(REQUEST_REFRESH, 1);
 	ds_writed(SELLITEMS, (Bit32u)((RealPt)ds_readd(FIG_FIGURE1_BUF) + 2100));
 
 	while (done == 0) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			set_var_to_zero();
-			ds_writeb(0x2845, -1);
+			ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 			memset(Real2Host(ds_readd(SELLITEMS)), 0, 2100);
 
 			for (items_x = 0; items_x <= 6; items_x++) {
@@ -132,7 +132,7 @@ void sell_screen(Bit8u *shop_ptr)
 			l5 = -1;
 			l6 = 0;
 			l10 = 1;
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		if (l8 != 0 || l10 != 0 || l11 != 0) {
@@ -561,8 +561,8 @@ void sell_screen(Bit8u *shop_ptr)
 	}
 
 	set_textcolor(fg_bak, bg_bak);
-	ds_writew(0x2846, 1);
-	ds_writeb(0x2845, -1);
+	ds_writew(REQUEST_REFRESH, 1);
+	ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 	ds_writew(0x29b4, 1);
 }
 

--- a/src/custom/schick/rewrite_m302de/seg058.cpp
+++ b/src/custom/schick/rewrite_m302de/seg058.cpp
@@ -577,11 +577,11 @@ void talk_smith(void)
 void TLK_schmied(signed short state)
 {
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x3472 + ds_readws(TYPEINDEX)) != 0 ? 1 :
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3472 + ds_readws(TYPEINDEX)) != 0 ? 1 :
 					(ds_readws(TYPEINDEX) == 17 ? 27 :
 					(ds_readws(TYPEINDEX) == 1 && ds_readb(0x3fc6) != 0 ? 28 : 4)));
 	} else if (state == 1) {
-		ds_writew(0xe30e, ds_readb(0x34a4 + ds_readws(TYPEINDEX)) != 0 ? 2 : 3);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x34a4 + ds_readws(TYPEINDEX)) != 0 ? 2 : 3);
 	} else if (state == 3) {
 		ds_writeb(0x34a4 + ds_readws(TYPEINDEX), 1);
 	} else if (state == 6 || state == 26) {

--- a/src/custom/schick/rewrite_m302de/seg058.cpp
+++ b/src/custom/schick/rewrite_m302de/seg058.cpp
@@ -174,7 +174,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 	} else {
 
 		set_var_to_zero();
-		ds_writeb(0x2845, -1);
+		ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 
 		draw_loc_icons(5, 23, 26, 27, 28, 8);
 		draw_main_screen();
@@ -479,8 +479,8 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 		}
 
 		set_textcolor(fg_bak, bg_bak);
-		ds_writew(0x2846, 1);
-		ds_writeb(0x2845, -1);
+		ds_writew(REQUEST_REFRESH, 1);
+		ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 	}
 }
 
@@ -510,13 +510,13 @@ void do_smith(void)
 	}
 
 	load_ggsts_nvf();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	smith_ptr = p_datseg + 0x6c10 + 2 * ds_readws(TYPEINDEX);
 	ds_writew(PRICE_MODIFICATOR, 4);
 
 	while (!done) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			draw_loc_icons(3, 21, 18, 8);
 			draw_main_screen();
@@ -525,7 +525,7 @@ void do_smith(void)
 			init_ani(0);
 			GUI_print_loc_line(get_dtp(4 * ds_readws(CITYINDEX)));
 			set_audio_track(ARCHIVE_FILE_SMITH_XMI);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		handle_gui_input();
@@ -552,7 +552,7 @@ void do_smith(void)
 		} else if (ds_readws(ACTION) == 129) {
 
 			talk_smith();
-			ds_writew(0x2846, 1);
+			ds_writew(REQUEST_REFRESH, 1);
 
 			if (ds_readbs(0x3472 + ds_readws(TYPEINDEX)) != 0 ||
 				ds_readbs(0x34a4 + ds_readws(TYPEINDEX)) != 0 ||

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -47,7 +47,7 @@ void do_tavern(void)
 
 	GUI_print_loc_line(get_dtp(4 * ds_readws(CITYINDEX)));
 
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	if (host_readws(tav_ptr) >= 6 && host_readws(tav_ptr) <= 13) {
 
@@ -69,7 +69,7 @@ void do_tavern(void)
 
 	while (!done) {
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 
 			draw_main_screen();
 			set_var_to_zero();
@@ -77,7 +77,7 @@ void do_tavern(void)
 			init_ani(0);
 			GUI_print_loc_line(get_dtp(4 * ds_readws(CITYINDEX)));
 			set_audio_track(ARCHIVE_FILE_INN_XMI);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		handle_gui_input();
@@ -132,7 +132,7 @@ void do_tavern(void)
 				tavern_follow_informer();
 			}
 
-			ds_writew(0x2846, done = 1);
+			ds_writew(REQUEST_REFRESH, done = 1);
 			ds_writew(COMBO_MODE, 0);
 
 		} else if (ds_readws(ACTION) == 130) {
@@ -239,13 +239,13 @@ void do_tavern(void)
 void octopus_attack_wrapper(void)
 {
 	octopus_attack();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 void pirates_attack_wrapper(void)
 {
 	pirates_attack();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 void enter_ghostship(void)
@@ -276,10 +276,10 @@ void enter_ghostship(void)
 	} while (answer == -1);
 
 	if (answer == 1) {
-		ds_writew(0x2846, 0);
+		ds_writew(REQUEST_REFRESH, 0);
 		ds_writeb(0x4333, 1);
 	} else {
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	}
 
 	set_var_to_zero();

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -154,7 +154,7 @@ void do_tavern(void)
 
 				for (i = 0; i <= 6; i++) {
 
-					ds_writeb(FOOD_MESSAGE + i, ds_writeb(0x26a4 + i, 0));
+					ds_writeb(FOOD_MESSAGE + i, ds_writeb(FOOD_MESSAGE_SHOWN + i, 0));
 
 					if (host_readbs(get_hero(i) + HERO_TYPE) != 0 &&
 						host_readbs(get_hero(i) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -208,7 +208,7 @@ void do_tavern(void)
 
 			bc_time(&timeval);
 
-			bonus = (timeval - ds_readds(0xe2d6)) > 120 ? 0 : 50;
+			bonus = (timeval - ds_readds(LAST_SAVE_TIME)) > 120 ? 0 : 50;
 
 			if (GUI_use_skill2(bonus, get_ltx(0x62c)) == -1) {
 				done = 1;

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -204,13 +204,13 @@ void do_tavern(void)
 			}
 
 		} else if (ds_readws(ACTION) == 131) {
-			/* USE TALENT */
+			/* USE SKILL */
 
 			bc_time(&timeval);
 
 			bonus = (timeval - ds_readds(0xe2d6)) > 120 ? 0 : 50;
 
-			if (GUI_use_talent2(bonus, get_ltx(0x62c)) == -1) {
+			if (GUI_use_skill2(bonus, get_ltx(0x62c)) == -1) {
 				done = 1;
 				ds_writew(COMBO_MODE, 0);
 			}

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -265,7 +265,7 @@ void enter_ghostship(void)
 	draw_main_screen();
 	init_ani(1);
 
-	load_buffer_1(ARCHIVE_FILE_SHIP_DTX);
+	load_tx(ARCHIVE_FILE_SHIP_DTX);
 
 	GUI_output(get_dtp(0x48));
 	GUI_output(get_dtp(0x4c));

--- a/src/custom/schick/rewrite_m302de/seg060.cpp
+++ b/src/custom/schick/rewrite_m302de/seg060.cpp
@@ -213,13 +213,13 @@ void talk_tavern(void)
 			} while (answer == -1);
 		}
 
-		ds_writews(0xe30e, -1);
+		ds_writews(DIALOG_NEXT_STATE, -1);
 
 		if (host_readws(ptr1) & 0x8000 || host_readws(ptr1) == -1) {
 			TLK_tavern(answer);
 		}
 
-		ds_writews(DIALOG_STATE, ds_readws(0xe30e) == -1 ? host_readb(ptr1 + 5) : ds_readws(0xe30e));
+		ds_writews(DIALOG_STATE, ds_readws(DIALOG_NEXT_STATE) == -1 ? host_readb(ptr1 + 5) : ds_readws(DIALOG_NEXT_STATE));
 
 		if (ds_readws(DIALOG_DONE) == 0) {
 
@@ -267,31 +267,31 @@ void TLK_tavern(signed short answer)
 
 			hero_pos = get_hero_CH_best();
 
-			ds_writew(0xe30e, test_attrib(get_hero(hero_pos), 2, 0) <= 0 ? 112 : 113);
+			ds_writew(DIALOG_NEXT_STATE, test_attrib(get_hero(hero_pos), 2, 0) <= 0 ? 112 : 113);
 
 			ds_writeb(0x3374 + ds_readws(TYPEINDEX), 0);
 
 		} else {
-			ds_writew(0xe30e, 113);
+			ds_writew(DIALOG_NEXT_STATE, 113);
 		}
 
 	} else if (l_si == 2) {
 
 		if ((ds_readb(0x3610) == 1 || ds_readb(0x3610) == 2) && answer == 1) {
-			ds_writew(0xe30e, 3);
+			ds_writew(DIALOG_NEXT_STATE, 3);
 		} else if ((ds_readb(0x3610) == 1 || ds_readb(0x3610) == 2) && answer == 2) {
-			ds_writew(0xe30e, 5);
+			ds_writew(DIALOG_NEXT_STATE, 5);
 		} else {
-			ds_writew(0xe30e, 4);
+			ds_writew(DIALOG_NEXT_STATE, 4);
 		}
 
 	} else if (l_si == 5) {
 
-		ds_writew(0xe30e, test_attrib(hero, 2, 3) > 0 ? 81 : 3);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(hero, 2, 3) > 0 ? 81 : 3);
 
 	} else if (l_si == 9) {
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 10 : 11);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 10 : 11);
 
 	} else if (l_si == 12 || l_si == 19 || l_si == 21) {
 
@@ -300,9 +300,9 @@ void TLK_tavern(signed short answer)
 	} else if (l_si == 14) {
 
 		if (test_attrib(hero, 2, 0) > 0) {
-			ds_writew(0xe30e, ds_readb(0x3610) == 1 ? 16 : 17);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3610) == 1 ? 16 : 17);
 		} else {
-			ds_writew(0xe30e, 15);
+			ds_writew(DIALOG_NEXT_STATE, 15);
 		}
 
 	} else if (l_si == 17 || l_si == 39 || l_si == 57) {
@@ -311,7 +311,7 @@ void TLK_tavern(signed short answer)
 
 	} else if (l_si == 18) {
 
-		ds_writew(0xe30e, test_attrib(hero, 2, 2) > 0 ? 19 : 20);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(hero, 2, 2) > 0 ? 19 : 20);
 
 	} else if (l_si == 24) {
 
@@ -321,7 +321,7 @@ void TLK_tavern(signed short answer)
 
 		p_money = get_party_money();
 
-		ds_writew(0xe30e, l_di <= p_money ? 25 : 26);
+		ds_writew(DIALOG_NEXT_STATE, l_di <= p_money ? 25 : 26);
 
 	} else if (l_si == 27) {
 
@@ -359,7 +359,7 @@ void TLK_tavern(signed short answer)
 
 		p_money = get_party_money();
 
-		ds_writew(0xe30e, l_di <= p_money ? 30 : 31);
+		ds_writew(DIALOG_NEXT_STATE, l_di <= p_money ? 30 : 31);
 
 	} else if (l_si == 32) {
 
@@ -401,27 +401,27 @@ void TLK_tavern(signed short answer)
 
 		p_money = get_party_money();
 
-		ds_writew(0xe30e, l_di <= p_money ? 41 : 42);
+		ds_writew(DIALOG_NEXT_STATE, l_di <= p_money ? 41 : 42);
 
 	} else if (l_si == 43) {
 
 		if (test_attrib(hero, 2, 4) > 0 && (ds_readb(0x3610) == 1 || ds_readb(0x3610) == 2)) {
-			ds_writew(0xe30e, 56);
+			ds_writew(DIALOG_NEXT_STATE, 56);
 		} else {
-			ds_writew(0xe30e, 44);
+			ds_writew(DIALOG_NEXT_STATE, 44);
 		}
 
 	} else if (l_si == 45) {
 
-		ds_writew(0xe30e, ds_readb(0x3610) == 3 ? 57 : 46);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3610) == 3 ? 57 : 46);
 
 	} else if (l_si == 46) {
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 47 : 48);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 47 : 48);
 
 	} else if (l_si == 49) {
 
-		ds_writew(0xe30e, test_attrib(hero, 2, 4) > 0 ? 19 : 20);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(hero, 2, 4) > 0 ? 19 : 20);
 
 	} else if (l_si == 54) {
 
@@ -441,19 +441,19 @@ void TLK_tavern(signed short answer)
 
 		add_party_money(10);
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 59 : 60);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 59 : 60);
 
 	} else if (l_si == 61) {
 
-		ds_writew(0xe30e, ds_readb(0x3610) == 3 ? 63 : 77);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3610) == 3 ? 63 : 77);
 
 	} else if (l_si == 63) {
 
-		ds_writew(0xe30e, ds_readb(0x3609) != 0 ? 64 : 65);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3609) != 0 ? 64 : 65);
 
 	} else if (l_si == 68) {
 
-		ds_writew(0xe30e, ds_readb(0x3609) != 0 ? 69 : 36);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3609) != 0 ? 69 : 36);
 
 	} else if (l_si == 71) {
 
@@ -462,84 +462,84 @@ void TLK_tavern(signed short answer)
 
 	} else if (l_si == 73) {
 
-		ds_writew(0xe30e, ds_readb(0x3608) != 0 ? 74 : 4);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3608) != 0 ? 74 : 4);
 
 	} else if (l_si == 77) {
 
-		ds_writew(0xe30e, ds_readb(0x3609) != 0 ? 78 : 82);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3609) != 0 ? 78 : 82);
 
 	} else if (l_si == 79) {
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 153 : 154);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 153 : 154);
 
 	} else if (l_si == 80) {
 
-		ds_writew(0xe30e, test_attrib(hero, 2, 0) <= 0 && ds_readb(0x360a) != 0 ? 20 : 19);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(hero, 2, 0) <= 0 && ds_readb(0x360a) != 0 ? 20 : 19);
 
 	} else if (l_si == 85) {
 
-		ds_writew(0xe30e, ds_readb(0x3608) != 0 ? 88 : 7);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3608) != 0 ? 88 : 7);
 
 	} else if (l_si == 86) {
 
 		l_di = test_attrib(hero, 2, 0);
 
-		ds_writew(0xe30e, ds_readb(0x3608) != 0 || (!ds_readb(0x3608) && !ds_readb(0x360a) && l_di <= 0) ? 84 : 81);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3608) != 0 || (!ds_readb(0x3608) && !ds_readb(0x360a) && l_di <= 0) ? 84 : 81);
 
 	} else if (l_si == 87) {
 
-		ds_writew(0xe30e, ds_readb(0x3608) != 0 ? 88 : 89);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3608) != 0 ? 88 : 89);
 
 	} else if (l_si == 88) {
 
-		ds_writew(0xe30e, ds_readb(0x360a) != 0 ? 92 : 97);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360a) != 0 ? 92 : 97);
 
 	} else if (l_si == 89) {
 
-		ds_writew(0xe30e, ds_readb(0x360a) != 0 ? 90 : 91);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360a) != 0 ? 90 : 91);
 
 	} else if (l_si == 93) {
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 94 : 95);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 94 : 95);
 
 	} else if (l_si == 98) {
 
-		ds_writew(0xe30e, test_attrib(hero, 2, 0) > 0 ? 99 : 102);
+		ds_writew(DIALOG_NEXT_STATE, test_attrib(hero, 2, 0) > 0 ? 99 : 102);
 
 	} else if (l_si == 99) {
 
-		ds_writew(0xe30e, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 100 : 101);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE + get_town_lookup_entry()) != 0 ? 100 : 101);
 
 	} else if (l_si == 103) {
 
-		ds_writew(0xe30e, ds_readb(0x3610) == 3 ? 131 : 132);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3610) == 3 ? 131 : 132);
 
 	} else if (l_si == 104) {
 
-		ds_writew(0xe30e, ds_readds(DAY_TIMER) >= HOURS(22) && ds_readb(0x3610) != 3 ? 117 : 119);
+		ds_writew(DIALOG_NEXT_STATE, ds_readds(DAY_TIMER) >= HOURS(22) && ds_readb(0x3610) != 3 ? 117 : 119);
 
 	} else if (l_si == 106) {
 
-		ds_writew(0xe30e, ds_readb(0x360a) != 0 ? 107 : 108);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360a) != 0 ? 107 : 108);
 
 	} else if (l_si == 108) {
 
 		if (ds_readb(0x3611) < count_heroes_in_group()) {
-			ds_writew(0xe30e, 109);
+			ds_writew(DIALOG_NEXT_STATE, 109);
 		} else {
-			ds_writew(0xe30e, 111);
+			ds_writew(DIALOG_NEXT_STATE, 111);
 			ds_writeb(0x3611, 0);
 		}
 
 	} else if (l_si == 109) {
 
-		ds_writew(0xe30e, 108);
+		ds_writew(DIALOG_NEXT_STATE, 108);
 
 		if ((host_readbs(get_hero(ds_readb(0x3611)) + 0x21) != 0) &&
 			!hero_dead(get_hero(ds_readb(0x3611))) &&
 			ds_readb(0x360c) != 0)
 		{
-			ds_writew(0xe30e, test_skill(get_hero(ds_readb(0x3611)), 18, ds_readbs(0x360c) - 8) > 0 ? 108 : 110);
+			ds_writew(DIALOG_NEXT_STATE, test_skill(get_hero(ds_readb(0x3611)), 18, ds_readbs(0x360c) - 8) > 0 ? 108 : 110);
 		}
 
 		inc_ds_bs_post(0x3611);	/* TODO: this variable is unsigned */
@@ -556,27 +556,27 @@ void TLK_tavern(signed short answer)
 
 		ds_writeb(0x3610, random_schick(3));
 
-		ds_writew(0xe30e, ds_readb(0x3610) == 1 ? 114 : (ds_readb(0x3610) == 2 ? 115 : 116));
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3610) == 1 ? 114 : (ds_readb(0x3610) == 2 ? 115 : 116));
 
 	} else if (l_si == 119) {
 
 		l_di = random_schick(3);
 
-		ds_writew(0xe30e, l_di == 1 ? 120 : (l_di == 2 ? 121 : 122));
+		ds_writew(DIALOG_NEXT_STATE, l_di == 1 ? 120 : (l_di == 2 ? 121 : 122));
 
 	} else if (l_si == 120) {
 
-		ds_writew(0xe30e, random_schick(2) == 1 ? 123 : 124);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(2) == 1 ? 123 : 124);
 
 	} else if (l_si == 121) {
 
 		l_di = random_schick(5);
 
-		ds_writew(0xe30e, l_di == 1 || l_di == 2 ? 125 : (l_di == 3 ? 126 : 127));
+		ds_writew(DIALOG_NEXT_STATE, l_di == 1 || l_di == 2 ? 125 : (l_di == 3 ? 126 : 127));
 
 	} else if (l_si == 122) {
 
-		ds_writew(0xe30e, random_schick(3) == 1 ? 128 : 129);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(3) == 1 ? 128 : 129);
 
 	} else if (l_si == 124 || l_si == 128) {
 
@@ -614,16 +614,16 @@ void TLK_tavern(signed short answer)
 
 		drink_while_drinking(10);
 
-		ds_writew(0xe30e, p_money >= 10 ? 104 : 105);
+		ds_writew(DIALOG_NEXT_STATE, p_money >= 10 ? 104 : 105);
 	}
 
 	if (l_si == 132) {
 
-		ds_writew(0xe30e, npc_meetings(ds_readws(TYPEINDEX)) ? 144 : (!tavern_quest_infos() ? 133 : 144));
+		ds_writew(DIALOG_NEXT_STATE, npc_meetings(ds_readws(TYPEINDEX)) ? 144 : (!tavern_quest_infos() ? 133 : 144));
 
 	} else if (l_si == 133) {
 
-		ds_writew(0xe30e, random_schick(5) == 5 ? 152 : 131);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(5) == 5 ? 152 : 131);
 
 	} else if (l_si == 134) {
 
@@ -635,11 +635,11 @@ void TLK_tavern(signed short answer)
 
 	} else if (l_si == 139) {
 
-		ds_writew(0xe30e, random_schick(4) == 1 ? 140 : 138);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(4) == 1 ? 140 : 138);
 
 	} else if (l_si == 140) {
 
-		ds_writew(0xe30e, random_schick(3) == 2 ? 142 : 141);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(3) == 2 ? 142 : 141);
 
 	} else if (l_si == 146) {
 
@@ -649,7 +649,7 @@ void TLK_tavern(signed short answer)
 			get_informer_name();
 		}
 
-		ds_writew(0xe30e, !ds_readb(CURRENT_INFORMER) ? 148 : 147);
+		ds_writew(DIALOG_NEXT_STATE, !ds_readb(CURRENT_INFORMER) ? 148 : 147);
 
 	} else if (l_si == 151) {
 
@@ -657,7 +657,7 @@ void TLK_tavern(signed short answer)
 
 	} else if (l_si == 152) {
 
-		ds_writew(0xe30e, random_schick(3) == 2 ? 134 : 135);
+		ds_writew(DIALOG_NEXT_STATE, random_schick(3) == 2 ? 134 : 135);
 
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg060.cpp
+++ b/src/custom/schick/rewrite_m302de/seg060.cpp
@@ -246,7 +246,7 @@ void talk_tavern(void)
 	ds_writews(0x346e, 0);
 	ds_writews(TEXTBOX_WIDTH, 3);
 	ds_writews(TEXT_FILE_INDEX, -1);
-	load_buffer_1(ds_readws(BUF1_FILE_INDEX));
+	load_tx(ds_readws(TX_FILE_INDEX));
 	set_var_to_zero();
 }
 

--- a/src/custom/schick/rewrite_m302de/seg061.cpp
+++ b/src/custom/schick/rewrite_m302de/seg061.cpp
@@ -41,7 +41,7 @@ void do_temple(void)
 	signed short game_state;
 
 	ds_writew(0x29b6, ds_writew(0x29b8, 0));
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	draw_loc_icons(9,	0, 1, 2,
 				3, 4, 5,
@@ -49,7 +49,7 @@ void do_temple(void)
 
 	while (!done) {
 
-		if (ds_readws(0x2846) != 0) {
+		if (ds_readws(REQUEST_REFRESH) != 0) {
 
 			/* search which god owns this temple */
 			ds_writew(TEMPLE_GOD, 1);
@@ -87,7 +87,7 @@ void do_temple(void)
 
 			GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		handle_gui_input();

--- a/src/custom/schick/rewrite_m302de/seg062.cpp
+++ b/src/custom/schick/rewrite_m302de/seg062.cpp
@@ -153,8 +153,8 @@ void ask_miracle(void)
 					/* RONDRA */
 					if (l_si <= 5) {
 						if (!ds_readd(INGAME_TIMERS + 0x30)) {
-							miracle_modify(get_hero(0) + 0x10b - get_hero(0), 3 * HOURS(24), 1);
-							miracle_modify(get_hero(0) + 0x6b - get_hero(0), 3 * HOURS(24), 1);
+							miracle_modify(get_hero(0) + (HERO_TA_FIGHT + 3) - get_hero(0), 3 * HOURS(24), 1);
+							miracle_modify(get_hero(0) + (HERO_AT + 3) - get_hero(0), 3 * HOURS(24), 1);
 							ds_writed(INGAME_TIMERS + 0x30, 3 * HOURS(24));
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x10));
 						}
@@ -179,7 +179,7 @@ void ask_miracle(void)
 						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x20));
 					} else if (l_si <= 9) {
 						if (!ds_readd(INGAME_TIMERS + 0x38)) {
-							miracle_modify(get_hero(0) + 0x116 - get_hero(0), 4 * HOURS(24), 2);
+							miracle_modify(get_hero(0) + (HERO_TA_BODY + 5) - get_hero(0), 4 * HOURS(24), 2);
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x24));
 							ds_writed(INGAME_TIMERS + 0x38, 4 * HOURS(24));
 						}
@@ -219,7 +219,7 @@ void ask_miracle(void)
 						miracle_resurrect(get_city(0x38));
 					} else if (l_si <= 5) {
 						if (!ds_readd(INGAME_TIMERS + 0x3c)) {
-							miracle_modify(get_hero(0) + 0x56 - get_hero(0), 4 * HOURS(24), -1);
+							miracle_modify(get_hero(0) + HERO_TA - get_hero(0), 4 * HOURS(24), -1);
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x3c));
 							ds_writed(INGAME_TIMERS + 0x3c, 4 * HOURS(24));
 						}
@@ -230,7 +230,7 @@ void ask_miracle(void)
 					/* HESINDE */
 					if (l_si <= 3) {
 						if (!ds_readd(INGAME_TIMERS + 0x40)) {
-							miracle_modify(get_hero(0) + 0x164 - get_hero(0), 4 * HOURS(24), 1);
+							miracle_modify(get_hero(0) + (HERO_SP_VISION + 1) - get_hero(0), 4 * HOURS(24), 1);
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x40));
 							ds_writed(INGAME_TIMERS + 0x40, 4 * HOURS(24));
 						}
@@ -339,20 +339,20 @@ void ask_miracle(void)
 
 						if (l_si <= 5) {
 							if (!ds_readd(INGAME_TIMERS + 0x4c)) {
-								miracle_modify(get_hero(0) + 0x139 - get_hero(0), 3 * HOURS(24), 1);
-								miracle_modify(get_hero(0) + 0x138 - get_hero(0), 3 * HOURS(24), 1);
+								miracle_modify(get_hero(0) + (HERO_TA_CRAFT + 8) - get_hero(0), 3 * HOURS(24), 1);
+								miracle_modify(get_hero(0) + (HERO_TA_CRAFT + 7) - get_hero(0), 3 * HOURS(24), 1);
 								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x60));
 								ds_writed(INGAME_TIMERS + 0x4c, 3 * HOURS(24));
 							}
 						} else if (l_si <= 8) {
 							if (!ds_readd(INGAME_TIMERS + 0x50)) {
-								miracle_modify(get_hero(0) + 0x11d - get_hero(0), 3 * HOURS(24), 1);
+								miracle_modify(get_hero(0) + (HERO_TA_SOCIAL + 2) - get_hero(0), 3 * HOURS(24), 1);
 								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x64));
 								ds_writed(INGAME_TIMERS + 0x50, 3 * HOURS(24));
 							}
 						} else if (l_si <= 9) {
 							if (!ds_readd(INGAME_TIMERS + 0x54)) {
-								miracle_modify(get_hero(0) + 0x3e - get_hero(0), 3 * HOURS(24), 1);
+								miracle_modify(get_hero(0) + HERO_FF - get_hero(0), 3 * HOURS(24), 1);
 								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x68));
 								ds_writed(INGAME_TIMERS + 0x54, 3 * HOURS(24));
 							}
@@ -433,14 +433,14 @@ void ask_miracle(void)
 					/* RAHJA */
 					if (l_si <= 8) {
 						if (!ds_readd(INGAME_TIMERS + 0x5c)) {
-							miracle_modify(get_hero(0) + 0x11c - get_hero(0), 7 * HOURS(24), 2);
-							miracle_modify(get_hero(0) + 0x118 - get_hero(0), 7 * HOURS(24), 2);
+							miracle_modify(get_hero(0) + (HERO_TA_SOCIAL + 1) - get_hero(0), 7 * HOURS(24), 2);
+							miracle_modify(get_hero(0) + (HERO_TA_BODY + 7) - get_hero(0), 7 * HOURS(24), 2);
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x80));
 							ds_writed(INGAME_TIMERS + 0x5c, 7 * HOURS(24));
 						}
 					} else if (l_si <= 13) {
 						if (!ds_readd(INGAME_TIMERS + 0x60)) {
-							miracle_modify(get_hero(0) + 0x3b - get_hero(0), 3 * HOURS(24), 1);
+							miracle_modify(get_hero(0) + HERO_CH - get_hero(0), 3 * HOURS(24), 1);
 							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_city(0x84));
 							ds_writed(INGAME_TIMERS + 0x60, 3 * HOURS(24));
 						}

--- a/src/custom/schick/rewrite_m302de/seg063.cpp
+++ b/src/custom/schick/rewrite_m302de/seg063.cpp
@@ -329,7 +329,7 @@ void do_harbour(void)
 				ds_writeb(0x4497, 0);
 
 				for (l_si = 0; l_si < 6; l_si++) {
-					ds_writeb(0x26a4 + l_si, 0);
+					ds_writeb(FOOD_MESSAGE_SHOWN + l_si, 0);
 				}
 
 				load_map();

--- a/src/custom/schick/rewrite_m302de/seg063.cpp
+++ b/src/custom/schick/rewrite_m302de/seg063.cpp
@@ -113,7 +113,7 @@ void do_harbour(void)
 			init_ani(0);
 			ds_writew(REQUEST_REFRESH, 0);
 
-			load_buffer_1(ARCHIVE_FILE_HAFEN_LTX);
+			load_tx(ARCHIVE_FILE_HAFEN_LTX);
 
 			if (flag != 0) {
 

--- a/src/custom/schick/rewrite_m302de/seg063.cpp
+++ b/src/custom/schick/rewrite_m302de/seg063.cpp
@@ -100,18 +100,18 @@ void do_harbour(void)
 	ds_writew(0x4334, ds_readws(TYPEINDEX));
 
 	draw_loc_icons(4, 40, 42, 41, 8);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	ds_writeb(0x4333, 0);
 
 	do {
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(6);
 			init_ani(0);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 
 			load_buffer_1(ARCHIVE_FILE_HAFEN_LTX);
 
@@ -356,8 +356,8 @@ void do_harbour(void)
 				passage_arrival();
 
 				ds_writew(WALLCLOCK_UPDATE, ds_writew(0x2ca2, ds_writew(0x2ca4, ds_writeb(0x42ae, 0))));
-				ds_writews(CURRENT_ANI, ds_writebs(0x2ca7, ds_writebs(0x2845, -1)));
-				ds_writew(0x2846, 1);
+				ds_writews(CURRENT_ANI, ds_writebs(0x2ca7, ds_writebs(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13))));
+				ds_writew(REQUEST_REFRESH, 1);
 				ds_writeb(TRAVELING, 0);
 
 				if (!ds_readb(0x4333)) {
@@ -554,7 +554,7 @@ void sea_travel(signed short passage, signed short dir)
 
 		}
 
-		if (ds_readws(0x2846) != 0 && !ds_readb(0x4333)) {
+		if (ds_readws(REQUEST_REFRESH) != 0 && !ds_readb(0x4333)) {
 
 			update_mouse_cursor();
 
@@ -579,7 +579,7 @@ void sea_travel(signed short passage, signed short dir)
 			ds_writew(WALLCLOCK_X, ds_readws(0x2ca2) + 120);
 			ds_writew(WALLCLOCK_Y, ds_readws(0x2ca4) + 87);
 			ds_writew(WALLCLOCK_UPDATE, 1);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		add_ds_ws(0x425a, 2 * (!dir ? 2 : -2));

--- a/src/custom/schick/rewrite_m302de/seg065.cpp
+++ b/src/custom/schick/rewrite_m302de/seg065.cpp
@@ -600,7 +600,7 @@ void show_outro(void)
 	set_party_money(get_party_money());
 
 	/* mark the game as done */
-	ds_writeb(0x2d34, 99);
+	ds_writeb(DATSEG_STATUS_START, 99);
 
 	ds_writew(0x2ca2, 0);
 	ds_writew(0x2ca4, 0);

--- a/src/custom/schick/rewrite_m302de/seg065.cpp
+++ b/src/custom/schick/rewrite_m302de/seg065.cpp
@@ -40,18 +40,18 @@ void do_market(void)
 	signed short bak1;
 
 	done = 0;
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	bak1 = ds_readbs(0x2d7c);
 	dir_bak = ds_readbs(DIRECTION);
 
 	do {
 
-		if (ds_readw(0x2846) != 0) {
+		if (ds_readw(REQUEST_REFRESH) != 0) {
 			draw_main_screen();
 			set_var_to_zero();
 			load_ani(16);
 			init_ani(0);
-			ds_writew(0x2846, 0);
+			ds_writew(REQUEST_REFRESH, 0);
 		}
 
 		answer = GUI_radio(get_ltx(0xaa0), 4,
@@ -101,7 +101,7 @@ void final_intro(void)
 	RealPt ptr2;
 	struct nvf_desc nvf;
 
-	ds_writebs(0x2845, -2);
+	ds_writebs(PP20_INDEX, (ARCHIVE_FILE_DNGS + 12));
 
 	update_mouse_cursor();
 

--- a/src/custom/schick/rewrite_m302de/seg065.cpp
+++ b/src/custom/schick/rewrite_m302de/seg065.cpp
@@ -590,7 +590,7 @@ void show_outro(void)
 			}
 
 			host_writed(hero + HERO_HEAL_TIMER, 0);
-			host_writed(hero + HERO_MAGIC_TIMER, 0);
+			host_writed(hero + HERO_STAFFSPELL_TIMER, 0);
 
 			host_writeb(hero + HERO_GROUP_POS, i + 1);
 		}

--- a/src/custom/schick/rewrite_m302de/seg066.cpp
+++ b/src/custom/schick/rewrite_m302de/seg066.cpp
@@ -295,7 +295,7 @@ void TLK_eremit(signed short state)
 	Bit8u *hero;
 
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x3615) != 0 ? 1 : 2);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3615) != 0 ? 1 : 2);
 	} else if (state == 6) {
 
 		hero = get_hero(0);

--- a/src/custom/schick/rewrite_m302de/seg066.cpp
+++ b/src/custom/schick/rewrite_m302de/seg066.cpp
@@ -327,7 +327,7 @@ void do_town(void)
 
 		set_audio_track(ARCHIVE_FILE_THORWAL_XMI);
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 
 		diary_new_entry();
 	}
@@ -869,16 +869,16 @@ signed short city_step(void)
 	ds_writebs((0xbd38 + 5), 11);
 	ds_writebs((0xbd38 + 6), 54);
 
-	if (ds_readws(0x2846) != 0) {
+	if (ds_readws(REQUEST_REFRESH) != 0) {
 
 		draw_main_screen();
 		GUI_print_loc_line(get_dtp(0x0000));
 
-		ds_writew(0x2846, ds_writews(0xd013, 0));
+		ds_writew(REQUEST_REFRESH, ds_writews(0xd013, 0));
 		ds_writews(0xe40c, -1);
 	}
 
-	if (ds_readw(0xd013) != 0 && ds_readbs(0x2845) == 0) {
+	if (ds_readw(0xd013) != 0 && ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 		draw_icons();
 		ds_writews(0xd013, 0);
 	}

--- a/src/custom/schick/rewrite_m302de/seg067.cpp
+++ b/src/custom/schick/rewrite_m302de/seg067.cpp
@@ -31,7 +31,7 @@ namespace M302de {
 void city_event_switch(void)
 {
 	/* load STRASSE.LTX */
-	load_buffer_1(ARCHIVE_FILE_STRASSE_LTX);
+	load_tx(ARCHIVE_FILE_STRASSE_LTX);
 
 	/* set city flag */
 	ds_writeb(C_EVENT_ACTIVE, 1);
@@ -52,7 +52,7 @@ void city_event_switch(void)
 	ds_writeb(C_EVENT_ACTIVE, 0);
 
 	/* load the LTX-file of the current town */
-	load_buffer_1(ds_readbs(CURRENT_TOWN) + 77);
+	load_tx(ds_readbs(CURRENT_TOWN) + 77);
 
 	/* update the current position / make the step */
 	ds_writews(X_TARGET, ds_readws(0x2d83));

--- a/src/custom/schick/rewrite_m302de/seg068.cpp
+++ b/src/custom/schick/rewrite_m302de/seg068.cpp
@@ -515,9 +515,9 @@ void academy_analues(void)
 
 		ds_writed(SPELLUSER, (Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * hero_pos));
 
-		buffer1_bak = ds_readws(BUF1_FILE_INDEX);
+		buffer1_bak = ds_readws(TX_FILE_INDEX);
 
-		load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+		load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_city(0x100),
@@ -525,7 +525,7 @@ void academy_analues(void)
 
 		if (buffer1_bak != -1 && buffer1_bak != 222) {
 
-			load_buffer_1(buffer1_bak);
+			load_tx(buffer1_bak);
 		}
 
 		GUI_input(Real2Host(ds_readd(DTP2)), 0);

--- a/src/custom/schick/rewrite_m302de/seg072.cpp
+++ b/src/custom/schick/rewrite_m302de/seg072.cpp
@@ -684,7 +684,7 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 			hero_disappear(Real2Host(ds_readd(UNICORN_HERO_PTR)), ds_readb(UNICORN_HERO_POS), -1);
 		} else if (state == 17) {
 			/* the hero gets heavily wounded, 1 LE left */
-			sub_hero_le(Real2Host(ds_readd(UNICORN_HERO_PTR)), host_readws(Real2Host(ds_readd(UNICORN_HERO_PTR)) + 0x60) - 1);
+			sub_hero_le(Real2Host(ds_readd(UNICORN_HERO_PTR)), host_readws(Real2Host(ds_readd(UNICORN_HERO_PTR)) + HERO_LE) - 1);
 			/* the party opens a camp */
 			ds_writeb(LOCATION, 6);
 			do_location();

--- a/src/custom/schick/rewrite_m302de/seg072.cpp
+++ b/src/custom/schick/rewrite_m302de/seg072.cpp
@@ -294,7 +294,7 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 				/* remove the NPC from the group */
 				remove_npc(24, 31, 231, get_ltx(0xbd8), (Bit8u*)0);
 
-				ds_writew(0x2846, 1);
+				ds_writew(REQUEST_REFRESH, 1);
 
 			} else if (state == 7 || state == 8 || state == 9 || state == 10) {
 				timewarp(MINUTES(30));

--- a/src/custom/schick/rewrite_m302de/seg072.cpp
+++ b/src/custom/schick/rewrite_m302de/seg072.cpp
@@ -39,18 +39,18 @@ void INF_jurge_hjore(signed short informer, signed short state)
 		/* JURGE TORFINSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, (ds_readb(INFORMER_JURGE) == 1 || ds_readb(0x360f) != 0) ? 44 : 43);
+			ds_writew(DIALOG_NEXT_STATE, (ds_readb(INFORMER_JURGE) == 1 || ds_readb(0x360f) != 0) ? 44 : 43);
 		} else if (state == 11) {
-			ds_writew(0xe30e, has_intro_letter() ? 36 : 37);
+			ds_writew(DIALOG_NEXT_STATE, has_intro_letter() ? 36 : 37);
 		} else if (state == 14) {
-			ds_writew(0xe30e, has_intro_letter() ? 39 : 40);
+			ds_writew(DIALOG_NEXT_STATE, has_intro_letter() ? 39 : 40);
 		} else if (state == 19) {
-			ds_writew(0xe30e, ds_readb(0x360f) != 0 ? 1 : (!ds_readb(0x360f) && ds_readb(INFORMER_JURGE) != 0 ? 2 : 3));
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360f) != 0 ? 1 : (!ds_readb(0x360f) && ds_readb(INFORMER_JURGE) != 0 ? 2 : 3));
 		} else if (state == 20) {
-			ds_writew(0xe30e, has_intro_letter() ? 21 : 22);
+			ds_writew(DIALOG_NEXT_STATE, has_intro_letter() ? 21 : 22);
 		} else if (state == 27) {
 			/* get the map */
-			ds_writew(0xe30e, count_map_parts() ? 29 : 30);
+			ds_writew(DIALOG_NEXT_STATE, count_map_parts() ? 29 : 30);
 
 			if (ds_readb(TREASURE_MAPS + 0) == 2) {
 				ds_writeb(TMAP_DOUBLE2, 1);
@@ -72,17 +72,17 @@ void INF_jurge_hjore(signed short informer, signed short state)
 		} else if (state == 42) {
 			ds_writeb(INFORMER_JURGE, 2);
 		} else if (state == 44) {
-			ds_writew(0xe30e, ds_readb(0x344c) != 0 ? 20 : 19);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x344c) != 0 ? 20 : 19);
 		} else if (state == 45) {
-			ds_writew(0xe30e, !ds_readb(INFORMER_JURGE) ? 6 : 5);
+			ds_writew(DIALOG_NEXT_STATE, !ds_readb(INFORMER_JURGE) ? 6 : 5);
 		}
 	} else if (informer == 1) {
 		/* HJORE AHRENSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, !ds_readb(INFORMER_HJORE) ? 16 : (ds_readb(INFORMER_HJORE) == 2 ? 1 : 5));
+			ds_writew(DIALOG_NEXT_STATE, !ds_readb(INFORMER_HJORE) ? 16 : (ds_readb(INFORMER_HJORE) == 2 ? 1 : 5));
 		} else if (state == 5) {
-			ds_writew(0xe30e, get_first_hero_with_item(176) != -1 ? 6 : 7);
+			ds_writew(DIALOG_NEXT_STATE, get_first_hero_with_item(176) != -1 ? 6 : 7);
 		} else if (state == 8 || state == 9 || state == 12) {
 			ds_writeb(INFORMER_HJORE, 2);
 		} else if (state == 10) {
@@ -119,7 +119,7 @@ void INF_yasma_umbrik_isleif(signed short informer, signed short state)
 		/* YASMA THINMARSDOTTER */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_YASMA) == 2 ? 1 : 2);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_YASMA) == 2 ? 1 : 2);
 		} else if (state == 15) {
 			ds_writeb(0x3df3, 1);
 		} else if (state == 22) {
@@ -136,9 +136,9 @@ void INF_yasma_umbrik_isleif(signed short informer, signed short state)
 		/* UMBRIK SIEBENSTEIN */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_UMBRIK) == 2 ? 1 : 2);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_UMBRIK) == 2 ? 1 : 2);
 		} else if (state == 2) {
-			ds_writew(0xe30e, ds_readb(QUEST_GORAH) != 0 ? 15 : (!ds_readb(INFORMER_UMBRIK) ? 24 : 3));
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(QUEST_GORAH) != 0 ? 15 : (!ds_readb(INFORMER_UMBRIK) ? 24 : 3));
 		} else if (state == 11 || state == 13) {
 			/* mark UMBRIK SIEBENSTEIN as done */
 			ds_writeb(INFORMER_UMBRIK, 2);
@@ -147,7 +147,7 @@ void INF_yasma_umbrik_isleif(signed short informer, signed short state)
 			ds_writeb(QUEST_GORAH, 1);
 		} else if (state == 15) {
 			/* check if the heros have the RUNENKNOCHEN / BONE WITH RUNE */
-			ds_writew(0xe30e, get_first_hero_with_item(164) != -1 ? 16 : 17);
+			ds_writew(DIALOG_NEXT_STATE, get_first_hero_with_item(164) != -1 ? 16 : 17);
 		} else if (state == 19) {
 			/* give the RUNENKNOCHEN / BONE WITH RUNE to UMBRIK */
 			hero = get_hero(get_first_hero_with_item(164));
@@ -170,16 +170,16 @@ void INF_yasma_umbrik_isleif(signed short informer, signed short state)
 		/* ISLEIF OLGARDSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_ISLEIF) == 2 ? 1 : 2);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_ISLEIF) == 2 ? 1 : 2);
 		} else if (state == 2) {
 			/* TODO: what does that mean ? */
-			ds_writew(0xe30e, ds_readb(0x344f) != 0 ? 3 : 4);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x344f) != 0 ? 3 : 4);
 		} else if (state == 8 || state == 23 || state == 25 || state == 27) {
 			/* mark ISLEIF OLGARDSSON as done */
 			ds_writeb(INFORMER_ISLEIF, 2);
 		} else if (state == 9) {
 			/* TODO: what does that mean ? */
-			ds_writew(0xe30e, ds_readb(0x344f) != 0 ? 10 : 11);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x344f) != 0 ? 10 : 11);
 		} else if (state == 15 || state == 19) {
 			/* TODO: check what happens here */
 		} else if (state == 16 || state == 20) {
@@ -202,7 +202,7 @@ void INF_yasma_umbrik_isleif(signed short informer, signed short state)
 
 		} else if (state == 24) {
 			/* TODO: what does that mean ? */
-			ds_writew(0xe30e, ds_readb(0x3450) != 0 ? 25 : 26);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3450) != 0 ? 25 : 26);
 		}
 	}
 }
@@ -221,9 +221,9 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 		/* RAGNA FIRUNJASDOTTER */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_RAGNA) == 2 ? 1 : 3);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_RAGNA) == 2 ? 1 : 3);
 		} else if (state == 4) {
-			ds_writew(0xe30e, count_map_parts() ? 9 : 10);
+			ds_writew(DIALOG_NEXT_STATE, count_map_parts() ? 9 : 10);
 		} else if (state == 8 || state == 25) {
 			/* mark RAGNA FIRUNJASDOTTER as done */
 			ds_writeb(INFORMER_RAGNA, 2);
@@ -240,7 +240,7 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 			if (!ds_readb(INFORMER_JURGE)) ds_writeb(INFORMER_JURGE, 1);
 		} else if (state == 17) {
 			/* TODO: what does that mean ? */
-			ds_writew(0xe30e, ds_readb(0x3451) != 0 ? 18 : 19);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3451) != 0 ? 18 : 19);
 		} else if (state == 21) {
 			/* check if the party already has this map piece */
 			if (ds_readb(TREASURE_MAPS + 3) == 2) ds_writeb(TMAP_DOUBLE2, 1);
@@ -278,17 +278,17 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 			/* BEORN HJALLASSON */
 
 			if (!state) {
-				ds_writew(0xe30e, ds_readb(INFORMER_BEORN) == 2 ? 1 : 2);
+				ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_BEORN) == 2 ? 1 : 2);
 			} else if (state == 2) {
 				/* is ERWO in the group ? */
-				ds_writew(0xe30e,
+				ds_writew(DIALOG_NEXT_STATE,
 					host_readbs(get_hero(6) + HERO_NPC_ID) == 6 && is_hero_available_in_group(get_hero(6)) ? 3 : 15);
 			} else if (state == 6) {
 
 				/* copy the name */
 				strcpy((char*)(p_datseg + 0xe42e), (char*)(get_hero(6) + HERO_NAME2));
 				/* set a pointer */
-				ds_writed(0xe308, (Bit32u)RealMake(datseg, 0xe42e));
+				ds_writed(DIALOG_TITLE, (Bit32u)RealMake(datseg, 0xe42e));
 				/* copy the picture of the NPC */
 				memcpy(Real2Host(ds_readd(DTP2)), get_hero(6) + HERO_PORTRAIT, 0x400);
 				/* remove the NPC from the group */
@@ -324,7 +324,7 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 				/* TODO: what does that mean ? */
 				ds_writeb(0x3454, 1);
 			} else if (state == 24) {
-				ds_writew(0xe30e, ds_readb(0x3452) != 0 && ds_readb(0x3453) != 0 && ds_readb(0x3454) != 0 ? 26 : 27);
+				ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3452) != 0 && ds_readb(0x3453) != 0 && ds_readb(0x3454) != 0 ? 26 : 27);
 			} else if (state == 25) {
 				/* TODO: what does that mean ? */
 				ds_writeb(0x3453, 1);
@@ -346,25 +346,25 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 					l_di = 0;
 				}
 
-				ds_writew(0xe30e, test_attrib(get_hero(0), 2, l_di) > 0 ? 26 : 28);
+				ds_writew(DIALOG_NEXT_STATE, test_attrib(get_hero(0), 2, l_di) > 0 ? 26 : 28);
 			}
 	} else if (informer == 2) {
 		/* ALGRID TRONDESDOTTER */
 
 		if (!state) {
 			/* TODO: check what happens here */
-			ds_writew(0xe30e, ds_readb(0x360f) ? 23 : (ds_readb(INFORMER_ALGRID) == 2 ? 1 : 22));
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360f) ? 23 : (ds_readb(INFORMER_ALGRID) == 2 ? 1 : 22));
 		} else if (state == 2) {
 			/* mark ALGRID TRONDESDOTTER as done */
 			ds_writeb(INFORMER_ALGRID, 2);
 
-			ds_writew(0xe30e, ds_readb(INFORMER_JURGE) == 2 ? 3 : 4);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_JURGE) == 2 ? 3 : 4);
 		} else if (state == 3) {
 			/* TODO: check what happens here */
-			ds_writew(0xe30e, ds_readb(0x3467) ? 5 : 6);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3467) ? 5 : 6);
 		} else if (state == 4) {
 			/* TODO: check what happens here */
-			ds_writew(0xe30e, ds_readb(0x3467) ? 7 : 8);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3467) ? 7 : 8);
 		} else if (state == 14) {
 			/* make TIOMAR SWAFNILDSSON known */
 			if (!ds_readb(INFORMER_TIOMAR)) ds_writeb(INFORMER_TIOMAR, 1);
@@ -386,9 +386,9 @@ void INF_eliane_tiomar(signed short informer, signed short state)
 		/* ELIANE WINDENBECK */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(QUEST_NAMELESS_GOT) || ds_readw(GOT_MAIN_QUEST) == 0 ? 1 : 6);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(QUEST_NAMELESS_GOT) || ds_readw(GOT_MAIN_QUEST) == 0 ? 1 : 6);
 		} else if (state == 1) {
-			ds_writew(0xe30e, ds_readb(QUEST_NAMELESS_DONE) && ds_readb(INFORMER_ELIANE) != 2 ? 2 : 3);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(QUEST_NAMELESS_DONE) && ds_readb(INFORMER_ELIANE) != 2 ? 2 : 3);
 		} else if (state == 5 || state == 27) {
 				/* check if the party already has this map piece */
 				if (ds_readb(TREASURE_MAPS + 5) == 2) ds_writeb(TMAP_DOUBLE2, 1);
@@ -402,7 +402,7 @@ void INF_eliane_tiomar(signed short informer, signed short state)
 				/* mark ELIANE WINDENBECK as done */
 				ds_writeb(INFORMER_ELIANE, 2);
 		} else if (state == 19) {
-			ds_writew(0xe30e, ds_readb(QUEST_NAMELESS_DONE) ? 20 : 30);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(QUEST_NAMELESS_DONE) ? 20 : 30);
 			ds_writeb(QUEST_NAMELESS_GOT, 1);
 		} else if (state == 16) {
 			/* mark YASMA THINMARSDOTTER as known */
@@ -413,19 +413,19 @@ void INF_eliane_tiomar(signed short informer, signed short state)
 			if (!ds_readb(INFORMER_ASGRIMM)) ds_writeb(INFORMER_ASGRIMM, 1);
 		} else if (state == 24) {
 			/* the group has the SCHWARZE STATUETTE/BLACK FIGURINE */
-			ds_writew(0xe30e, get_first_hero_with_item(248) != -1 ? 27 : 28);
+			ds_writew(DIALOG_NEXT_STATE, get_first_hero_with_item(248) != -1 ? 27 : 28);
 		}
 	} else if (informer == 1) {
 		/* TIOMAR SWAFNILDSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(0x360f) != 0 ?
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360f) != 0 ?
 						44 :
 						(!ds_readb(INFORMER_TIOMAR) || ds_readb(INFORMER_TIOMAR) == 2 ?	2 : 1));
 		} else if (state == 1) {
-			ds_writew(0xe30e, ds_readb(0x3469) != 0 ? 36 : 3);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3469) != 0 ? 36 : 3);
 		} else if (state == 4) {
-			ds_writew(0xe30e, get_first_hero_with_item(247) != -1 ? 6 : 7);
+			ds_writew(DIALOG_NEXT_STATE, get_first_hero_with_item(247) != -1 ? 6 : 7);
 		} else if (state == 12 || state == 42) {
 				/* check if the party already has this map piece */
 				if (ds_readb(TREASURE_MAPS + 8) == 2) ds_writeb(TMAP_DOUBLE2, 1);
@@ -446,7 +446,7 @@ void INF_eliane_tiomar(signed short informer, signed short state)
 		} else if (state == 20) {
 			/* drink with TIOMAR */
 			timewarp(HOURS(1));
-			ds_writew(0xe30e, test_skill(get_hero(ds_writeb(0x3468, (unsigned char)get_random_hero())), 18, 0) > 0 ? 21 : 22);
+			ds_writew(DIALOG_NEXT_STATE, test_skill(get_hero(ds_writeb(0x3468, (unsigned char)get_random_hero())), 18, 0) > 0 ? 21 : 22);
 		} else if (state == 22) {
 			/* TIOMARS drinkmate gets drunken */
 			hero_get_drunken(get_hero(ds_readb(0x3468)));
@@ -460,9 +460,9 @@ void INF_eliane_tiomar(signed short informer, signed short state)
 		} else if (state == 34) {
 			ds_writeb(0x3469, 1);
 		} else if (state == 36) {
-			ds_writew(0xe30e, get_first_hero_with_item(247) != -1 ? 37 : 2);
+			ds_writew(DIALOG_NEXT_STATE, get_first_hero_with_item(247) != -1 ? 37 : 2);
 		} else if (state == 45) {
-			ds_writew(0xe30e, ds_readb(INFORMER_UMBRIK) == 2 ? 46 : 47);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_UMBRIK) == 2 ? 46 : 47);
 		}
 
 	}
@@ -481,7 +481,7 @@ void INF_olvir_asgrimm(signed short informer, signed short state)
 		/* OLVIR GUNDRIDSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_OLVIR) == 2 ? 1 : 2);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_OLVIR) == 2 ? 1 : 2);
 		} else if (state == 2) {
 			/* mark OLVIR GUNDRIDSSON as done */
 			ds_writeb(INFORMER_OLVIR, 2);
@@ -496,28 +496,28 @@ void INF_olvir_asgrimm(signed short informer, signed short state)
 		} else if (state == 14 || state == 15 || state == 21 || state == 22 || state == 28) {
 			timewarp(HOURS(1));
 		} else if (state == 16) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 13);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 13);
 			ds_writeb(0x3459, 1);
 		} else if (state == 17) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 14);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 14);
 			ds_writeb(0x3459, 1);
 		} else if (state == 18) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 15);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 15);
 			ds_writeb(0x3459, 1);
 		} else if (state == 26) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 22);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 22);
 			ds_writeb(0x3459, 1);
 		} else if (state == 27) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 23);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 23);
 			ds_writeb(0x3459, 1);
 		} else if (state == 31) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 29);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 29);
 			ds_writeb(0x3459, 1);
 		} else if (state == 32) {
-			ds_writew(0xe30e, ds_readb(0x3459) != 0 ? 19 : 30);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3459) != 0 ? 19 : 30);
 			ds_writeb(0x3459, 1);
 		} else if (state == 33) {
-			ds_writew(0xe30e, ds_readb(0x345a) != 0 ? 11 : (ds_readb(0x345b) != 0 ? 35 : 36));
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x345a) != 0 ? 11 : (ds_readb(0x345b) != 0 ? 35 : 36));
 		} else if (state == 34) {
 			ds_writeb(0x345a, 0);
 			ds_writeb(0x345b, 1);
@@ -525,15 +525,15 @@ void INF_olvir_asgrimm(signed short informer, signed short state)
 			ds_writeb(0x345b, 0);
 			ds_writeb(0x345c, 1);
 		} else if (state == 37) {
-			ds_writew(0xe30e, ds_readb(0x3457) != 0 ? 39 : 40);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3457) != 0 ? 39 : 40);
 		} else if (state == 39) {
-			ds_writew(0xe30e, ds_readb(0x3456) != 0 ? 42 : 41);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3456) != 0 ? 42 : 41);
 		}
 	} else if (informer == 1) {
 		/* ASGRIMM THURBOLDSSON */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(0x360f) != 0 ? 22 : (ds_readw(GOT_MAIN_QUEST) == 0|| ds_readb(INFORMER_ASGRIMM) == 2 ? 1 : 2));
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x360f) != 0 ? 22 : (ds_readw(GOT_MAIN_QUEST) == 0|| ds_readb(INFORMER_ASGRIMM) == 2 ? 1 : 2));
 		} else if (state == 2) {
 			/* mark ASGRIMM THURBOLDSSON as done */
 			ds_writeb(INFORMER_ASGRIMM, 2);
@@ -578,12 +578,12 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 		enough_money = money >= 6000 ? 1 : 0;
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_TREBORN) != 0 ? -1 : 1);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_TREBORN) != 0 ? -1 : 1);
 		} else if (state == 1) {
 			/* mark TREBORN KOLBERG as met */
 			if (!ds_readb(INFORMER_TREBORN)) ds_writeb(INFORMER_TREBORN, 1);
 		} else if (state == 5) {
-			ds_writew(0xe30e, enough_money ? 7 : 8);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 7 : 8);
 		} else if (state == 9) {
 
 			/* buy the map */
@@ -607,16 +607,16 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 			/* mark JURGE TORFINSSON as known */
 			if (!ds_readb(INFORMER_JURGE)) ds_writeb(INFORMER_JURGE, 1);
 		} else if (state == 13) {
-			ds_writew(0xe30e, enough_money ? 14 : 15);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 14 : 15);
 		} else if (state == 17) {
-			ds_writew(0xe30e, enough_money ? 19 : 20);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 19 : 20);
 		} else if (state == 18) {
 			ds_writew(TYPEINDEX, 91);
 			do_merchant();
 		} else if (state == 21) {
 			ds_writeb(TREBORN_DATE, 1);
 		} else if (state == 23) {
-			ds_writew(0xe30e, enough_money ? 25 : 24);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 25 : 24);
 		}
 	} else if (informer == 1) {
 		/* TREBORN KOLBERG (second meeting) */
@@ -624,11 +624,11 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 		enough_money = money >= 7500 ? 1 : 0;
 
 		if (!state) {
-			ds_writew(0xe30e, !ds_readb(TREBORN_DATE) ? -1 : 1);
+			ds_writew(DIALOG_NEXT_STATE, !ds_readb(TREBORN_DATE) ? -1 : 1);
 		} else if (state == 2) {
-			ds_writew(0xe30e, enough_money ? 3 : 4);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 3 : 4);
 		} else if (state == 5) {
-			ds_writew(0xe30e, enough_money ? 6 : 7);
+			ds_writew(DIALOG_NEXT_STATE, enough_money ? 6 : 7);
 		} else if (state == 12) {
 			/* buy the map */
 			money -= 7500;
@@ -655,7 +655,7 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 		/* EINHORN / UNICORN (first meeting) */
 
 		if (!state) {
-			ds_writew(0xe30e, ds_readb(INFORMER_UNICORN) == 2 ? 1 : 2);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_UNICORN) == 2 ? 1 : 2);
 		} else if (state == 2) {
 			/* select the hero with the highest CH value */
 			/* REMARK: what if the NPC is choosen ? */
@@ -673,12 +673,12 @@ void INF_treborn_unicorn(signed short informer, signed short state)
 			ds_writeb(INFORMER_UNICORN, 2);
 		} else if (state == 10) {
 			/* test FF+2 */
-			ds_writew(0xe30e, test_attrib(Real2Host(ds_readd(UNICORN_HERO_PTR)), 4, 2) > 0 ? 11 : 14);
+			ds_writew(DIALOG_NEXT_STATE, test_attrib(Real2Host(ds_readd(UNICORN_HERO_PTR)), 4, 2) > 0 ? 11 : 14);
 		} else if (state == 11) {
 			/* test FF+5 */
-			ds_writew(0xe30e, test_attrib(Real2Host(ds_readd(UNICORN_HERO_PTR)), 4, 5) > 0 ? 12 : 13);
+			ds_writew(DIALOG_NEXT_STATE, test_attrib(Real2Host(ds_readd(UNICORN_HERO_PTR)), 4, 5) > 0 ? 12 : 13);
 		} else if (state == 15) {
-			ds_writew(0xe30e, random_schick(100) <= 50 ? 16 : 17);
+			ds_writew(DIALOG_NEXT_STATE, random_schick(100) <= 50 ? 16 : 17);
 		} else if (state == 16) {
 			/* the hero disappears */
 			hero_disappear(Real2Host(ds_readd(UNICORN_HERO_PTR)), ds_readb(UNICORN_HERO_POS), -1);
@@ -714,9 +714,9 @@ void INF_swafnild_unicorn(signed short informer, signed short state)
 		/* SWAFNILD EGILSDOTTER */
 
 		if (state == 1) {
-			ds_writew(0xe30e, ds_readb(INFORMER_SWAFNILD) == 2 ? 3 : 7);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(INFORMER_SWAFNILD) == 2 ? 3 : 7);
 		} else if (state == 4) {
-			ds_writew(0xe30e, ds_readb(0x3462) != 0 ? 38 : 39);
+			ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3462) != 0 ? 38 : 39);
 		} else if (state == 7) {
 
 			if ((ds_readbs(CURRENT_TOWN) >= 1 && ds_readbs(CURRENT_TOWN) <= 10) ||
@@ -746,14 +746,14 @@ void INF_swafnild_unicorn(signed short informer, signed short state)
 			if (!ds_readb(INFORMER_TIOMAR)) ds_writeb(INFORMER_TIOMAR, 1);
 		} else if (state == 18) {
 			/* test CH+5 */
-			ds_writew(0xe30e, test_attrib(get_hero(0), 2, 5) > 0 ? 19 : 20);
+			ds_writew(DIALOG_NEXT_STATE, test_attrib(get_hero(0), 2, 5) > 0 ? 19 : 20);
 		} else if (state == 21) {
 			/* mark SWAFNILD EGILSDOTTER as done */
 			ds_writeb(INFORMER_SWAFNILD, 2);
 			ds_writeb(0x3462, 1);
 		} else if (state == 22) {
 			/* test CH+3 */
-			ds_writew(0xe30e, test_attrib(get_hero(0), 2, 3) > 0 ? 24 : 23);
+			ds_writew(DIALOG_NEXT_STATE, test_attrib(get_hero(0), 2, 3) > 0 ? 24 : 23);
 		} else if (state == 24 || state == 41) {
 			/* mark SWAFNILD EGILSDOTTER as done */
 			ds_writeb(INFORMER_SWAFNILD, 2);

--- a/src/custom/schick/rewrite_m302de/seg074.cpp
+++ b/src/custom/schick/rewrite_m302de/seg074.cpp
@@ -64,11 +64,11 @@ void show_automap(void)
 		ds_writeb(CURRENT_TOWN, (signed char)town);
 		ds_writeb(DUNGEON_INDEX, (signed char)dungeon);
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 
 		do {
 
-			if (ds_readw(0x2846) != 0) {
+			if (ds_readw(REQUEST_REFRESH) != 0) {
 				loc_bak = ds_readbs(LOCATION);
 				ds_writeb(LOCATION, 1);
 
@@ -85,7 +85,7 @@ void show_automap(void)
 				clear_ani_pal();
 				draw_automap_to_screen();
 				set_ani_pal(p_datseg + 0x7d0e);
-				ds_writew(0x2846, 0);
+				ds_writew(REQUEST_REFRESH, 0);
 			}
 
 			done = 0;
@@ -136,7 +136,7 @@ void show_automap(void)
 		} while (done == 0);
 
 		ds_writew(TEXTBOX_WIDTH, bak);
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 
 		clear_ani_pal();
 
@@ -632,7 +632,7 @@ signed short select_teleport_dest(void)
 	}
 
 	ds_writew(TEXTBOX_WIDTH, bak);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	return ae_costs;
 }

--- a/src/custom/schick/rewrite_m302de/seg075.cpp
+++ b/src/custom/schick/rewrite_m302de/seg075.cpp
@@ -540,7 +540,7 @@ signed short is_staff_lvl2_in_group(void)
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			check_hero(hero_i) &&
-			(host_readbs(hero_i + HERO_WAND) >= 2))
+			(host_readbs(hero_i + HERO_STAFFSPELL_LVL) >= 2))
 		{
 			return 1;
 		}
@@ -912,7 +912,7 @@ signed short DNG_check_climb_tools(void)
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero) &&
 			(host_readbs(hero + HERO_TYPE) == 9) &&
-			(host_readbs(hero + HERO_WAND) > 2))
+			(host_readbs(hero + HERO_STAFFSPELL_LVL) > 2))
 		{
 			return i + 1;
 		}

--- a/src/custom/schick/rewrite_m302de/seg087.cpp
+++ b/src/custom/schick/rewrite_m302de/seg087.cpp
@@ -382,7 +382,7 @@ signed short DNG14_handler(void)
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					host_readbs(hero + HERO_TYPE) == 9 &&
-					host_readbs(hero + HERO_WAND) > 2)
+					host_readbs(hero + HERO_STAFFSPELL_LVL) > 2)
 				{
 					/* mage with staffspell-level > 2 => can transform staff to rope */
 					l_di++;

--- a/src/custom/schick/rewrite_m302de/seg095.cpp
+++ b/src/custom/schick/rewrite_m302de/seg095.cpp
@@ -109,8 +109,8 @@ void npc_farewell(void)
 	if (check_hero(get_hero(6)) == 0 && ds_readws(NPC_MONTHS) < 99)
 		return;
 
-	tmp = ds_readw(BUF1_FILE_INDEX);
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	tmp = ds_readw(TX_FILE_INDEX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	switch (host_readbs(get_hero(6) + HERO_NPC_ID)) {
 		/* Nariell */
@@ -178,7 +178,7 @@ void npc_farewell(void)
 	}
 
 	if (tmp != -1 && tmp != 0xe1)
-		load_buffer_1(tmp);
+		load_tx(tmp);
 }
 
 //static
@@ -187,7 +187,7 @@ void npc_nariell(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x14);
@@ -229,7 +229,7 @@ void npc_harika(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x16);
@@ -298,7 +298,7 @@ void npc_curian(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x19);
@@ -339,7 +339,7 @@ void npc_ardora(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x15);
@@ -408,7 +408,7 @@ void npc_garsvik(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x17);
@@ -449,7 +449,7 @@ void npc_erwo(void)
 	signed short answer;
 
 	/* load NSC.LTX */
-	load_buffer_1(ARCHIVE_FILE_NSC_LTX);
+	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	/* load head */
 	load_in_head(0x18);

--- a/src/custom/schick/rewrite_m302de/seg096.cpp
+++ b/src/custom/schick/rewrite_m302de/seg096.cpp
@@ -61,7 +61,7 @@ RealPt GUI_names_grammar(signed short flag, signed short index, signed short typ
 
 		flag += lp5.a[ds_readbs(0x02ac + index)];
 
-		lp1 = (signed short*)(p_datseg + 0x270);
+		lp1 = (signed short*)(p_datseg + 0x0270);
 
 		while (((l4 = host_readws((Bit8u*)(lp1++))) != -1) && (l4 != index));
 
@@ -159,7 +159,7 @@ RealPt GUI_2f2(signed short v1, signed short v2, signed short v3)
 {
 	signed short l;
 
-	l = (v3 == 0) ? ds_readbs(0x2ac + v2) : ds_readbs(v2 + 0x925);
+	l = (v3 == 0) ? ds_readbs(0x02ac + v2) : ds_readbs(v2 + 0x0925);
 
 	return (RealPt)ds_readd(0xaa14 + 4 * ds_readbs(0xaa30 + v1 * 3 + l));
 }

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -923,9 +923,9 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 				host_writeb(Real2Host(ds_readd(DTP2)), 0);
 
-				l4 = ds_readws(BUF1_FILE_INDEX);
+				l4 = ds_readws(TX_FILE_INDEX);
 
-				load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+				load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 #if !defined(__BORLANDC__)
 				func = spellhandler[l_di];
 #else
@@ -934,7 +934,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 				func();
 
 				if ((l4 != -1) && (l4 != 222)) {
-					load_buffer_1(l4);
+					load_tx(l4);
 				}
 
 				retval = 1;

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -965,7 +965,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 						if ((host_readbs(Real2Host(hero) + HERO_ENEMY_ID) < 10) &&
 							(host_readbs(Real2Host(hero) + HERO_ENEMY_ID) > 0) &&
-							(ds_readbs(0x2845) == 0))
+							(ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK))
 						{
 							magic_heal_ani(Real2Host(hero));
 						}

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -436,17 +436,17 @@ signed short use_magic(RealPt hero)
 				GUI_output(get_ltx(0x53c));
 			} else {
 
-				if (ds_readbs((0x972 + 5) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) <= host_readws(Real2Host(hero) + HERO_AE)) {
+				if (ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) <= host_readws(Real2Host(hero) + HERO_AE)) {
 					/* check AE */
 
 					retval = 1;
 
 					/* Original-Bug: the second attribute is used twice here */
 					if (test_attrib3(Real2Host(hero),
-						ds_readbs((0x972 + 1) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((0x972 + 2) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((0x972 + 2) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((0x972 + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND))) > 0)
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 0) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 3) + 6 * host_readbs(Real2Host(hero) + HERO_WAND))) > 0)
 					{
 						/* Success */
 
@@ -457,9 +457,9 @@ signed short use_magic(RealPt hero)
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
-						sub_ae_splash(Real2Host(hero), ds_readbs((0x972 + 5) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
+						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
 
-						sub_ptr_ws(Real2Host(hero) + HERO_AE_ORIG,	ds_readbs((0x972 + 6) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
+						sub_ptr_ws(Real2Host(hero) + HERO_AE_ORIG,	ds_readbs((STAFFSPELL_DESCRIPTIONS + 5) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
 
 						/* Staffspell level +1 */
 						inc_ptr_bs(Real2Host(hero) + HERO_WAND);
@@ -474,7 +474,7 @@ signed short use_magic(RealPt hero)
 						GUI_output(get_ltx(0x548));
 
 						/* only half of the AE costs */
-						sub_ae_splash(Real2Host(hero), ds_readbs((0x972 + 5) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) / 2);
+						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) / 2);
 
 						/* let some time pass */
 						timewarp(0x2a30);

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -224,16 +224,16 @@ void FIG_do_spell_damage(signed short le)
 
 
 		/* ensure the spelluser does not attack himself */
-		if (Real2Host(ds_readd(SPELLTARGET)) != get_spelluser()) {
+		if (get_spelltarget() != get_spelluser()) {
 
 			/* do the damage */
-			sub_hero_le(Real2Host(ds_readd(SPELLTARGET)), le);
+			sub_hero_le(get_spelltarget(), le);
 
 			/* add a message (ired star with le) */
 			FIG_add_msg(0x08, le);
 
 			/* set a variable if the hoer died */
-			if (hero_dead(Real2Host(ds_readd(SPELLTARGET)))) {
+			if (hero_dead(get_spelltarget())) {
 				ds_writew(0xe3a6, 1);
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -183,7 +183,7 @@ void magic_heal_ani(Bit8u *hero)
 		ds_writew(0xc015, 31);
 		ds_writew(0xc017, 31);
 		ds_writed(0xc00d, ds_readd(BUFFER1_PTR));
-		ds_writed(0xc019, (Bit32u)(target + 0x2da));
+		ds_writed(0xc019, (Bit32u)(target + HERO_PORTRAIT));
 		do_pic_copy(0);
 
 		/* copy stars over it */
@@ -733,7 +733,7 @@ signed short test_spell(Bit8u *hero, signed short spell_nr, signed char bonus)
 		return 0;
 	}
 	/* check if spell skill >= -5 */
-	if (host_readbs(hero + spell_nr + 0x13d) < -5)
+	if (host_readbs(hero + spell_nr + HERO_SPELLS) < -5)
 		return 0;
 	/* check if hero has enough AE */
 	if (get_spell_cost(spell_nr, 0) > host_readws(hero + HERO_AE))
@@ -761,7 +761,7 @@ signed short test_spell(Bit8u *hero, signed short spell_nr, signed char bonus)
 		D1_INFO("Zauberprobe : %s %+d ", names_spell[spell_nr], bonus);
 #endif
 
-		bonus -= host_readbs(hero + spell_nr + 0x13d);
+		bonus -= host_readbs(hero + spell_nr + HERO_SPELLS);
 
 		retval = test_attrib3(hero, host_readbs(spell_desc+1),
 			host_readbs(spell_desc+2), host_readbs(spell_desc+3), bonus);

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -330,7 +330,7 @@ signed short get_spell_cost(signed short spell, signed short half_cost)
 {
 	signed char ret;
 
-	ret = ds_readbs(0x99d + 4 + spell * 10);
+	ret = ds_readbs(SPELL_DESCRIPTIONS + 4 + spell * 10);
 
 	if (half_cost != 0) {
 		if (ret == -1) {
@@ -512,12 +512,12 @@ signed short can_use_spellclass(Bit8u *hero, signed short spellclass_nr)
 	signed short first_spell;
 
 
-	first_spell = ds_readbs(0xd03 + 2 * spellclass_nr);
-	for (i = 0; ds_readbs(0xd04 + 2 * spellclass_nr) > i; i++) {
+	first_spell = ds_readbs(SPELLS_INDEX + 2 * spellclass_nr);
+	for (i = 0; ds_readbs((SPELLS_INDEX + 1) + 2 * spellclass_nr) > i; i++) {
 
 		if ((host_readbs(hero + HERO_SPELLS + first_spell + i) >= -5) &&
-			(((ds_readw(IN_FIGHT) != 0) && (ds_readbs((0x99d + 5) + 10 * (first_spell + i)) == 1)) ||
-			((ds_readw(IN_FIGHT) == 0) && (ds_readbs((0x99d + 5) + 10 * (first_spell + i)) != 1))))
+			(((ds_readw(IN_FIGHT) != 0) && (ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * (first_spell + i)) == 1)) ||
+			((ds_readw(IN_FIGHT) == 0) && (ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * (first_spell + i)) != 1))))
 		{
 			return 1;
 		}
@@ -621,9 +621,9 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 			retval = -2;
 		} else {
 
-			first_spell = ds_readbs(0xd03 + 2 * answer1);
+			first_spell = ds_readbs(SPELLS_INDEX + 2 * answer1);
 
-			for (l_di = 0; l_di < ds_readbs(0xd04 + 2 * answer1); l_di++) {
+			for (l_di = 0; l_di < ds_readbs((SPELLS_INDEX + 1) + 2 * answer1); l_di++) {
 
 				ds_writed(RADIO_NAME_LIST + 4 * l_di,
 					(Bit32u)((RealPt)ds_readd(DTP2) + 50 * (l_di)));
@@ -636,8 +636,8 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 						(char*)get_ltx(4 * (first_spell + l_di + 106)),
 						host_readbs(hero + HERO_SPELLS + first_spell + l_di));
 				} else if (
-					(((ds_readw(IN_FIGHT) != 0) && (ds_readbs((0x99d + 5) + 10 * (first_spell + l_di)) == 1)) ||
-					((ds_readw(IN_FIGHT) == 0) && (ds_readbs((0x99d + 5) + 10 * (first_spell + l_di)) != 1))) &&
+					(((ds_readw(IN_FIGHT) != 0) && (ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * (first_spell + l_di)) == 1)) ||
+					((ds_readw(IN_FIGHT) == 0) && (ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * (first_spell + l_di)) != 1))) &&
 					(host_readbs(hero + HERO_SPELLS + first_spell + l_di) >= -5))
 				{
 
@@ -663,7 +663,7 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 				}
 			}
 
-			retval = GUI_radio(get_ltx(0x364), ds_readbs(0xd04 + 2 * answer1),
+			retval = GUI_radio(get_ltx(0x364), ds_readbs((SPELLS_INDEX + 1) + 2 * answer1),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x00))),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x04))),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x08))),
@@ -699,14 +699,14 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 
 		if (retval > 0) {
 			if ((ds_readw(IN_FIGHT) == 0) &&
-				(ds_readbs((0x99d + 5) + 10 * retval) == 1) &&
+				(ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * retval) == 1) &&
 				(show_vals == 0))
 			{
 				GUI_output(get_ltx(0x93c));
 				retval = -2;
 			} else {
 				if ((ds_readw(IN_FIGHT) != 0) &&
-					(ds_readbs((0x99d + 5) + 10 * retval) == -1))
+					(ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * retval) == -1))
 				{
 					GUI_output(get_ltx(0x940));
 					retval = -2;
@@ -739,7 +739,7 @@ signed short test_spell(Bit8u *hero, signed short spell_nr, signed char bonus)
 	if (get_spell_cost(spell_nr, 0) > host_readws(hero + HERO_AE))
 		return -99;
 
-	spell_desc = p_datseg + spell_nr * 10 + 0x99d;
+	spell_desc = p_datseg + spell_nr * 10 + SPELL_DESCRIPTIONS;
 
 	if (host_readb(spell_desc + 0x9) != 0) {
 
@@ -846,7 +846,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 		if (l_di > 0) {
 			/* pointer to the spell description */
-			ptr = p_datseg + 0x99d + 10 * l_di;
+			ptr = p_datseg + SPELL_DESCRIPTIONS + 10 * l_di;
 			/* reset the spelltarget of the hero */
 			host_writeb(Real2Host(hero) + HERO_ENEMY_ID, 0);
 
@@ -874,7 +874,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 	if (l_di > 0) {
 
 		/* pointer to the spell description */
-		ptr = p_datseg + 0x99d + 10 * l_di;
+		ptr = p_datseg + SPELL_DESCRIPTIONS + 10 * l_di;
 
 		if ((ds_readws(IN_FIGHT) == 0) && (host_readbs(ptr + 5) == 1)) {
 			GUI_output(get_ltx(0x93c));
@@ -929,7 +929,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 #if !defined(__BORLANDC__)
 				func = spellhandler[l_di];
 #else
-				func = (void (*)(void))ds_readd(0xdbb + 4 * l_di);
+				func = (void (*)(void))ds_readd(SPELL_HANDLERS + 4 * l_di);
 #endif
 				func();
 

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -432,40 +432,40 @@ signed short use_magic(RealPt hero)
 				return 0;
 			}
 
-			if (host_readbs(Real2Host(hero) + HERO_WAND) == 7) {
+			if (host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL) == 7) {
 				GUI_output(get_ltx(0x53c));
 			} else {
 
-				if (ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) <= host_readws(Real2Host(hero) + HERO_AE)) {
+				if (ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)) <= host_readws(Real2Host(hero) + HERO_AE)) {
 					/* check AE */
 
 					retval = 1;
 
 					/* Original-Bug: the second attribute is used twice here */
 					if (test_attrib3(Real2Host(hero),
-						ds_readbs((STAFFSPELL_DESCRIPTIONS + 0) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)),
-						ds_readbs((STAFFSPELL_DESCRIPTIONS + 3) + 6 * host_readbs(Real2Host(hero) + HERO_WAND))) > 0)
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 0) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 1) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)),
+						ds_readbs((STAFFSPELL_DESCRIPTIONS + 3) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL))) > 0)
 					{
 						/* Success */
 
 						/* print a message */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
 							(char*)get_ltx(0x54c),
-							host_readbs(Real2Host(hero) + HERO_WAND) + 1);
+							host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL) + 1);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
-						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
+						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)));
 
-						sub_ptr_ws(Real2Host(hero) + HERO_AE_ORIG,	ds_readbs((STAFFSPELL_DESCRIPTIONS + 5) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)));
+						sub_ptr_ws(Real2Host(hero) + HERO_AE_ORIG,	ds_readbs((STAFFSPELL_DESCRIPTIONS + 5) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)));
 
 						/* Staffspell level +1 */
-						inc_ptr_bs(Real2Host(hero) + HERO_WAND);
+						inc_ptr_bs(Real2Host(hero) + HERO_STAFFSPELL_LVL);
 
 						/* set the timer */
-						host_writed(Real2Host(hero) + HERO_MAGIC_TIMER, 0xfd20);
+						host_writed(Real2Host(hero) + HERO_STAFFSPELL_TIMER, 0xfd20);
 
 						/* let some time pass */
 						timewarp(0x6978);
@@ -474,7 +474,7 @@ signed short use_magic(RealPt hero)
 						GUI_output(get_ltx(0x548));
 
 						/* only half of the AE costs */
-						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_WAND)) / 2);
+						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)) / 2);
 
 						/* let some time pass */
 						timewarp(0x2a30);

--- a/src/custom/schick/rewrite_m302de/seg099.cpp
+++ b/src/custom/schick/rewrite_m302de/seg099.cpp
@@ -37,10 +37,10 @@ void spell_beherrschung(void)
 	ds_writed(SPELLTARGET,
 		(Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser() + HERO_ENEMY_ID) - 1) * SIZEOF_HERO));
 
-	if (!hero_cursed(Real2Host(ds_readd(SPELLTARGET)))) {
+	if (!hero_cursed(get_spelltarget())) {
 		ds_writew(0xac0e, -2);
 	} else {
-		if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+		if (get_spelltarget() == get_spelluser()) {
 			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_dtp(0));
 			ds_writew(0xac0e, 0);
 		} else {
@@ -49,10 +49,10 @@ void spell_beherrschung(void)
 			if (host_readws(get_spelluser() + HERO_AE) < ds_readws(0xac0e)) {
 				ds_writew(0xac0e, -2);
 			} else {
-				and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0xdf);
+				and_ptr_bs(get_spelltarget() + HERO_STATUS1, 0xdf);
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_dtp(0x4),
-					(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+					(char*)get_spelltarget() + HERO_NAME2);
 			}
 		}
 	}
@@ -151,7 +151,7 @@ void spell_verwandlung(void)
 	ds_writed(SPELLTARGET,
 		(Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser() + HERO_ENEMY_ID) - 1) * SIZEOF_HERO));
 
-	if (hero_stoned(Real2Host(ds_readd(SPELLTARGET)))) {
+	if (hero_stoned(get_spelltarget())) {
 
 		/* set AEcosts */
 		ds_writew(0xac0e, random_schick(10) * 5);
@@ -163,22 +163,22 @@ void spell_verwandlung(void)
 		} else {
 			/* YES: spell has effect */
 			/* unset stoned bit */
-			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0xfb);
+			and_ptr_bs(get_spelltarget() + HERO_STATUS1, 0xfb);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x10),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+				(char*)get_spelltarget() + HERO_NAME2);
 		}
 	} else {
-		if (hero_transformed(Real2Host(ds_readd(SPELLTARGET)))) {
+		if (hero_transformed(get_spelltarget())) {
 
-			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS2, 0xbf);
+			and_ptr_bs(get_spelltarget() + HERO_STATUS2, 0xbf);
 
 			/* increase attributes */
 			for (i = 0; i <= 6; i++)
-				inc_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU + i * 3);
+				inc_ptr_bs(get_spelltarget() + HERO_MU + i * 3);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_ltx(0x8d4),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+				(char*)get_spelltarget() + HERO_NAME2);
 		} else {
 
 #ifdef M302de_ORIGINAL_BUGFIX
@@ -188,7 +188,7 @@ void spell_verwandlung(void)
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x14),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+				(char*)get_spelltarget() + HERO_NAME2);
 			ds_writew(0xac0e, 0);
 		}
 	}
@@ -222,7 +222,7 @@ void spell_band(void)
 		ds_writed(SPELLTARGET,
 			(Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser() + HERO_ENEMY_ID) - 1) * SIZEOF_HERO));
 
-		if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+		if (get_spelltarget() == get_spelluser()) {
 			/* don't cast yourself */
 
 			/* set AE costs */
@@ -233,12 +233,12 @@ void spell_band(void)
 				(char*)get_dtp(0x1c0));
 		} else {
 			/* set status bit */
-			or_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0x80);
+			or_ptr_bs(get_spelltarget() + HERO_STATUS1, 0x80);
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_dtp(0x18),
-					(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+					(char*)get_spelltarget() + HERO_NAME2);
 		}
 	}
 }
@@ -438,7 +438,7 @@ void spell_somnigravis(void)
 	ds_writed(SPELLTARGET,
 		(Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser() + HERO_ENEMY_ID) - 1) * SIZEOF_HERO));
 
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 		/* don't cast yourself */
 
 		/* set AE costs */

--- a/src/custom/schick/rewrite_m302de/seg099.cpp
+++ b/src/custom/schick/rewrite_m302de/seg099.cpp
@@ -49,10 +49,10 @@ void spell_beherrschung(void)
 			if (host_readws(get_spelluser() + HERO_AE) < ds_readws(0xac0e)) {
 				ds_writew(0xac0e, -2);
 			} else {
-				and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + 0xaa, 0xdf);
+				and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0xdf);
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_dtp(0x4),
-					(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+					(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 			}
 		}
 	}
@@ -163,22 +163,22 @@ void spell_verwandlung(void)
 		} else {
 			/* YES: spell has effect */
 			/* unset stoned bit */
-			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + 0xaa, 0xfb);
+			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0xfb);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x10),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 		}
 	} else {
 		if (hero_transformed(Real2Host(ds_readd(SPELLTARGET)))) {
 
-			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + 0xab, 0xbf);
+			and_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS2, 0xbf);
 
 			/* increase attributes */
 			for (i = 0; i <= 6; i++)
-				inc_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + 0x35 + i * 3);
+				inc_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU + i * 3);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_ltx(0x8d4),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 		} else {
 
 #ifdef M302de_ORIGINAL_BUGFIX
@@ -188,7 +188,7 @@ void spell_verwandlung(void)
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x14),
-				(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+				(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 			ds_writew(0xac0e, 0);
 		}
 	}
@@ -233,12 +233,12 @@ void spell_band(void)
 				(char*)get_dtp(0x1c0));
 		} else {
 			/* set status bit */
-			or_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + 0xaa, 0x80);
+			or_ptr_bs(Real2Host(ds_readd(SPELLTARGET)) + HERO_STATUS1, 0x80);
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_dtp(0x18),
-					(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+					(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 		}
 	}
 }
@@ -966,7 +966,7 @@ RealPt spell_analues(void)
 	}
 
 	item_pos = select_item_to_drop(get_spelluser());
-	item_id = host_readws(get_spelluser() + 14 * item_pos + 0x196);
+	item_id = host_readws(get_spelluser() + 14 * item_pos + HERO_ITEM_HEAD);
 
 	strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_dtp(0xd0));
 
@@ -984,7 +984,7 @@ RealPt spell_analues(void)
 						(char*)get_dtp(ds_readbs((ANALUES_ITEMS + 4) + i * 5) * 4));
 
 					/* set the magic flag */
-					or_ptr_bs(get_spelluser() + item_pos * 14 + 0x19a, 0x80);
+					or_ptr_bs(get_spelluser() + item_pos * 14 + (HERO_ITEM_HEAD + 4), 0x80);
 					break;
 				} else {
 					/* nothing found string */

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -601,8 +601,8 @@ void spell_ignifaxius(void)
 		if ((host_readws(p_armour) != 0) && (rs_malus != 0)) {
 
 			/* adjust rs_malus */
-			if ((host_readbs(p_armour + 7) + rs_malus) > ds_readbs(0x877 + host_readbs(get_itemsdat(host_readws(p_armour)) + 4) * 2)) {
-				rs_malus = ds_readbs(0x877 + host_readbs(get_itemsdat(host_readws(p_armour)) + 4) * 2) - host_readbs(p_armour + 7);
+			if ((host_readbs(p_armour + 7) + rs_malus) > ds_readbs(0x0877 + host_readbs(get_itemsdat(host_readws(p_armour)) + 4) * 2)) {
+				rs_malus = ds_readbs(0x0877 + host_readbs(get_itemsdat(host_readws(p_armour)) + 4) * 2) - host_readbs(p_armour + 7);
 			}
 
 			/* add rs_malus to the armour */

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -778,7 +778,7 @@ void spell_scharfes_auge(void)
 	ds_writed(SPELLTARGET,
 		(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * target));
 
-	/* all range talents are boosted + 3 */
+	/* all range skills are boosted + 3 */
 
 	slot = get_free_mod_slot();
 

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -153,18 +153,18 @@ void spell_odem_arcanum(void)
 
 	pos = select_item_to_drop(get_spelluser());
 
-	id = host_readws(get_spelluser() + pos * 14 + 0x196);
+	id = host_readws(get_spelluser() + pos * 14 + HERO_ITEM_HEAD);
 
 	if (id) {
 
-		if (ks_magic_hidden(get_spelluser() + pos * 14 + 0x196)) {
+		if (ks_magic_hidden(get_spelluser() + pos * 14 + HERO_ITEM_HEAD)) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x144),
 				(char*)Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)));
 
 			/* set known flag */
-			or_ptr_bs(get_spelluser() + pos * 14 + 0x19a, 0x80);
+			or_ptr_bs(get_spelluser() + pos * 14 + (HERO_ITEM_HEAD + 4), 0x80);
 
 		} else {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
@@ -424,23 +424,23 @@ void spell_eisenrost(void)
 				(char*)get_dtp(0x1c0));
 		} else {
 			/* get weapon id of the target */
-			id = host_readws(get_spelltarget() + 0x1c0);
+			id = host_readws(get_spelltarget() + HERO_ITEM_RIGHT);
 
 			if (!id) {
 				/* no weapon in hand */
 				ds_writew(0xac0e, -2);
 			} else {
 				/* check if weapon is already broken */
-				if (ks_broken(get_spelltarget() + 0x1c0)) {
+				if (ks_broken(get_spelltarget() + HERO_ITEM_RIGHT)) {
 
 					strcpy((char*)Real2Host(ds_readd(DTP2)),
 						(char*)get_dtp(0x168));
 
 				} else {
 
-					if (host_readbs(get_spelltarget() + 0x1c6) > 0) {
+					if (host_readbs(get_spelltarget() + (HERO_ITEM_RIGHT + 6)) > 0) {
 						/* set broken flag */
-						or_ptr_bs(get_spelltarget() + 0x1c4, 0x01);
+						or_ptr_bs(get_spelltarget() + (HERO_ITEM_RIGHT + 4), 0x01);
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
 							(char*)get_dtp(0x170),
 							(char*)Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)),
@@ -596,7 +596,7 @@ void spell_ignifaxius(void)
 	                (Bit32u)((RealPt)ds_readd(HEROS) + hero_pos * SIZEOF_HERO));
 
 		/* get a pointer to the armour */
-		p_armour = get_spelltarget() + 0x1b2;
+		p_armour = get_spelltarget() + HERO_ITEM_BODY;
 
 		if ((host_readws(p_armour) != 0) && (rs_malus != 0)) {
 
@@ -782,15 +782,15 @@ void spell_scharfes_auge(void)
 
 	slot = get_free_mod_slot();
 
-	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + 0x110, 3, (signed char)target);
+	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + (HERO_TA_FIGHT + 8), 3, (signed char)target);
 
 	slot = get_free_mod_slot();
 
-	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + 0x10f, 3, (signed char)target);
+	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + (HERO_TA_FIGHT + 7), 3, (signed char)target);
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
 		(char*)get_dtp(97 * 4),
-		(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10);
+		(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 
 }
 

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -782,15 +782,15 @@ void spell_scharfes_auge(void)
 
 	slot = get_free_mod_slot();
 
-	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + (HERO_TA_FIGHT + 8), 3, (signed char)target);
+	set_mod_slot(slot, 3 * 9L, get_spelltarget() + (HERO_TA_FIGHT + 8), 3, (signed char)target);
 
 	slot = get_free_mod_slot();
 
-	set_mod_slot(slot, 3 * 9L, Real2Host(ds_readd(SPELLTARGET)) + (HERO_TA_FIGHT + 7), 3, (signed char)target);
+	set_mod_slot(slot, 3 * 9L, get_spelltarget() + (HERO_TA_FIGHT + 7), 3, (signed char)target);
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
 		(char*)get_dtp(97 * 4),
-		(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
+		(char*)get_spelltarget() + HERO_NAME2);
 
 }
 

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -247,7 +247,7 @@ void spell_hexenknoten(void)
 		return;
 	}
 
-	ptr = Real2Host(FIG_get_ptr(host_readbs(get_spelluser() + HERO_FIGHT_ID)));
+	ptr = Real2Host(FIG_get_ptr(host_readbs(get_spelluser() + HERO_FIGHTER_ID)));
 	x = host_readbs(ptr + 3);
 	y = host_readbs(ptr + 4);
 

--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -50,7 +50,7 @@ void spell_arcano(void)
 	slot = get_free_mod_slot();
 
 	/* MR + 2 for 1 h */
-	set_mod_slot(slot, HOURS(1), Real2Host(ds_readd(SPELLTARGET)) + 0x66, 2,
+	set_mod_slot(slot, HOURS(1), Real2Host(ds_readd(SPELLTARGET)) + HERO_MR, 2,
 			(signed char)target);
 
 	/* "Die Magieresistenz von %s steigt um 2 Punkte." */
@@ -133,23 +133,23 @@ void spell_inc_ch(void)
 	}
 
 	/* check if CH was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x3b) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x3a)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_CH) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_CH_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(414 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* CH + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x3b, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_CH, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(414 * 4));
 	}
 }
@@ -205,11 +205,11 @@ void spell_inc_ff(void)
 	}
 
 	/* check if FF was already increased */
-	if (host_readbs(get_spelltarget() + 0x3e) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x3d)) {
+	if (host_readbs(get_spelltarget() + 0x3e) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_FF_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(415 * 4));
 	} else {
 		/* get a free mod_slot */
@@ -221,7 +221,7 @@ void spell_inc_ff(void)
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(415 * 4));
 	}
 }
@@ -251,23 +251,23 @@ void spell_inc_ge(void)
 	}
 
 	/* check if GE was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x41) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x40)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_GE) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_GE_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(416 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* GE + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x41, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_GE, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(416 * 4));
 	}
 }
@@ -297,23 +297,23 @@ void spell_inc_in(void)
 	}
 
 	/* check if IN was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x44) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x43)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_IN) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_IN_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(417 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* IN + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x44, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_IN, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(417 * 4));
 	}
 }
@@ -343,23 +343,23 @@ void spell_inc_kk(void)
 	}
 
 	/* check if KK was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x47) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x46)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KK) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KK_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(418 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* IN + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x47, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_KK, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(418 * 4));
 	}
 }
@@ -389,23 +389,23 @@ void spell_inc_kl(void)
 	}
 
 	/* check if KL was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x38) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x37)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KL) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KL_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(413 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* KL + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x38, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_KL, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(413 * 4));
 	}
 }
@@ -435,23 +435,23 @@ void spell_inc_mu(void)
 	}
 
 	/* check if MU was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x35) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + 0x34)) {
+	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(412 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* MU + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + 0x35, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_MU, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + 0x10,
+			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
 			(char*)get_ltx(412 * 4));
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -50,7 +50,7 @@ void spell_arcano(void)
 	slot = get_free_mod_slot();
 
 	/* MR + 2 for 1 h */
-	set_mod_slot(slot, HOURS(1), Real2Host(ds_readd(SPELLTARGET)) + HERO_MR, 2,
+	set_mod_slot(slot, HOURS(1), get_spelltarget() + HERO_MR, 2,
 			(signed char)target);
 
 	/* "Die Magieresistenz von %s steigt um 2 Punkte." */
@@ -120,7 +120,7 @@ void spell_inc_ch(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -133,23 +133,23 @@ void spell_inc_ch(void)
 	}
 
 	/* check if CH was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_CH) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_CH_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_CH) > host_readbs(get_spelltarget() + HERO_CH_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(414 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* CH + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_CH, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_CH, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(414 * 4));
 	}
 }
@@ -192,7 +192,7 @@ void spell_inc_ff(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -205,11 +205,11 @@ void spell_inc_ff(void)
 	}
 
 	/* check if FF was already increased */
-	if (host_readbs(get_spelltarget() + 0x3e) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_FF_ORIG)) {
+	if (host_readbs(get_spelltarget() + 0x3e) > host_readbs(get_spelltarget() + HERO_FF_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(415 * 4));
 	} else {
 		/* get a free mod_slot */
@@ -221,7 +221,7 @@ void spell_inc_ff(void)
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(415 * 4));
 	}
 }
@@ -238,7 +238,7 @@ void spell_inc_ge(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -251,23 +251,23 @@ void spell_inc_ge(void)
 	}
 
 	/* check if GE was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_GE) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_GE_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_GE) > host_readbs(get_spelltarget() + HERO_GE_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(416 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* GE + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_GE, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_GE, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(416 * 4));
 	}
 }
@@ -284,7 +284,7 @@ void spell_inc_in(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -297,23 +297,23 @@ void spell_inc_in(void)
 	}
 
 	/* check if IN was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_IN) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_IN_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_IN) > host_readbs(get_spelltarget() + HERO_IN_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(417 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* IN + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_IN, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_IN, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(417 * 4));
 	}
 }
@@ -330,7 +330,7 @@ void spell_inc_kk(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -343,23 +343,23 @@ void spell_inc_kk(void)
 	}
 
 	/* check if KK was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KK) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KK_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_KK) > host_readbs(get_spelltarget() + HERO_KK_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(418 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* IN + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_KK, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_KK, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(418 * 4));
 	}
 }
@@ -376,7 +376,7 @@ void spell_inc_kl(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -389,23 +389,23 @@ void spell_inc_kl(void)
 	}
 
 	/* check if KL was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KL) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_KL_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_KL) > host_readbs(get_spelltarget() + HERO_KL_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(413 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* KL + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_KL, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_KL, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(413 * 4));
 	}
 }
@@ -422,7 +422,7 @@ void spell_inc_mu(void)
 	ds_writed(SPELLTARGET, (Bit32u)((RealPt)ds_readd(HEROS) + target * SIZEOF_HERO));
 
 	/* check if the target is the spelluser */
-	if (Real2Host(ds_readd(SPELLTARGET)) == get_spelluser()) {
+	if (get_spelltarget() == get_spelluser()) {
 
 		/* set AP costs to 0 */
 		ds_writew(0xac0e, 0);
@@ -435,23 +435,23 @@ void spell_inc_mu(void)
 	}
 
 	/* check if MU was already increased */
-	if (host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU) > host_readbs(Real2Host(ds_readd(SPELLTARGET)) + HERO_MU_ORIG)) {
+	if (host_readbs(get_spelltarget() + HERO_MU) > host_readbs(get_spelltarget() + HERO_MU_ORIG)) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(113 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(412 * 4));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
 
 		/* MU + 2 for 2 hours */
-		set_mod_slot(slot, HOURS(2), Real2Host(ds_readd(SPELLTARGET)) + HERO_MU, 2, (signed char)target);
+		set_mod_slot(slot, HOURS(2), get_spelltarget() + HERO_MU, 2, (signed char)target);
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_dtp(101 * 4),
-			(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2,
+			(char*)get_spelltarget() + HERO_NAME2,
 			(char*)get_ltx(412 * 4));
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -156,7 +156,7 @@ signed short MON_get_spell_cost(signed short mspell_nr, signed short flag)
 
 
 /**
- * MON_test_skill() -	talent test for monsters
+ * MON_test_skill() -	skill test for monsters
  * @monster:		pointer to monster
  * @t1:			nr of 1st attribute
  * @t2:			nr of 2nd attribute

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -222,14 +222,14 @@ signed short MON_cast_spell(RealPt monster, signed char bonus)
 	void (*func)(void);
 	volatile signed short bak;
 
-	l_si = host_readbs(Real2Host(monster) + 0x2c);
+	l_si = host_readbs(Real2Host(monster) + ENEMY_SHEET_CUR_SPELL);
 
 	if (l_si > 0) {
 
 		cost = MON_get_spell_cost(l_si, 0);
 
 		/* check AE */
-		if (host_readws(Real2Host(monster) + 0x17) < cost) {
+		if (host_readws(Real2Host(monster) + ENEMY_SHEET_AE) < cost) {
 			return -1;
 		}
 

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -50,12 +50,12 @@ void MON_do_damage(signed short damage)
 {
 	if (damage > 0) {
 
-		if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+		if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 			/* target is a hero */
 
 			/* set the pointer to the target */
 			ds_writed(SPELLTARGET,
-				(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+				(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 			/* do the damage */
 			sub_hero_le(get_spelltarget(), damage);
@@ -73,7 +73,7 @@ void MON_do_damage(signed short damage)
 
 			/* set the pointer to the target */
 			ds_writed(SPELLTARGET_E,
-				(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+				(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 			/* do the damage */
 			FIG_damage_enemy(get_spelltarget_e(), damage, 1);
@@ -92,12 +92,12 @@ void MON_do_damage(signed short damage)
 /* unused */
 signed short MON_get_target_PA(void)
 {
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
-			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 		/* calc and return PA-value */
 		return host_readbs(get_spelltarget() + 0x6f + host_readbs(get_spelltarget() + 0x78))
@@ -108,7 +108,7 @@ signed short MON_get_target_PA(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* calc and return PA-value */
 		return host_readbs(get_spelltarget_e() + 0x1d);
@@ -118,12 +118,12 @@ signed short MON_get_target_PA(void)
 /* unused */
 signed short MON_get_target_RS(void)
 {
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
-			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 		/* return RS-value */
 		return host_readbs(get_spelltarget() + 0x30);
@@ -133,7 +133,7 @@ signed short MON_get_target_RS(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* return PA-value */
 		return host_readbs(get_spelltarget_e() + 0x02);
@@ -188,9 +188,9 @@ signed short MON_test_skill(Bit8u *monster, signed short mspell_nr, signed char 
 	if (host_readbs(desc + 6) != 0) {
 
 		/* add MR */
-		bonus += (host_readbs(monster + ENEMY_SHEET_FIGHT_ID) >= 10) ?
-			ds_readbs((0xd0df + 25) + SIZEOF_ENEMY_SHEET * host_readbs(monster + ENEMY_SHEET_FIGHT_ID)) :
-			host_readbs(get_hero(host_readbs(monster + ENEMY_SHEET_FIGHT_ID) - 1) + 0x66);
+		bonus += (host_readbs(monster + ENEMY_SHEET_FIGHTER_ID) >= 10) ?
+			ds_readbs((0xd0df + 25) + SIZEOF_ENEMY_SHEET * host_readbs(monster + ENEMY_SHEET_FIGHTER_ID)) :
+			host_readbs(get_hero(host_readbs(monster + ENEMY_SHEET_FIGHTER_ID) - 1) + 0x66);
 	}
 
 	/* check if the monster spell has a valid ID */
@@ -292,7 +292,7 @@ void mspell_verwandlung(void)
 {
 	/* set pointer to monster target */
 	ds_writed(SPELLTARGET_E,
-		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
+		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
 
 	if (enemy_stoned(get_spelltarget_e())) {
 
@@ -334,7 +334,7 @@ void mspell_bannbaladin(void)
 {
 	/* set pointer to hero target */
 	ds_writed(SPELLTARGET,
-                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1) * SIZEOF_HERO));
+                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1) * SIZEOF_HERO));
 
 	/* set the flag */
 	or_ptr_bs(get_spelltarget() + 0xab, 0x08);
@@ -349,7 +349,7 @@ void mspell_boeser_blick(void)
 {
 	/* set pointer to hero target */
 	ds_writed(SPELLTARGET,
-                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1) * SIZEOF_HERO));
+                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1) * SIZEOF_HERO));
 
 	/* set the flag */
 	or_ptr_bs(get_spelltarget() + 0xaa, 0x20);
@@ -364,7 +364,7 @@ void mspell_horriphobus(void)
 {
 	/* set pointer to hero target */
 	ds_writed(SPELLTARGET,
-                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1) * SIZEOF_HERO));
+                        (Bit32u)((RealPt)ds_readd(HEROS) + (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1) * SIZEOF_HERO));
 
 	/* set the flag */
 	or_ptr_bs(get_spelltarget() + 0xab, 0x01);
@@ -380,7 +380,7 @@ void mspell_axxeleratus(void)
 {
 	/* set pointer to monster target */
 	ds_writed(SPELLTARGET_E,
-		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
+		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
 
 	/* #Attacks + 1 */
 	inc_ptr_bs(get_spelltarget_e() + 0x1b);
@@ -403,7 +403,7 @@ void mspell_balsam(void)
 
 	/* set pointer to monster target */
 	ds_writed(SPELLTARGET_E,
-		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
+		(Bit32u)RealMake(datseg, host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET + 0xd0df));
 
 	ds_writew(MONSTER_SPELL_COST, 0);
 
@@ -429,12 +429,12 @@ void mspell_balsam(void)
 
 void mspell_blitz(void)
 {
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
-			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 		/* set blitz timer to 3 rounds */
 		host_writeb(get_spelltarget() + 0x96, 3);
@@ -448,7 +448,7 @@ void mspell_blitz(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* set blitz timer to 3 rounds */
 		host_writeb(get_spelltarget_e() + 0x2f, 3);
@@ -464,12 +464,12 @@ void mspell_eisenrost(void)
 {
 	signed short id;
 
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
-			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 		id = host_readws(get_spelltarget() + HERO_ITEM_RIGHT);
 
@@ -498,7 +498,7 @@ void mspell_eisenrost(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* if weapon is not broken */
 		if (!host_readbs(get_spelltarget_e() + 0x30)) {
@@ -562,11 +562,11 @@ void mspell_ignifaxius(void)
 	/* calc RS malus */
 	rs_malus = damage / 10;
 
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* get the position of the target hero */
-		hero_pos = host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1;
+		hero_pos = host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1;
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
@@ -601,7 +601,7 @@ void mspell_ignifaxius(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* subtract RS malus */
 		host_writeb(get_spelltarget_e() + 0x02,
@@ -626,11 +626,11 @@ void mspell_plumbumbarum(void)
 	signed short slot;
 	signed short hero_pos;
 
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) < 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) < 10) {
 		/* target is a hero */
 
 		/* get the position of the target hero */
-		hero_pos = host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1;
+		hero_pos = host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1;
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
@@ -649,7 +649,7 @@ void mspell_plumbumbarum(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* AT - 3 */
 		host_writeb(get_spelltarget_e() + 0x1c,
@@ -667,7 +667,7 @@ void mspell_saft_kraft(void)
 
 	/* set the pointer to the target */
 	ds_writed(SPELLTARGET_E,
-		(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+		(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 	/* AT + 5 */
 	host_writeb(get_spelltarget_e() + 0x1c,
@@ -708,12 +708,12 @@ void mspell_armatrutz(void)
 void mspell_paral(void)
 {
 
-	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) >= 10) {
+	if (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) >= 10) {
 		/* target is a monster */
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET_E,
-			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) * SIZEOF_ENEMY_SHEET));
+			(Bit32u)RealMake(datseg, 0xd0df + host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) * SIZEOF_ENEMY_SHEET));
 
 		/* set the flag */
 		or_ptr_bs(get_spelltarget_e() + 0x31, 0x04);
@@ -727,7 +727,7 @@ void mspell_paral(void)
 
 		/* set the pointer to the target */
 		ds_writed(SPELLTARGET,
-			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
+			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHTER_ID) - 1)));
 
 		/* set the flag */
 		or_ptr_bs(get_spelltarget() + 0xaa, 0x04);

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -578,9 +578,9 @@ void mspell_ignifaxius(void)
 		if ((host_readws(p_armour) != 0) && (rs_malus != 0)) {
 
 			/* adjust rs_malus */
-			if ((host_readbs(p_armour + 7) + rs_malus) > ds_readbs(0x877 + 2 * host_readbs(4 + get_itemsdat(host_readws(p_armour)))))
+			if ((host_readbs(p_armour + 7) + rs_malus) > ds_readbs(0x0877 + 2 * host_readbs(4 + get_itemsdat(host_readws(p_armour)))))
 			{
-				rs_malus = ds_readbs(0x877 + 2 * host_readbs(4 + get_itemsdat(host_readws(p_armour))))
+				rs_malus = ds_readbs(0x0877 + 2 * host_readbs(4 + get_itemsdat(host_readws(p_armour))))
 						- host_readbs(p_armour + 7);
 			}
 

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -144,7 +144,7 @@ signed short MON_get_spell_cost(signed short mspell_nr, signed short flag)
 {
 	signed char cost;
 
-	cost = ds_readbs(0xf13 + 8 * mspell_nr);
+	cost = ds_readbs(MON_SPELL_DESCRIPTIONS + 8 * mspell_nr);
 
 	if (flag != 0) {
 
@@ -182,7 +182,7 @@ signed short MON_test_skill(Bit8u *monster, signed short mspell_nr, signed char 
 {
 	Bit8u *desc;
 
-	desc = p_datseg + 0xf13 + 8 * mspell_nr;
+	desc = p_datseg + MON_SPELL_DESCRIPTIONS + 8 * mspell_nr;
 
 	/* depends on MR */
 	if (host_readbs(desc + 6) != 0) {
@@ -258,7 +258,7 @@ signed short MON_cast_spell(RealPt monster, signed char bonus)
 #if !defined(__BORLANDC__)
 			func = mspell[l_si];
 #else
-			func = (void (*)(void))ds_readd(0x0fc2 + 4 * l_si);
+			func = (void (*)(void))ds_readd(MON_SPELL_HANDLERS + 4 * l_si);
 #endif
 
 			func();

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -471,17 +471,17 @@ void mspell_eisenrost(void)
 		ds_writed(SPELLTARGET,
 			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * (host_readbs(get_spelluser_e() + ENEMY_SHEET_FIGHT_ID) - 1)));
 
-		id = host_readws(get_spelltarget() + 0x1c0);
+		id = host_readws(get_spelltarget() + HERO_ITEM_RIGHT);
 
 		if (!id) {
 			/* target hero has no weapon */
 			ds_writew(MONSTER_SPELL_COST, 2);
-		} else if (!ks_broken(get_spelltarget() + 0x1c0)) {
+		} else if (!ks_broken(get_spelltarget() + HERO_ITEM_RIGHT)) {
 
-			if (host_readbs(get_spelltarget() + 0x1c6) > 0) {
+			if (host_readbs(get_spelltarget() + (HERO_ITEM_RIGHT + 6)) > 0) {
 
 				/* set the broken flag */
-				or_ptr_bs(get_spelltarget() + 0x1c4, 1);
+				or_ptr_bs(get_spelltarget() + (HERO_ITEM_RIGHT + 4), 1);
 
 				/* prepare message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
@@ -573,7 +573,7 @@ void mspell_ignifaxius(void)
 			(Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * hero_pos));
 
 		/* pointer to the armour of the target hero */
-		p_armour = get_spelltarget() + 0x1b2;
+		p_armour = get_spelltarget() + HERO_ITEM_BODY;
 
 		if ((host_readws(p_armour) != 0) && (rs_malus != 0)) {
 

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -251,9 +251,9 @@ signed short MON_cast_spell(RealPt monster, signed char bonus)
 			/* terminate output string */
 			host_writeb(Real2Host(ds_readd(DTP2)), 0);
 
-			bak = ds_readws(BUF1_FILE_INDEX);
+			bak = ds_readws(TX_FILE_INDEX);
 
-			load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+			load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 #if !defined(__BORLANDC__)
 			func = mspell[l_si];
@@ -264,7 +264,7 @@ signed short MON_cast_spell(RealPt monster, signed char bonus)
 			func();
 
 			if ((bak != -1) && (bak != 222)) {
-				load_buffer_1(bak);
+				load_tx(bak);
 			}
 
 			l_di = 1;

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -564,7 +564,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					add_party_money(money);
 
 					ds_writed((INGAME_TIMERS + 0x18), 0xa8c0);
-					ds_writew(0x2846, 1);
+					ds_writew(REQUEST_REFRESH, 1);
 				} else {
 					GUI_output(get_dtp(0x90));
 
@@ -598,7 +598,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					add_party_money(money);
 
 					ds_writed((INGAME_TIMERS + 0x1c), 0xa8c0);
-					ds_writew(0x2846, 1);
+					ds_writew(REQUEST_REFRESH, 1);
 				} else {
 					GUI_output(get_dtp(0x90));
 
@@ -625,7 +625,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 				add_party_money(money);
 
-				ds_writew(0x2846, 1);
+				ds_writew(REQUEST_REFRESH, 1);
 			} else {
 				GUI_output(get_dtp(0x9c));
 
@@ -653,7 +653,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 				add_party_money(money);
 
-				ds_writew(0x2846, 1);
+				ds_writew(REQUEST_REFRESH, 1);
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_dtp(0xa4),
@@ -663,7 +663,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 				set_party_money(0);
 
-				ds_writew(0x2846, 1);
+				ds_writew(REQUEST_REFRESH, 1);
 
 				l_si = -1;
 			}

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -512,7 +512,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 								l_si = 0;
 
-								host_writed(patient + HERO_MAGIC_TIMER, 0x1fa40L);
+								host_writed(patient + HERO_STAFFSPELL_TIMER, 0x1fa40L);
 							}
 						} else {
 

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -186,7 +186,7 @@ signed short test_skill(Bit8u *hero, signed short skill, signed char bonus)
 	if ((skill >= 7) && (skill <= 51)) {
 
 #if !defined(__BORLANDC__)
-		D1_INFO("Skill test %s %+d: ", names_skill[skill], bonus);
+		D1_INFO("Talentprobe %s %+d: ", names_skill[skill], bonus);
 #endif
 
 		/* special test if skill is a range weapon skill */

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -77,7 +77,7 @@ signed short LVL_select_skill(Bit8u *hero, signed short show_values)
 				sprintf((char*)Real2Host(ds_readd(DTP2)) + 50 * i,
 					format_str.a,
 					get_ltx((l1 + i + 48) * 4),
-					host_readbs(hero + l1 + i + 0x108));
+					host_readbs(hero + l1 + i + HERO_TA_FIGHT));
 
 				ds_writed(RADIO_NAME_LIST + 4 * i, (Bit32u)((RealPt)ds_readd(DTP2) + 50 * i));
 			}

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -329,9 +329,9 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 	if (skill != -1) {
 
-		bak = ds_readws(BUF1_FILE_INDEX);
+		bak = ds_readws(TX_FILE_INDEX);
 
-		load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+		load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 		switch(skill) {
 		case 44 : {
@@ -678,7 +678,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 		}
 
 		if ((bak != -1) && (bak != 222)) {
-			load_buffer_1(bak);
+			load_tx(bak);
 		}
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -144,12 +144,12 @@ RealPt get_proper_hero(signed short skill)
 			!hero_dead(Real2Host(hero_i))) {
 
 			/* add current and maximum attibute values */
-			cur =	host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(SKILLS_EXTRA + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(SKILLS_EXTRA + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILLS_EXTRA + 1) + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILLS_EXTRA + 1) + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILLS_EXTRA + 2) + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILLS_EXTRA + 2) + 4 * skill)) +
+			cur =	host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(SKILL_DESCRIPTIONS + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(SKILL_DESCRIPTIONS + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILL_DESCRIPTIONS + 1) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILL_DESCRIPTIONS + 1) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILL_DESCRIPTIONS + 2) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILL_DESCRIPTIONS + 2) + 4 * skill)) +
 				host_readbs(Real2Host(hero_i) + HERO_TA_FIGHT + skill);
 
 			if (cur > max) {
@@ -246,7 +246,7 @@ signed short test_skill(Bit8u *hero, signed short skill, signed char bonus)
 		/* do the test */
 		bonus -= host_readbs(hero + HERO_TA_FIGHT + skill);
 
-		return test_attrib3(hero, ds_readbs(SKILLS_EXTRA + skill * 4), ds_readbs((SKILLS_EXTRA + 1) + skill * 4), ds_readbs((SKILLS_EXTRA + 2) + skill * 4), bonus);
+		return test_attrib3(hero, ds_readbs(SKILL_DESCRIPTIONS + skill * 4), ds_readbs((SKILL_DESCRIPTIONS + 1) + skill * 4), ds_readbs((SKILL_DESCRIPTIONS + 2) + skill * 4), bonus);
 
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -68,11 +68,11 @@ signed short LVL_select_talent(Bit8u *hero, signed short show_values)
 
 	if (answer != -2) {
 
-		l1 = ds_readbs(0x10ce + 2 * answer);
+		l1 = ds_readbs(SKILLS_INDEX + 2 * answer);
 
 		if (show_values != 0) {
 
-			for (i = 0; ds_readbs(0x10cf + 2 * answer) > i; i++) {
+			for (i = 0; ds_readbs((SKILLS_INDEX + 1) + 2 * answer) > i; i++) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)) + 50 * i,
 					format_str.a,
@@ -83,12 +83,12 @@ signed short LVL_select_talent(Bit8u *hero, signed short show_values)
 			}
 		} else {
 
-			for (i = 0; ds_readbs(0x10cf + 2 * answer) > i; i++) {
+			for (i = 0; ds_readbs((SKILLS_INDEX + 1) + 2 * answer) > i; i++) {
 				ds_writed(RADIO_NAME_LIST + 4 * i, (Bit32u)(host_readd(Real2Host(ds_readd(TEXT_LTX)) + (l1 + i + 48) * 4)));
 			}
 		}
 
-		retval = GUI_radio(get_ltx(0x368), ds_readbs(0x10cf + 2 * answer),
+		retval = GUI_radio(get_ltx(0x368), ds_readbs((SKILLS_INDEX + 1) + 2 * answer),
 				Real2Host(ds_readd(RADIO_NAME_LIST)),
 				Real2Host(ds_readd((RADIO_NAME_LIST + 4))),
 				Real2Host(ds_readd((RADIO_NAME_LIST + 2 * 4))),
@@ -144,12 +144,12 @@ RealPt get_proper_hero(signed short skill)
 			!hero_dead(Real2Host(hero_i))) {
 
 			/* add current and maximum attibute values */
-			cur =	host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(0xffe + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(0xffe + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(0xfff + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(0xfff + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(0x1000 + 4 * skill)) +
-				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(0x1000 + 4 * skill)) + +
+			cur =	host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs(SKILLS_EXTRA + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs(SKILLS_EXTRA + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILLS_EXTRA + 1) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILLS_EXTRA + 1) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU + 3 * ds_readbs((SKILLS_EXTRA + 2) + 4 * skill)) +
+				host_readbs(Real2Host(hero_i) + HERO_MU_MOD + 3 * ds_readbs((SKILLS_EXTRA + 2) + 4 * skill)) +
 				host_readbs(Real2Host(hero_i) + HERO_TA_FIGHT + skill);
 
 			if (cur > max) {
@@ -246,7 +246,7 @@ signed short test_skill(Bit8u *hero, signed short skill, signed char bonus)
 		/* do the test */
 		bonus -= host_readbs(hero + HERO_TA_FIGHT + skill);
 
-		return test_attrib3(hero, ds_readbs(0xffe + skill * 4), ds_readbs(0xfff + skill * 4), ds_readbs(0x1000 + skill * 4), bonus);
+		return test_attrib3(hero, ds_readbs(SKILLS_EXTRA + skill * 4), ds_readbs((SKILLS_EXTRA + 1) + skill * 4), ds_readbs((SKILLS_EXTRA + 2) + skill * 4), bonus);
 
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -1,5 +1,5 @@
 /*
- *      Rewrite of DSA1 v3.02_de functions of seg103 (talents)
+ *      Rewrite of DSA1 v3.02_de functions of seg103 (skills)
  *      Functions rewritten: 8/8 (complete)
  *
  *	Borlandified and identical
@@ -29,7 +29,7 @@ struct dummy {
 	char a[6];
 };
 
-signed short LVL_select_talent(Bit8u *hero, signed short show_values)
+signed short LVL_select_skill(Bit8u *hero, signed short show_values)
 {
 	signed short i;
 
@@ -37,7 +37,7 @@ signed short LVL_select_talent(Bit8u *hero, signed short show_values)
 	signed short l1;
 	signed short retval = -1;
 	/* string on stack "%s~%d" */
-	struct dummy format_str = *(struct dummy*)(p_datseg + SELECT_TALENT_LVLUP);
+	struct dummy format_str = *(struct dummy*)(p_datseg + SELECT_SKILL_LVLUP);
 
 	if (show_values != 0) {
 
@@ -59,7 +59,7 @@ signed short LVL_select_talent(Bit8u *hero, signed short show_values)
 		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ltx(0x360));
 	}
 
-	/* ask for the talent category */
+	/* ask for the skill category */
 	answer = GUI_radio(Real2Host(ds_readd(DTP2)), 7,
 				get_ltx(0x190), get_ltx(0x194),
 				get_ltx(0x198), get_ltx(0x1a4),
@@ -186,7 +186,7 @@ signed short test_skill(Bit8u *hero, signed short skill, signed char bonus)
 	if ((skill >= 7) && (skill <= 51)) {
 
 #if !defined(__BORLANDC__)
-		D1_INFO("Talentprobe %s %+d: ", names_skill[skill], bonus);
+		D1_INFO("Skill test %s %+d: ", names_skill[skill], bonus);
 #endif
 
 		/* special test if skill is a range weapon skill */
@@ -257,44 +257,44 @@ struct dummy2 {
 	signed char a[6];
 };
 
-signed short select_talent(void)
+signed short select_skill(void)
 {
 	signed short l_si = -1;
-	signed short nr_talents = 3;
+	signed short nr_skills = 3;
 	/* available skills {44, 45, 46, -1, -1, -1} */
-	struct dummy2 a = *(struct dummy2*)(p_datseg + SELECT_TALENT_DEFAULTS);
+	struct dummy2 a = *(struct dummy2*)(p_datseg + SELECT_SKILL_DEFAULTS);
 
 	/* add skills for special location */
 	/* 9 = ACROBATICS, 32 = ALCHEMY, 43 = CHEAT, 47 = INSTRUMENT, 49 = PICKPOCKET, */
 	if (ds_readbs(LOCATION) == 3) {
 		/* TAVERN */
-		a.a[nr_talents] = 9;
-		nr_talents++;
+		a.a[nr_skills] = 9;
+		nr_skills++;
 
 		if (ds_readws(0x6532) == 0) {
-			a.a[nr_talents] = 43;
-			nr_talents++;
+			a.a[nr_skills] = 43;
+			nr_skills++;
 		}
 
-		a.a[nr_talents] = 47;
-		nr_talents++;
+		a.a[nr_skills] = 47;
+		nr_skills++;
 	} else if ((ds_readbs(LOCATION) == 6) || (ds_readbs(LOCATION) == 7)) {
 		/* CAMP (Wildernes) or INN */
-		a.a[nr_talents] = 32;
-		nr_talents++;
+		a.a[nr_skills] = 32;
+		nr_skills++;
 	} else if (ds_readbs(LOCATION) == 9) {
 		/* MARKET */
-		a.a[nr_talents] = 9;
-		nr_talents++;
-		a.a[nr_talents] = 49;
-		nr_talents++;
+		a.a[nr_skills] = 9;
+		nr_skills++;
+		a.a[nr_skills] = 49;
+		nr_skills++;
 	} else if (ds_readbs(LOCATION) == 5) {
 		/* MERCHANT */
-		a.a[nr_talents] = 49;
-		nr_talents++;
+		a.a[nr_skills] = 49;
+		nr_skills++;
 	}
 
-	l_si = GUI_radio(get_ltx(0x368), (signed char)nr_talents,
+	l_si = GUI_radio(get_ltx(0x368), (signed char)nr_skills,
 				get_ltx((a.a[0] + 48) * 4),
 				get_ltx((a.a[1] + 48) * 4),
 				get_ltx((a.a[2] + 48) * 4),
@@ -310,7 +310,7 @@ signed short select_talent(void)
 	return l_si;
 }
 
-signed short use_talent(signed short hero_pos, signed char bonus, signed short talent)
+signed short use_skill(signed short hero_pos, signed char bonus, signed short skill)
 {
 	register signed short l_si;
 	signed short l_di;
@@ -327,13 +327,13 @@ signed short use_talent(signed short hero_pos, signed char bonus, signed short t
 
 	hero = get_hero(hero_pos);
 
-	if (talent != -1) {
+	if (skill != -1) {
 
 		bak = ds_readws(BUF1_FILE_INDEX);
 
 		load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
 
-		switch(talent) {
+		switch(skill) {
 		case 44 : {
 			ds_writeb(0x64a2, (signed char)hero_pos);
 
@@ -449,7 +449,7 @@ signed short use_talent(signed short hero_pos, signed char bonus, signed short t
 			if (patient_pos != -1) {
 				patient = get_hero(patient_pos);
 
-				talent_cure_disease(hero, patient, bonus, 0);
+				skill_cure_disease(hero, patient, bonus, 0);
 			}
 			break;
 		}
@@ -685,9 +685,9 @@ signed short use_talent(signed short hero_pos, signed char bonus, signed short t
 	return l_si;
 }
 
-signed short GUI_use_talent(signed short hero_pos, signed char bonus)
+signed short GUI_use_skill(signed short hero_pos, signed char bonus)
 {
-	signed short talent;
+	signed short skill;
 	Bit8u *hero;
 
 	hero = get_hero(hero_pos);
@@ -696,20 +696,20 @@ signed short GUI_use_talent(signed short hero_pos, signed char bonus)
 		return -1;
 	}
 
-	talent = select_talent();
-	return use_talent(hero_pos, bonus, talent);
+	skill = select_skill();
+	return use_skill(hero_pos, bonus, skill);
 }
 
-signed short GUI_use_talent2(signed short bonus, Bit8u *msg)
+signed short GUI_use_skill2(signed short bonus, Bit8u *msg)
 {
 	signed short hero_pos;
-	signed short talent;
+	signed short skill;
 
-	talent = select_talent();
+	skill = select_skill();
 
-	if (talent != -1) {
+	if (skill != -1) {
 
-		ds_writew(SKILLED_HERO_POS, get_skilled_hero_pos(talent));
+		ds_writew(SKILLED_HERO_POS, get_skilled_hero_pos(skill));
 
 		hero_pos = select_hero_ok(msg);
 
@@ -718,7 +718,7 @@ signed short GUI_use_talent2(signed short bonus, Bit8u *msg)
 			hero_pos = -1;
 		}
 		if (hero_pos != -1) {
-			return use_talent(hero_pos, (signed char)bonus, talent);
+			return use_skill(hero_pos, (signed char)bonus, skill);
 		}
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg103.h
+++ b/src/custom/schick/rewrite_m302de/seg103.h
@@ -9,14 +9,14 @@ signed short test_skill(Bit8u *hero, signed short, signed char);
 signed short bargain(Bit8u*, signed short, Bit32s, signed short, signed char);
 
 /* 0x2a */
-signed short GUI_use_talent(signed short, signed char);
+signed short GUI_use_skill(signed short, signed char);
 
 /* 0x2f */
 /* can be static */
-signed short select_talent(void);
+signed short select_skill(void);
 
 /* 0x34 */
-signed short LVL_select_talent(Bit8u *, signed short);
+signed short LVL_select_skill(Bit8u *, signed short);
 
 /* 0x39 */
 /* can be static */
@@ -24,10 +24,10 @@ RealPt get_proper_hero(signed short);
 
 /* 0x3e */
 /* can be static */
-signed short use_talent(signed short, signed char, signed short);
+signed short use_skill(signed short, signed char, signed short);
 
 /* 0x43 */
-signed short GUI_use_talent2(signed short, Bit8u*);
+signed short GUI_use_skill2(signed short, Bit8u*);
 
 #if !defined(__BORLANDC__)
 }

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -374,7 +374,7 @@ signed short has_herb_for_disease(Bit8u *hero, signed short disease)
 	return retval;
 }
 
-signed short talent_cure_disease(Bit8u *healer, Bit8u *patient, signed short handycap, signed short flag)
+signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short handycap, signed short flag)
 {
 	signed short disease;
 	signed short retval;
@@ -405,7 +405,7 @@ signed short talent_cure_disease(Bit8u *healer, Bit8u *patient, signed short han
 
 		} else if (host_readds(patient + HERO_HEAL_TIMER) > 0) {
 
-			/* recently tried to cure with talent */
+			/* recently tried to cure with skill */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_ltx(0xae4),

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -546,12 +546,12 @@ signed short get_skilled_hero_pos(signed short skill)
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
 
-			cur =	host_readbs(hero + HERO_MU + 3 * (ds_readbs(0xffe + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(0xffe + 4 * skill))) +
-				host_readbs(hero + HERO_MU + 3 * (ds_readbs(0xfff + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(0xfff + 4 * skill))) +
-				host_readbs(hero + HERO_MU + 3 * (ds_readbs(0x1000 + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(0x1000 + 4 * skill))) +
+			cur =	host_readbs(hero + HERO_MU + 3 * (ds_readbs(SKILLS_EXTRA + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(SKILLS_EXTRA + 4 * skill))) +
+				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILLS_EXTRA + 1) + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILLS_EXTRA + 1) + 4 * skill))) +
+				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILLS_EXTRA + 2) + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILLS_EXTRA + 2) + 4 * skill))) +
 				host_readbs(hero + HERO_TA_FIGHT + skill);
 
 			if (cur > max) {

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -275,7 +275,7 @@ signed short plan_alchemy(Bit8u *hero)
 										}
 									}
 								} else {
-									host_writed(hero + HERO_MAGIC_TIMER, 0x1fa40);
+									host_writed(hero + HERO_STAFFSPELL_TIMER, 0x1fa40);
 								}
 
 								retval = do_alchemy(hero, recipe_index, 0);

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -386,8 +386,8 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 	retval = 0;
 
 	if (flag) {
-		bak = ds_readws(BUF1_FILE_INDEX);
-		load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+		bak = ds_readws(TX_FILE_INDEX);
+		load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 	}
 
 	if (is_hero_healable(patient)) {
@@ -487,7 +487,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 
 
 		if ((flag != 0) && (bak != -1) && (bak != 222)) {
-			load_buffer_1(bak);
+			load_tx(bak);
 		}
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -546,12 +546,12 @@ signed short get_skilled_hero_pos(signed short skill)
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
 
-			cur =	host_readbs(hero + HERO_MU + 3 * (ds_readbs(SKILLS_EXTRA + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(SKILLS_EXTRA + 4 * skill))) +
-				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILLS_EXTRA + 1) + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILLS_EXTRA + 1) + 4 * skill))) +
-				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILLS_EXTRA + 2) + 4 * skill))) +
-				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILLS_EXTRA + 2) + 4 * skill))) +
+			cur =	host_readbs(hero + HERO_MU + 3 * (ds_readbs(SKILL_DESCRIPTIONS + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs(SKILL_DESCRIPTIONS + 4 * skill))) +
+				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILL_DESCRIPTIONS + 1) + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILL_DESCRIPTIONS + 1) + 4 * skill))) +
+				host_readbs(hero + HERO_MU + 3 * (ds_readbs((SKILL_DESCRIPTIONS + 2) + 4 * skill))) +
+				host_readbs(hero + HERO_MU_MOD + 3 * (ds_readbs((SKILL_DESCRIPTIONS + 2) + 4 * skill))) +
 				host_readbs(hero + HERO_TA_FIGHT + skill);
 
 			if (cur > max) {

--- a/src/custom/schick/rewrite_m302de/seg104.h
+++ b/src/custom/schick/rewrite_m302de/seg104.h
@@ -20,7 +20,7 @@ signed short plan_alchemy(Bit8u*);
 signed short has_herb_for_disease(Bit8u*, signed short);
 
 /* 0x39 */
-signed short talent_cure_disease(Bit8u*, Bit8u*, signed short, signed short);
+signed short skill_cure_disease(Bit8u*, Bit8u*, signed short, signed short);
 
 /* 0x3e */
 RealPt get_heaviest_hero(void);

--- a/src/custom/schick/rewrite_m302de/seg105.cpp
+++ b/src/custom/schick/rewrite_m302de/seg105.cpp
@@ -160,7 +160,7 @@ void add_equip_boni(Bit8u *owner, Bit8u *equipper, signed short item, signed sho
 			host_writeb(equipper + HERO_TA,
 				host_readbs(equipper + HERO_TA) - 4);
 
-			if (ds_readb(0x2845) == 20) {
+			if (ds_readb(PP20_INDEX) == ARCHIVE_FILE_ZUSTA_UK) {
 				equip_belt_ani();
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg105.cpp
+++ b/src/custom/schick/rewrite_m302de/seg105.cpp
@@ -383,7 +383,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 							host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14,
 								(item_stackable(item_p)) ? si :
 									(item_useable(item_p)) ?
-										ds_readbs(0x08aa + host_readbs(item_p + 4) * 3): 0);
+										ds_readbs((0x08a9 + 1) + host_readbs(item_p + 4) * 3): 0);
 #else
 
 							/* write item counter */
@@ -393,7 +393,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 							else if (item_useable(item_p))
 									/* unknown */
 									host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14,
-										ds_readbs(0x08aa + host_readbs(item_p + 4) * 3));
+										ds_readbs((0x08a9 + 1) + host_readbs(item_p + 4) * 3));
 								 else
 									host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14, 0);
 #endif

--- a/src/custom/schick/rewrite_m302de/seg105.cpp
+++ b/src/custom/schick/rewrite_m302de/seg105.cpp
@@ -100,13 +100,13 @@ void add_equip_boni(Bit8u *owner, Bit8u *equipper, signed short item, signed sho
 		if (item_armor(item_p)) {
 
 			/* add RS boni */
-			add_ptr_bs(equipper + HERO_RS_BONUS1, ds_readbs(0x877 + host_readbs(item_p + 4) * 2));
+			add_ptr_bs(equipper + HERO_RS_BONUS1, ds_readbs(0x0877 + host_readbs(item_p + 4) * 2));
 
 			/* subtract used item value */
 			sub_ptr_bs(equipper + HERO_RS_BONUS1, host_readbs(owner + HERO_ITEM_HEAD + 7 + pos_i * 14));
 
 			/* add RS-BE */
-			add_ptr_bs(equipper + HERO_RS_BE, ds_readbs(0x877  + 1 + host_readbs(item_p + 4) * 2));
+			add_ptr_bs(equipper + HERO_RS_BE, ds_readbs(0x0877  + 1 + host_readbs(item_p + 4) * 2));
 
 		}
 
@@ -118,11 +118,11 @@ void add_equip_boni(Bit8u *owner, Bit8u *equipper, signed short item, signed sho
 
 			/* set AT */
 			host_writeb(equipper + HERO_AT_MOD,
-				ds_readb(0x6b0 + 5 + host_readbs(item_p + 4) * 7));
+				ds_readb(0x06b0 + 5 + host_readbs(item_p + 4) * 7));
 
 			/* set PA */
 			host_writeb(equipper + HERO_PA_MOD,
-				ds_readb(0x6b0 + 6 + host_readbs(item_p + 4) * 7));
+				ds_readb(0x06b0 + 6 + host_readbs(item_p + 4) * 7));
 
 		}
 
@@ -193,7 +193,7 @@ unsigned short can_hero_use_item(Bit8u *hero, unsigned short item)
 #endif
 
 	/* calculate the address of the class forbidden items array */
-	if (is_in_word_array(item, (signed short*)Real2Host(ds_readd(0x634 + host_readbs(hero + HERO_TYPE) * 4))))
+	if (is_in_word_array(item, (signed short*)Real2Host(ds_readd(0x0634 + host_readbs(hero + HERO_TYPE) * 4))))
 		return 0;
 	else
 		return 1;
@@ -383,7 +383,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 							host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14,
 								(item_stackable(item_p)) ? si :
 									(item_useable(item_p)) ?
-										ds_readbs(0x8aa + host_readbs(item_p + 4) * 3): 0);
+										ds_readbs(0x08aa + host_readbs(item_p + 4) * 3): 0);
 #else
 
 							/* write item counter */
@@ -393,7 +393,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 							else if (item_useable(item_p))
 									/* unknown */
 									host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14,
-										ds_readbs(0x8aa + host_readbs(item_p + 4) * 3));
+										ds_readbs(0x08aa + host_readbs(item_p + 4) * 3));
 								 else
 									host_writew(hero + HERO_ITEM_HEAD + 2 + di * 14, 0);
 #endif
@@ -411,7 +411,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 							/* set breakfactor */
 							if (item_weapon(item_p)) {
 								host_writeb(hero + HERO_ITEM_HEAD + 6 + di * 14,
-									ds_readb(0x6b0 + 3 + host_readbs(item_p + 4) * 7));
+									ds_readb(0x06b0 + 3 + host_readbs(item_p + 4) * 7));
 							}
 
 							/* adjust weight */

--- a/src/custom/schick/rewrite_m302de/seg105.cpp
+++ b/src/custom/schick/rewrite_m302de/seg105.cpp
@@ -193,7 +193,7 @@ unsigned short can_hero_use_item(Bit8u *hero, unsigned short item)
 #endif
 
 	/* calculate the address of the class forbidden items array */
-	if (is_in_word_array(item, (signed short*)Real2Host(ds_readd(0x0634 + host_readbs(hero + HERO_TYPE) * 4))))
+	if (is_in_word_array(item, (signed short*)Real2Host(ds_readd(WEARABLE_ITEMS + host_readbs(hero + HERO_TYPE) * 4))))
 		return 0;
 	else
 		return 1;

--- a/src/custom/schick/rewrite_m302de/seg106.cpp
+++ b/src/custom/schick/rewrite_m302de/seg106.cpp
@@ -269,7 +269,7 @@ void print_item_description(Bit8u *hero, signed short pos)
 	if (host_readw(item_p) == 0x85) {
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 			(char*)get_city(0xd4),
-			host_readbs(hero + HERO_WAND));
+			host_readbs(hero + HERO_STAFFSPELL_LVL));
 		strcat((char*)Real2Host(ds_readd(DTP2)),
 			(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 	}

--- a/src/custom/schick/rewrite_m302de/seg106.cpp
+++ b/src/custom/schick/rewrite_m302de/seg106.cpp
@@ -49,7 +49,7 @@ signed short two_hand_collision(Bit8u* hero, signed short item, signed short pos
 		}
 
 		/* get the item in the other hand */
-		in_hand = host_readw(hero + other_pos * 0x0e + 0x196);
+		in_hand = host_readw(hero + other_pos * 0x0e + HERO_ITEM_HEAD);
 		if (in_hand) {
 
 			/* check if one hand has a two-handed weapon */
@@ -553,7 +553,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_ltx(0x348),
-				host_readws(hero1+ 0x198 + pos1 * SIZEOF_KS_ITEM),
+				host_readws(hero1+ (HERO_ITEM_HEAD + 2) + pos1 * SIZEOF_KS_ITEM),
 				(char*)Real2Host(GUI_names_grammar(6, item1, 0)),
 				(char*)hero2 + HERO_NAME2);
 
@@ -717,14 +717,14 @@ signed short get_max_light_time(void)
 			/* search for a burning torch */
 			if (host_readw(hero + HERO_ITEM_HEAD + j * 14) == 0x16) {
 
-				if (host_readbs(hero + j * 14 + 0x196 + 8) > retval) {
-					retval = host_readbs(hero + j * 14 + 0x196 + 8);
+				if (host_readbs(hero + j * 14 + HERO_ITEM_HEAD + 8) > retval) {
+					retval = host_readbs(hero + j * 14 + HERO_ITEM_HEAD + 8);
 				}
 			} else if (host_readw(hero + HERO_ITEM_HEAD + j * 14) == 0xf9) {
 				/* search for a burning lantern */
 
-				if (host_readbs(hero + j * 14 + 0x196 + 8) / 10 > retval) {
-					retval = host_readbs(hero + j * 14 + 0x196 + 8) / 10;
+				if (host_readbs(hero + j * 14 + HERO_ITEM_HEAD + 8) / 10 > retval) {
+					retval = host_readbs(hero + j * 14 + HERO_ITEM_HEAD + 8) / 10;
 				}
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg106.cpp
+++ b/src/custom/schick/rewrite_m302de/seg106.cpp
@@ -137,7 +137,7 @@ void move_item(signed short pos1, signed short pos2, Bit8u *hero)
 							GUI_output(Real2Host(ds_readd(DTP2)));
 						} else {
 							if (!can_item_at_pos(item2, pos1)) {
-								if (is_in_word_array(item2, (signed short*)(p_datseg + 0x29e)))
+								if (is_in_word_array(item2, (signed short*)(p_datseg + 0x029e)))
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
 										(char*)get_ltx(0x378),
 										(char*)Real2Host(GUI_names_grammar(0x4000, item2, 0)),
@@ -223,7 +223,7 @@ void print_item_description(Bit8u *hero, signed short pos)
 
 		if ((((signed short)host_readw(item_p + 2) > 1) &&
 			item_stackable(get_itemsdat(host_readw(item_p)))) ||
-			is_in_word_array(host_readw(item_p), (signed short*)(p_datseg + 0x29e))) {
+			is_in_word_array(host_readw(item_p), (signed short*)(p_datseg + 0x029e))) {
 			/* more than one item or special */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_city(0x120),
@@ -343,7 +343,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 		} else if (!can_item_at_pos(item1, pos2)) {
 
-			if (is_in_word_array(item1, (signed short*)(p_datseg + 0x29e))) {
+			if (is_in_word_array(item1, (signed short*)(p_datseg + 0x029e))) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_ltx(0x378),
@@ -395,7 +395,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 		} else if (!can_item_at_pos(item2, pos1)) {
 
-			if (is_in_word_array(item2, (signed short*)(p_datseg + 0x29e))) {
+			if (is_in_word_array(item2, (signed short*)(p_datseg + 0x029e))) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
 					(char*)get_ltx(0x378),

--- a/src/custom/schick/rewrite_m302de/seg107.cpp
+++ b/src/custom/schick/rewrite_m302de/seg107.cpp
@@ -109,10 +109,10 @@ void item_arcano(void)
 	signed short b1_index;
 
 	/* save index off buffer1 */
-	b1_index = ds_readws(BUF1_FILE_INDEX);
+	b1_index = ds_readws(TX_FILE_INDEX);
 
 	/* load SPELLTXT*/
-	load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+	load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 	ds_writed(SPELLUSER, ds_readd(ITEMUSER));
 
@@ -129,7 +129,7 @@ void item_arcano(void)
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
 		/* need to reload buffer1 */
-		load_buffer_1(b1_index);
+		load_tx(b1_index);
 	}
 }
 
@@ -194,10 +194,10 @@ void item_armatrutz(void)
 	signed short b1_index;
 
 	/* save index off buffer1 */
-	b1_index = ds_readws(BUF1_FILE_INDEX);
+	b1_index = ds_readws(TX_FILE_INDEX);
 
 	/* load SPELLTXT*/
-	load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+	load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 	ds_writed(SPELLUSER, ds_readd(ITEMUSER));
 
@@ -216,7 +216,7 @@ void item_armatrutz(void)
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
 		/* need to reload buffer1 */
-		load_buffer_1(b1_index);
+		load_tx(b1_index);
 	}
 }
 
@@ -227,10 +227,10 @@ void item_flimflam(void)
 	signed short b1_index;
 
 	/* save index off buffer1 */
-	b1_index = ds_readws(BUF1_FILE_INDEX);
+	b1_index = ds_readws(TX_FILE_INDEX);
 
 	/* load SPELLTXT*/
-	load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+	load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 	ds_writed(SPELLUSER, ds_readd(ITEMUSER));
 
@@ -241,7 +241,7 @@ void item_flimflam(void)
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
 		/* need to reload buffer1 */
-		load_buffer_1(b1_index);
+		load_tx(b1_index);
 	}
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
@@ -448,10 +448,10 @@ void item_brenne(void)
 	signed short refill_pos;
 
 	/* save index off buffer1 */
-	b1_index = ds_readws(BUF1_FILE_INDEX);
+	b1_index = ds_readws(TX_FILE_INDEX);
 
 	/* load SPELLTXT*/
-	load_buffer_1(ARCHIVE_FILE_SPELLTXT_LTX);
+	load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 	if (ds_readws(USED_ITEM_ID) == 249) {
 		/* refill burning lantern */
@@ -516,7 +516,7 @@ void item_brenne(void)
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
 		/* need to reload buffer1 */
-		load_buffer_1(b1_index);
+		load_tx(b1_index);
 	}
 
 	GUI_output(Real2Host(ds_readd(DTP2)));

--- a/src/custom/schick/rewrite_m302de/seg107.cpp
+++ b/src/custom/schick/rewrite_m302de/seg107.cpp
@@ -93,9 +93,9 @@ void use_item(signed short item_pos, signed short hero_pos)
 			} else {
 				/* special item */
 #if !defined(__BORLANDC__)
-				func = handler[ds_readbs(0x08ab + 3 * host_readbs(Real2Host(ds_readd(USED_ITEM_DESC)) + 4))];
+				func = handler[ds_readbs((0x08a9 + 2) + 3 * host_readbs(Real2Host(ds_readd(USED_ITEM_DESC)) + 4))];
 #else
-				func = (void (*)(void))ds_readd(USE_SPECIAL_ITEM_HANDLERS + 4 * ds_readbs(0x08ab + 3 * host_readbs(Real2Host(ds_readd(USED_ITEM_DESC)) + 4)));
+				func = (void (*)(void))ds_readd(USE_SPECIAL_ITEM_HANDLERS + 4 * ds_readbs((0x08a9 + 2) + 3 * host_readbs(Real2Host(ds_readd(USED_ITEM_DESC)) + 4)));
 #endif
 				func();
 			}

--- a/src/custom/schick/rewrite_m302de/seg107.cpp
+++ b/src/custom/schick/rewrite_m302de/seg107.cpp
@@ -67,7 +67,7 @@ void use_item(signed short item_pos, signed short hero_pos)
 			if (!item_useable(Real2Host(ds_readd(USED_ITEM_DESC)))) {
 				/* item is not usable */
 
-				if (is_in_word_array(ds_readws(USED_ITEM_ID), (signed short*)(p_datseg + 0x29e)))
+				if (is_in_word_array(ds_readws(USED_ITEM_ID), (signed short*)(p_datseg + 0x029e)))
 				{
 					/* german grammar, singular and plural are the same */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),

--- a/src/custom/schick/rewrite_m302de/seg107.cpp
+++ b/src/custom/schick/rewrite_m302de/seg107.cpp
@@ -58,7 +58,7 @@ void use_item(signed short item_pos, signed short hero_pos)
 
 	ds_writed(ITEMUSER, (Bit32u)((RealPt)ds_readd(HEROS) + hero_pos * SIZEOF_HERO));
 
-	ds_writew(USED_ITEM_ID, host_readws(get_itemuser() + ds_readws(USED_ITEM_POS) * 14 + 0x196));
+	ds_writew(USED_ITEM_ID, host_readws(get_itemuser() + ds_readws(USED_ITEM_POS) * 14 + HERO_ITEM_HEAD));
 
 	ds_writed(USED_ITEM_DESC, (Bit32u)((RealPt)ds_readd(ITEMSDAT) + ds_readws(USED_ITEM_ID) * 12));
 
@@ -87,7 +87,7 @@ void use_item(signed short item_pos, signed short hero_pos)
 				/* don't consume poison */
 				consume(get_itemuser(), get_itemuser(), item_pos);
 
-			} else if ((host_readws(get_itemuser() + 14 * ds_readws(USED_ITEM_POS) + 0x198)) <= 0) {
+			} else if ((host_readws(get_itemuser() + 14 * ds_readws(USED_ITEM_POS) + (HERO_ITEM_HEAD + 2))) <= 0) {
 				/* magic item is used up */
 				GUI_output(get_ltx(0x9f8));
 			} else {
@@ -124,7 +124,7 @@ void item_arcano(void)
 		/* use it */
 		spell_arcano();
 		/* decrement usage counter */
-		dec_ptr_ws(get_itemuser() + 0x198 + ds_readws(USED_ITEM_POS) * 14);
+		dec_ptr_ws(get_itemuser() + (HERO_ITEM_HEAD + 2) + ds_readws(USED_ITEM_POS) * 14);
 	}
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
@@ -209,7 +209,7 @@ void item_armatrutz(void)
 		/* use it */
 		spell_armatrutz();
 		/* decrement usage counter */
-		dec_ptr_ws(get_itemuser() + 0x198 + ds_readws(USED_ITEM_POS) * 14);
+		dec_ptr_ws(get_itemuser() + (HERO_ITEM_HEAD + 2) + ds_readws(USED_ITEM_POS) * 14);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 	}
@@ -237,7 +237,7 @@ void item_flimflam(void)
 	spell_flimflam();
 
 	/* decrement usage counter */
-	dec_ptr_ws(get_itemuser() + 0x198 + ds_readws(USED_ITEM_POS) * 14);
+	dec_ptr_ws(get_itemuser() + (HERO_ITEM_HEAD + 2) + ds_readws(USED_ITEM_POS) * 14);
 
 	if ((b1_index != -1) && (b1_index != 0xde)) {
 		/* need to reload buffer1 */
@@ -294,16 +294,16 @@ void item_weapon_poison(void)
 
 	signed short bottle;
 
-	if ((host_readws(get_itemuser() + 0x1c0) != 0) &&
-		(host_readws(get_itemuser() + 0x1c0) != 9) &&
-		(host_readws(get_itemuser() + 0x1c0) != 19) &&
-		(host_readws(get_itemuser() + 0x1c0) != 12))
+	if ((host_readws(get_itemuser() + HERO_ITEM_RIGHT) != 0) &&
+		(host_readws(get_itemuser() + HERO_ITEM_RIGHT) != 9) &&
+		(host_readws(get_itemuser() + HERO_ITEM_RIGHT) != 19) &&
+		(host_readws(get_itemuser() + HERO_ITEM_RIGHT) != 12))
 	{
 
 		switch (ds_readws(USED_ITEM_ID)) {
 		case 168 : {
 			/* VOMICUM */
-			or_ptr_bs(get_itemuser() + 0x1c4, 0x40);
+			or_ptr_bs(get_itemuser() + (HERO_ITEM_RIGHT + 4), 0x40);
 
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 168), 1);
 
@@ -312,7 +312,7 @@ void item_weapon_poison(void)
 		}
 		case 166 : {
 			/* EXPURGICUM */
-			or_ptr_bs(get_itemuser() + 0x1c4, 0x20);
+			or_ptr_bs(get_itemuser() + (HERO_ITEM_RIGHT + 4), 0x20);
 
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 166), 1);
 
@@ -321,71 +321,71 @@ void item_weapon_poison(void)
 		}
 		case 55: {
 			/* SHURIN-BULB POISON / KROETENSCHEMELGIFT */
-			host_writeb(get_itemuser() + 0x1c9, 1);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 1);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 55), 1);
 			bottle = 31;
 			break;
 		}
 		case 56: {
 			/* ARAX POISON / ARAXGIFT */
-			host_writeb(get_itemuser() + 0x1c9, 2);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 2);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 56), 1);
 			bottle = 31;
 			break;
 		}
 		case 57: {
 			/* FEAR POISON / ANGSTGIFT */
-			host_writeb(get_itemuser() + 0x1c9, 3);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 3);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 57), 1);
 			bottle = 31;
 			break;
 		}
 		case 58: {
 			/* SLEPPING POISON / SCHALFGIFT */
-			host_writeb(get_itemuser() + 0x1c9, 4);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 4);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 58), 1);
 			bottle = 31;
 			break;
 		}
 		case 59: {
 			/* GOLDEN GLUE / GOLDLEIM */
-			host_writeb(get_itemuser() + 0x1c9, 5);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 59), 1);
 			bottle = 31;
 			break;
 		}
 		case 141: {
 			/* LOTUS POISON / LOTUSGIFT */
-			host_writeb(get_itemuser() + 0x1c9, 7);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 7);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 141), 1);
 			bottle = 31;
 			break;
 		}
 		case 142: {
 			/* KUKRIS */
-			host_writeb(get_itemuser() + 0x1c9, 8);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 8);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 142), 1);
 			bottle = 31;
 			break;
 		}
 		case 143: {
 			/* BANE DUST / BANNSTAUB */
-			host_writeb(get_itemuser() + 0x1c9, 9);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 9);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 143), 1);
 			bottle = 31;
 			break;
 		}
 		case 144: {
-			host_writeb(get_itemuser() + 0x1c9, 6);
-			host_writeb(get_itemuser() + 0x1ca, 5);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 9), 6);
+			host_writeb(get_itemuser() + (HERO_ITEM_RIGHT + 10), 5);
 			drop_item(get_itemuser(), get_item_pos(get_itemuser(), 144), 1);
 			bottle = 31;
 			break;
@@ -396,11 +396,11 @@ void item_weapon_poison(void)
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_ltx(0xb8c),
-			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readws(get_itemuser() + 0x1c0), 0)));
+			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readws(get_itemuser() + HERO_ITEM_RIGHT), 0)));
 	} else {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
 			(char*)get_ltx(0xc94),
-			(char*)get_itemuser() + 0x10);
+			(char*)get_itemuser() + HERO_NAME2);
 	}
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
@@ -432,7 +432,7 @@ void item_magic_book(void)
 	GUI_output(get_ltx(0xbb4));
 
 	/* Heptagon +2 */
-	add_ptr_bs(get_itemuser() + 0x152, 2);
+	add_ptr_bs(get_itemuser() + (HERO_SP_DEMON + 3), 2);
 
 	/* drop the book */
 	drop_item(get_itemuser(), get_item_pos(get_itemuser(), 246), 1);
@@ -470,7 +470,7 @@ void item_brenne(void)
 			refill_pos = get_item_pos(get_spelluser(), 249);
 
 			/* reset the burning time of the lantern */
-			host_writeb(get_itemuser() + 0x19e + refill_pos * 14, 100);
+			host_writeb(get_itemuser() + (HERO_ITEM_HEAD + 8) + refill_pos * 14, 100);
 
 			/* drop the oil */
 			drop_item(get_itemuser(), pos, 1);
@@ -481,12 +481,12 @@ void item_brenne(void)
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x1dc),
-				(char*)get_itemuser() + 0x10);
+				(char*)get_itemuser() + HERO_NAME2);
 		} else {
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x1e0),
-				(char*)get_itemuser() + 0x10);
+				(char*)get_itemuser() + HERO_NAME2);
 		}
 	} else {
 
@@ -495,7 +495,7 @@ void item_brenne(void)
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
 				(char*)get_dtp(0x1e8),
-				(char*)get_itemuser() + 0x10);
+				(char*)get_itemuser() + HERO_NAME2);
 		} else {
 
 			if (ds_readws(USED_ITEM_ID) == 65) {

--- a/src/custom/schick/rewrite_m302de/seg108.cpp
+++ b/src/custom/schick/rewrite_m302de/seg108.cpp
@@ -155,10 +155,10 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 		if (host_readb(item_p + 3) == 0) {
 
-			if (is_in_word_array(item, (signed short*)(p_datseg + 0x08f1))) {
+			if (is_in_word_array(item, (signed short*)(p_datseg + HERBS_UNEATABLE))) {
 				GUI_output(get_ltx(0x7cc));
-			} else if (is_in_word_array(item, (signed short*)(p_datseg + 0x08e7)) ||
-					is_in_word_array(item, (signed short*)(p_datseg + 0x08d3))) {
+			} else if (is_in_word_array(item, (signed short*)(p_datseg + HERBS_TOXIC)) ||
+					is_in_word_array(item, (signed short*)(p_datseg + POISON_POTIONS))) {
 				/* herbs and poisons */
 				GUI_output(get_ltx(0x7d0));
 			} else {
@@ -279,8 +279,8 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 		} else {
 
 			/* check if item is an elexire */
-			l_si = is_in_word_array(item, (signed short*)(p_datseg + 0x08ff));
-			id_bad_elex = is_in_word_array(item, (signed short*)(p_datseg + 0x090f));
+			l_si = is_in_word_array(item, (signed short*)(p_datseg + ELIXIR_POTIONS));
+			id_bad_elex = is_in_word_array(item, (signed short*)(p_datseg + BAD_ELIXIRS));
 
 
 			if (l_si != 0) {

--- a/src/custom/schick/rewrite_m302de/seg108.cpp
+++ b/src/custom/schick/rewrite_m302de/seg108.cpp
@@ -155,10 +155,10 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 		if (host_readb(item_p + 3) == 0) {
 
-			if (is_in_word_array(item, (signed short*)(p_datseg + 0x8f1))) {
+			if (is_in_word_array(item, (signed short*)(p_datseg + 0x08f1))) {
 				GUI_output(get_ltx(0x7cc));
-			} else if (is_in_word_array(item, (signed short*)(p_datseg + 0x8e7)) ||
-					is_in_word_array(item, (signed short*)(p_datseg + 0x8d3))) {
+			} else if (is_in_word_array(item, (signed short*)(p_datseg + 0x08e7)) ||
+					is_in_word_array(item, (signed short*)(p_datseg + 0x08d3))) {
 				/* herbs and poisons */
 				GUI_output(get_ltx(0x7d0));
 			} else {
@@ -279,8 +279,8 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 		} else {
 
 			/* check if item is an elexire */
-			l_si = is_in_word_array(item, (signed short*)(p_datseg + 0x8ff));
-			id_bad_elex = is_in_word_array(item, (signed short*)(p_datseg + 0x90f));
+			l_si = is_in_word_array(item, (signed short*)(p_datseg + 0x08ff));
+			id_bad_elex = is_in_word_array(item, (signed short*)(p_datseg + 0x090f));
 
 
 			if (l_si != 0) {

--- a/src/custom/schick/rewrite_m302de/seg108.cpp
+++ b/src/custom/schick/rewrite_m302de/seg108.cpp
@@ -149,7 +149,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 			}
 		}
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 
 	} else if (item_herb_potion(item_p)) {
 
@@ -594,7 +594,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 			}
 		}
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	} else {
 		/* this item cannot be consumed */
 		GUI_output(get_ltx(0x338));

--- a/src/custom/schick/rewrite_m302de/seg109.cpp
+++ b/src/custom/schick/rewrite_m302de/seg109.cpp
@@ -91,15 +91,15 @@ void TRV_event(signed short travel_event)
 
 /**
  * \brief	executes a fight and load a textfile
- * \param fight_nr	ID of the fight
+ * \param fight_id	ID of the fight
  * \param travel_event	ID of the travel event
  * \return return value of the fight
  */
-signed short TRV_fight_event(signed short fight_nr, signed short travel_event)
+signed short TRV_fight_event(signed short fight_id, signed short travel_event)
 {
 	signed short retval;
 
-	retval = do_fight(fight_nr);
+	retval = do_fight(fight_id);
 	TRV_load_textfile(travel_event);
 
 	return retval;

--- a/src/custom/schick/rewrite_m302de/seg109.cpp
+++ b/src/custom/schick/rewrite_m302de/seg109.cpp
@@ -34,7 +34,7 @@ namespace M302de {
 
 void TRV_load_textfile(signed short travel_event)
 {
-	load_buffer_1(ARCHIVE_FILE_FEATURE_LTX);
+	load_tx(ARCHIVE_FILE_FEATURE_LTX);
 
 	if (travel_event == -1) {
 		travel_event = ds_readws(0xb133);
@@ -84,7 +84,7 @@ void TRV_event(signed short travel_event)
 	ds_writews(0x2ca4, bak2);
 	ds_writews(TEXTBOX_WIDTH, tw_bak);
 	ds_writeb(0x2c98, 0);
-	load_buffer_1(ARCHIVE_FILE_MAPTEXT_LTX);
+	load_tx(ARCHIVE_FILE_MAPTEXT_LTX);
 	ds_writew(WALLCLOCK_UPDATE, 1);
 }
 #endif

--- a/src/custom/schick/rewrite_m302de/seg109.cpp
+++ b/src/custom/schick/rewrite_m302de/seg109.cpp
@@ -159,7 +159,7 @@ void TRV_inside_herb_place(void)
 	}
 
 	set_var_to_zero();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 signed short TRV_found_camp_place(signed short a0)
@@ -198,7 +198,7 @@ signed short TRV_found_camp_place(signed short a0)
 		TRV_load_textfile(-1);
 
 		ds_writew(HERO_SLEEP_MOD, ds_writews(REPLENISH_STOCKS_MOD, ds_writews(GATHER_HERBS_MOD, 0)));
-		ds_writew(0x2846, 2);
+		ds_writew(REQUEST_REFRESH, 2);
 
 		return 1;
 	}
@@ -256,7 +256,7 @@ void TRV_found_replenish_place(signed short a0)
 
 		set_var_to_zero();
 
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	}
 }
 
@@ -279,7 +279,7 @@ void TRV_found_inn(signed short city, signed short type)
 	}
 
 	set_var_to_zero();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 /**
@@ -297,7 +297,7 @@ signed short TRV_enter_hut_question(void)
 	answer = GUI_bool(get_dtp(0x60));
 
 	set_var_to_zero();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 
 	return answer;
 }
@@ -361,7 +361,7 @@ signed short TRV_cross_a_ford(Bit8u *msg, signed short time, signed short mod)
 
 	set_var_to_zero();
 	ds_writeb(0xe5d2, 0);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 	return 1;
 }
 
@@ -647,7 +647,7 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 
 	set_var_to_zero();
 	ds_writeb(0xe5d2, 0);
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 void tevent_005(void)

--- a/src/custom/schick/rewrite_m302de/seg111.cpp
+++ b/src/custom/schick/rewrite_m302de/seg111.cpp
@@ -321,7 +321,7 @@ void tevent_060(void)
 							nr_items += hero_count_item(hero, 121);
 							nr_items += hero_count_item(hero, 32);
 
-							if (host_readbs(hero + HERO_WAND) >= 3)
+							if (host_readbs(hero + HERO_STAFFSPELL_LVL) >= 3)
 							{
 								has_magic_rope = 1;
 							}

--- a/src/custom/schick/rewrite_m302de/seg111.cpp
+++ b/src/custom/schick/rewrite_m302de/seg111.cpp
@@ -163,11 +163,11 @@ void tevent_059(void)
 
 	if (TRV_enter_hut_question())
 	{
-		ds_writews(0x434f, 0);
+		ds_writews(CAMP_INCIDENT, 0);
 		ds_writeb(LOCATION, 6);
 		do_location();
 		ds_writeb(LOCATION, 0);
-		ds_writews(0x434f, -1);
+		ds_writews(CAMP_INCIDENT, -1);
 
 		TRV_load_textfile(-1);
 

--- a/src/custom/schick/rewrite_m302de/seg113.cpp
+++ b/src/custom/schick/rewrite_m302de/seg113.cpp
@@ -429,7 +429,7 @@ void hero_disappear(Bit8u *hero, unsigned short pos, signed short type)
 	if (type != -2) {
 		draw_main_screen();
 		init_ani(2);
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	}
 
 	/* set flag to check all heros */
@@ -849,7 +849,7 @@ void tevent_107(void)
 	}
 
 	set_var_to_zero();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 void tevent_108(void)

--- a/src/custom/schick/rewrite_m302de/seg115.cpp
+++ b/src/custom/schick/rewrite_m302de/seg115.cpp
@@ -746,7 +746,7 @@ void tevent_100(void)
 				GUI_output(get_city(0x118));
 			}
 
-			ds_writew(0x2846, 1);
+			ds_writew(REQUEST_REFRESH, 1);
 
 		} else if (answer == 3)
 		{

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -698,7 +698,7 @@ void TLK_old_woman(signed short state)
 			}
 		}
 
-		ds_writew(0xe30e, count_heroes_in_group() == counter ? 4 : 5);
+		ds_writew(DIALOG_NEXT_STATE, count_heroes_in_group() == counter ? 4 : 5);
 
 	} else if (state == 4 || state == 14 || state == 21) {
 
@@ -720,7 +720,7 @@ void TLK_old_woman(signed short state)
 
 		ds_writed(RANDOM_TLK_HERO, (Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * get_random_hero()));
 
-		ds_writew(0xe30e, count_heroes_in_group() == counter ? 24 : 25);
+		ds_writew(DIALOG_NEXT_STATE, count_heroes_in_group() == counter ? 24 : 25);
 
 	} else if (state == 33) {
 
@@ -729,7 +729,7 @@ void TLK_old_woman(signed short state)
 		} while (1);
 
 	} else if (state == 34) {
-		ds_writew(0xe30e, ds_readb(CURRENT_TOWN) == 20 ? 35 : 39);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(CURRENT_TOWN) == 20 ? 35 : 39);
 	} else if (state == 37) {
 		ds_writeb(0x3dee, ds_writeb(0x3dec, 1));
 	} else if (state == 38) {

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -44,14 +44,14 @@ void tevent_130(void)
 
 	if (TRV_enter_hut_question()) {
 
-		ds_writews(0x434f, 0);
+		ds_writews(CAMP_INCIDENT, 0);
 
 		ds_writeb(LOCATION, 6);
 		do_location();
 		ds_writeb(LOCATION, 0);
 
 		TRV_load_textfile(-1);
-		ds_writews(0x434f, -1);
+		ds_writews(CAMP_INCIDENT, -1);
 
 		load_in_head(10);
 

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -347,7 +347,7 @@ void tevent_135(void)
 	}
 
 	set_var_to_zero();
-	ds_writew(0x2846, 1);
+	ds_writew(REQUEST_REFRESH, 1);
 }
 
 void tevent_137(void)

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -384,17 +384,17 @@ void tevent_137(void)
 					if ((item_pos = get_item_pos(hero, 30)) != -1) {
 						and_ptr_bs(hero + HERO_ITEM_HEAD + 4 + 14 * item_pos, 0xfb);
 #if !defined(__BORLANDC__)
-						and_ptr_bs(hero + 14 * item_pos + 0x196 + 4, 0xfd);
-						or_ptr_bs(hero + 14 * item_pos + 0x196 + 4, 0 << 1);
+						and_ptr_bs(hero + 14 * item_pos + HERO_ITEM_HEAD + 4, 0xfd);
+						or_ptr_bs(hero + 14 * item_pos + HERO_ITEM_HEAD + 4, 0 << 1);
 #else
 						asm {	mov al, 0
 							mov dx, item_pos
 							imul dx, dx, 14
 							les bx, hero
 							db 0x03, 0xda ; /* add bx, dx */
-							and byte ptr es:[bx + 0x19a], 0xfd
+							and byte ptr es:[bx + (HERO_ITEM_HEAD + 4)], 0xfd
 							shl al, 1
-							or es:[bx + 0x19a], al
+							or es:[bx + (HERO_ITEM_HEAD + 4)], al
 						}
 #endif
 					}
@@ -648,7 +648,7 @@ void tevent_144(void)
 						(char*)get_city(0x98),
 						(char*)get_hero(6) + HERO_NAME2);
 
-					GUI_dialogbox((RealPt)ds_readd(HEROS) + SIZEOF_HERO * 6 + 0x2da,
+					GUI_dialogbox((RealPt)ds_readd(HEROS) + SIZEOF_HERO * 6 + HERO_PORTRAIT,
 							Real2Host(ds_readd(HEROS)) + SIZEOF_HERO * 6  + 0x10,
 							Real2Host(ds_readd(DTP2)), 0);
 				}

--- a/src/custom/schick/rewrite_m302de/seg117.cpp
+++ b/src/custom/schick/rewrite_m302de/seg117.cpp
@@ -661,7 +661,7 @@ void random_encounter(signed short arg)
 	ds_writew(0x2ca2, bak1);
 	ds_writew(0x2ca4, bak2);
 	ds_writew(WALLCLOCK_UPDATE, bak3);
-	load_buffer_1(ARCHIVE_FILE_MAPTEXT_LTX);
+	load_tx(ARCHIVE_FILE_MAPTEXT_LTX);
 }
 
 void search_ruin1(void)

--- a/src/custom/schick/rewrite_m302de/seg117.cpp
+++ b/src/custom/schick/rewrite_m302de/seg117.cpp
@@ -688,7 +688,7 @@ void TLK_way_to_ruin(signed short state)
 	hero2 = Real2Host(get_first_hero_available_in_group());
 
 	if (!state) {
-		ds_writew(0xe30e, ds_readb(0x3dfb) != 0 ? 45 : 66);
+		ds_writew(DIALOG_NEXT_STATE, ds_readb(0x3dfb) != 0 ? 45 : 66);
 		ds_writew(0xb21b, 0);
 	} else if (state == 66 || state == 45) {
 		show_treasure_map();
@@ -696,7 +696,7 @@ void TLK_way_to_ruin(signed short state)
 		timewarp(HOURS(1));
 	} else if (state == 6) {
 		hero = (RealPt)ds_readd(HEROS) + SIZEOF_HERO * get_random_hero();
-		ds_writew(0xe30e, test_skill(Real2Host(hero), 31, 6) > 0 ? 8 : 7);
+		ds_writew(DIALOG_NEXT_STATE, test_skill(Real2Host(hero), 31, 6) > 0 ? 8 : 7);
 	} else if (state == 8) {
 		timewarp(HOURS(1));
 		TRV_ford_test(0, 30);
@@ -716,9 +716,9 @@ void TLK_way_to_ruin(signed short state)
 
 		} while (ds_readws(0xb21b) != 7);
 
-		ds_writew(0xe30e, ds_readws(0xb21b) == 7 ? 13 : 10);
+		ds_writew(DIALOG_NEXT_STATE, ds_readws(0xb21b) == 7 ? 13 : 10);
 	} else if (state == 10) {
-		ds_writew(0xe30e, test_skill(Real2Host(ds_readd(RUIN_HERO)), 14, 5) > 0 ? 11 : 12);
+		ds_writew(DIALOG_NEXT_STATE, test_skill(Real2Host(ds_readd(RUIN_HERO)), 14, 5) > 0 ? 11 : 12);
 	} else if (state == 12) {
 		sub_hero_le(Real2Host(ds_readd(RUIN_HERO)), random_schick(4) + 1);
 
@@ -735,11 +735,11 @@ void TLK_way_to_ruin(signed short state)
 	} else if (state == 15 || state == 16) {
 		timewarp(MINUTES(20));
 	} else if (state == 17) {
-		ds_writew(0xe30e, test_skill(hero2, 28, 5) > 0 ? 18 : 19);
+		ds_writew(DIALOG_NEXT_STATE, test_skill(hero2, 28, 5) > 0 ? 18 : 19);
 	} else if (state == 19) {
 		timewarp(MINUTES(20));
 		ds_writed(RUIN_HERO, (Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * get_random_hero()));
-		ds_writew(0xe30e, test_skill(Real2Host(ds_readd(RUIN_HERO)), 4, 2) > 0 ? 20 : 21);
+		ds_writew(DIALOG_NEXT_STATE, test_skill(Real2Host(ds_readd(RUIN_HERO)), 4, 2) > 0 ? 20 : 21);
 	} else if (state == 20) {
 		loose_random_item(get_hero(get_random_hero()), 5, get_ltx(0x7e8));
 	} else if (state == 21) {
@@ -769,7 +769,7 @@ void TLK_way_to_ruin(signed short state)
 			}
 		}
 
-		ds_writew(0xe30e, (count_heroes_in_group() >> 1) < ds_readws(0xb21b) ? 29 : 30);
+		ds_writew(DIALOG_NEXT_STATE, (count_heroes_in_group() >> 1) < ds_readws(0xb21b) ? 29 : 30);
 
 	} else if (state == 41) {
 		ds_writeb(0xe5d2, 1);
@@ -798,7 +798,7 @@ void TLK_way_to_ruin(signed short state)
 			}
 		}
 
-		ds_writew(0xe30e, (count_heroes_in_group() >> 1) < ds_readws(0xb21b) ? 49 : 50);
+		ds_writew(DIALOG_NEXT_STATE, (count_heroes_in_group() >> 1) < ds_readws(0xb21b) ? 49 : 50);
 	}
 
 	ds_writeb(0xe5d2, 0);

--- a/src/custom/schick/rewrite_m302de/seg117.cpp
+++ b/src/custom/schick/rewrite_m302de/seg117.cpp
@@ -70,7 +70,7 @@ void resume_traveling(void)
 
 	set_var_to_zero();
 
-	ds_writew(0x2846, ds_writeb(TRAVELING, 1));
+	ds_writew(REQUEST_REFRESH, ds_writeb(TRAVELING, 1));
 
 	ds_writeb(0xe5d2, 0);
 	ds_writeb(TRAVEL_EVENT_ACTIVE, 0);
@@ -777,7 +777,7 @@ void TLK_way_to_ruin(signed short state)
 		draw_main_screen();
 		init_ani(0);
 		timewarp(MINUTES(90));
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	} else if (state == 42 || state == 60) {
 		timewarp(MINUTES(150));
 	} else if (state == 67 || state == 44) {

--- a/src/custom/schick/rewrite_m302de/seg118.cpp
+++ b/src/custom/schick/rewrite_m302de/seg118.cpp
@@ -243,7 +243,7 @@ void tevent_037(void)
 		set_var_to_zero();
 
 		ds_writeb(0xe5d2, 0);
-		ds_writew(0x2846, 1);
+		ds_writew(REQUEST_REFRESH, 1);
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg119.cpp
+++ b/src/custom/schick/rewrite_m302de/seg119.cpp
@@ -109,7 +109,7 @@ void disease_effect(void)
 			}
 
 
-			disease_ptr = Real2Host(hero) + 0xb8;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 5);
 
 			/* NUMBSKULL / DUMPFSCHAEDEL: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -123,7 +123,7 @@ void disease_effect(void)
 						sub_ptr_bs(Real2Host(hero) + j + 0x6f, 2);
 					}
 
-					sub_ptr_bs(Real2Host(hero) + 0x41, 2);
+					sub_ptr_bs(Real2Host(hero) + HERO_GE, 2);
 					sub_ptr_bs(Real2Host(hero) + HERO_KK, 5);
 
 
@@ -168,7 +168,7 @@ void disease_effect(void)
 							add_ptr_bs(Real2Host(hero) + j + 0x6f, 2);
 						}
 
-						add_ptr_bs(Real2Host(hero) + 0x41, 2);
+						add_ptr_bs(Real2Host(hero) + HERO_GE, 2);
 						add_ptr_bs(Real2Host(hero) + HERO_KK, 5);
 					}
 
@@ -197,7 +197,7 @@ void disease_effect(void)
 						add_ptr_bs(Real2Host(hero) + j + 0x6f, 2);
 					}
 
-					add_ptr_bs(Real2Host(hero) + 0x41, 2);
+					add_ptr_bs(Real2Host(hero) + HERO_GE, 2);
 					add_ptr_bs(Real2Host(hero) + HERO_KK, 5);
 				}
 
@@ -209,7 +209,7 @@ void disease_effect(void)
 				GUI_output(Real2Host(ds_readd(DTP2)));
 			}
 
-			disease_ptr = Real2Host(hero) + 0xbd;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 10);
 
 			/* BLUE COUGH / BLAUE KEUCHE: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -224,10 +224,10 @@ void disease_effect(void)
 					}
 
 					host_writebs(disease_ptr + 2, host_readbs(Real2Host(hero) + HERO_KK) / 2);
-					host_writebs(disease_ptr + 3, host_readbs(Real2Host(hero) + 0x41) / 2);
+					host_writebs(disease_ptr + 3, host_readbs(Real2Host(hero) + HERO_GE) / 2);
 
 
-					sub_ptr_bs(Real2Host(hero) + 0x41, host_readbs(disease_ptr + 3));
+					sub_ptr_bs(Real2Host(hero) + HERO_GE, host_readbs(disease_ptr + 3));
 					sub_ptr_bs(Real2Host(hero) + HERO_KK, host_readbs(disease_ptr + 2));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
@@ -240,7 +240,7 @@ void disease_effect(void)
 
 				if ((host_readbs(disease_ptr + 1) > 3) && (random_schick(100) <= 25)) {
 
-						dec_ptr_bs(Real2Host(hero) + 0x46);
+						dec_ptr_bs(Real2Host(hero) + HERO_KK_ORIG);
 						dec_ptr_bs(Real2Host(hero) + HERO_KK);
 						sub_ptr_ws(Real2Host(hero) + HERO_LE_ORIG, host_readbs(disease_ptr + 1) / 3);
 						sub_hero_le(Real2Host(hero), host_readbs(disease_ptr + 1) / 3);
@@ -286,14 +286,14 @@ void disease_effect(void)
 						add_ptr_bs(Real2Host(hero) + j + 0x6f, 4);
 					}
 
-					add_ptr_bs(Real2Host(hero) + 0x41, host_readbs(disease_ptr + 3));
+					add_ptr_bs(Real2Host(hero) + HERO_GE, host_readbs(disease_ptr + 3));
 					add_ptr_bs(Real2Host(hero) + HERO_KK, host_readbs(disease_ptr + 2));
 					host_writebs(disease_ptr + 2, host_writebs(disease_ptr + 3, 0));
 				}
 			}
 
 
-			disease_ptr = Real2Host(hero) + 0xc2;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 15);
 
 			/* PARALYSIS / PARALYSE: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -304,7 +304,7 @@ void disease_effect(void)
 				} else {
 					j = random_schick(6);
 					add_ptr_bs(disease_ptr + 3, j);
-					sub_ptr_bs(Real2Host(hero) + 0x41, j);
+					sub_ptr_bs(Real2Host(hero) + HERO_GE, j);
 
 					j = random_schick(6);
 					add_ptr_bs(disease_ptr + 2, j);
@@ -345,13 +345,13 @@ void disease_effect(void)
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
 						dec_ptr_bs(disease_ptr + 3);
-						inc_ptr_bs(Real2Host(hero) + 0x41);
+						inc_ptr_bs(Real2Host(hero) + HERO_GE);
 					}
 				}
 			}
 
 
-			disease_ptr = Real2Host(hero) + 0xc7;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 20);
 
 			/* BATTLEFIELD FEVER / SCHLACHTFELDFIEBER: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -428,7 +428,7 @@ void disease_effect(void)
 				GUI_output(Real2Host(ds_readd(DTP2)));
 			}
 
-			disease_ptr = Real2Host(hero) + 0xcc;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 25);
 
 			/* FROSTBITE / FROSTSCHAEDEN: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -437,8 +437,8 @@ void disease_effect(void)
 
 				if (random_schick(100) <= host_readbs(disease_ptr + 1) * 5) {
 
-					dec_ptr_bs(Real2Host(hero) + 0x41);
-					dec_ptr_bs(Real2Host(hero) + 0x40);
+					dec_ptr_bs(Real2Host(hero) + HERO_GE);
+					dec_ptr_bs(Real2Host(hero) + HERO_GE_ORIG);
 
 					j = 1;
 
@@ -457,10 +457,10 @@ void disease_effect(void)
 					dec_ptr_bs(Real2Host(hero) + HERO_KK);
 				}
 
-				if (host_readbs(Real2Host(hero) + 0x41) != 0) {
+				if (host_readbs(Real2Host(hero) + HERO_GE) != 0) {
 
 					inc_ptr_bs(disease_ptr + 3);
-					dec_ptr_bs(Real2Host(hero) + 0x41);
+					dec_ptr_bs(Real2Host(hero) + HERO_GE);
 				}
 
 				if (j == 0) {
@@ -499,12 +499,12 @@ void disease_effect(void)
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
 						dec_ptr_bs(disease_ptr + 3);
-						inc_ptr_bs(Real2Host(hero) + 0x41);
+						inc_ptr_bs(Real2Host(hero) + HERO_GE);
 					}
 				}
 			}
 
-			disease_ptr = Real2Host(hero) + 0xd1;
+			disease_ptr = Real2Host(hero) + (HERO_ILLNESS + 30);
 
 			/* RABIES / TOLLWUT: get worser */
 			if (host_readbs(disease_ptr) == -1) {
@@ -583,15 +583,15 @@ void disease_effect(void)
 			/* kill hero if KK <= 0 */
 			if (host_readbs(Real2Host(hero) + HERO_KK) <= 0) {
 
-				host_writebs(Real2Host(hero) + HERO_KK, host_readbs(Real2Host(hero) + 0x46));
+				host_writebs(Real2Host(hero) + HERO_KK, host_readbs(Real2Host(hero) + HERO_KK_ORIG));
 
 				sub_hero_le(Real2Host(hero), 5000);
 			}
 
 			/* kill hero if GE <= 0 */
-			if (host_readbs(Real2Host(hero) + 0x41) <= 0) {
+			if (host_readbs(Real2Host(hero) + HERO_GE) <= 0) {
 
-				host_writebs(Real2Host(hero) + 0x41, host_readbs(Real2Host(hero) + 0x40));
+				host_writebs(Real2Host(hero) + HERO_GE, host_readbs(Real2Host(hero) + HERO_GE_ORIG));
 
 				sub_hero_le(Real2Host(hero), 5000);
 			}

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -66,7 +66,7 @@ void rabies(RealPt hero, signed short hero_pos)
 	hero = (RealPt)ds_readd(HEROS) + SIZEOF_HERO * hero_pos;
 	host_writeb(Real2Host(hero) + HERO_SEX, sex_bak);
 
-	if (ds_readbs(0x2845) == 0) {
+	if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 		draw_status_line();
 	}
 
@@ -241,7 +241,7 @@ void rabies(RealPt hero, signed short hero_pos)
 		GRP_switch_to_next(1);
 	}
 
-	if (ds_readbs(0x2845) == 0) {
+	if (ds_readbs(PP20_INDEX) == ARCHIVE_FILE_PLAYM_UK) {
 		draw_status_line();
 	}
 }
@@ -709,7 +709,7 @@ void game_over_screen(void)
 
 	refresh_screen_size();
 
-	ds_writeb(0x2845, -1);
+	ds_writeb(PP20_INDEX, (ARCHIVE_FILE_DNGS + 13));
 }
 
 /* Borlandified and identical */

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -118,7 +118,7 @@ void rabies(RealPt hero, signed short hero_pos)
 
 				if (answer != -1) {
 
-					talent_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
+					skill_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
 				}
 
 				done = 1;
@@ -144,7 +144,7 @@ void rabies(RealPt hero, signed short hero_pos)
 						answer = select_hero_ok(get_ltx(0x62c));
 
 						if (answer != -1) {
-							talent_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
+							skill_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
 						}
 						break;
 					}
@@ -184,7 +184,7 @@ void rabies(RealPt hero, signed short hero_pos)
 								answer = select_hero_ok(get_ltx(0x62c));
 
 								if ((answer != -1) && (answer != hero_pos)) {
-									talent_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
+									skill_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
 								}
 							}
 						} else {

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -588,7 +588,7 @@ void cleanup_game(void)
 	exit_AIL();
 
 	/* disable CD-Audio */
-	if (ds_readw(0x95) != 0) {
+	if (ds_readw(0x0095) != 0) {
 		CD_audio_stop();
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -588,7 +588,7 @@ void cleanup_game(void)
 	exit_AIL();
 
 	/* disable CD-Audio */
-	if (ds_readw(0x0095) != 0) {
+	if (ds_readw(CD_INIT_SUCCESSFUL) != 0) {
 		CD_audio_stop();
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -520,7 +520,7 @@ void prepare_dirs(void)
 
 	/* delete *.* in TEMP-dir */
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)Real2Host(ds_readd(0x4c88)),
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 		(char*)p_datseg + ALL_FILES_WILDCARD2);
 
 	l_si = bc_findfirst((RealPt)ds_readd(TEXT_OUTPUT_BUF), &blk, 0);
@@ -529,7 +529,7 @@ void prepare_dirs(void)
 
 		do {
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 				((char*)(&blk)) + 30);			/* contains a filename */
 
 			bc_unlink((RealPt)ds_readd(TEXT_OUTPUT_BUF));
@@ -562,7 +562,7 @@ void prepare_dirs(void)
 		bc_close(l_di);
 
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)Real2Host(ds_readd(0x4c88)),
+			(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),
 			((char*)(&blk)) + 30);			/* contains a filename */
 
 		l_di = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0);
@@ -640,7 +640,7 @@ void cleanup_game(void)
 	/* delete all files in TEMP */
 
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)Real2Host(ds_readd(0x4c88)),	/* contains "TEMP\\%s" */
+		(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),	/* contains "TEMP\\%s" */
 		(char*)p_datseg + ALL_FILES_WILDCARD3);		/* contains "*.*" */
 
 	l_di = bc_findfirst((RealPt)ds_readd(TEXT_OUTPUT_BUF), &blk, 0);
@@ -649,7 +649,7 @@ void cleanup_game(void)
 		do {
 			/* delete each found file */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)Real2Host(ds_readd(0x4c88)),	/* contains "TEMP\\%s" */
+				(char*)Real2Host(ds_readd(STR_TEMP_XX_PTR2)),	/* contains "TEMP\\%s" */
 				((char*)(&blk)) + 30);			/* contains a filename */
 
 			bc_unlink((RealPt)ds_readd(TEXT_OUTPUT_BUF));

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -11,8 +11,16 @@
 
 #define POISON_POTIONS	(0x08d3)	/* s16 array with item IDs of poisons */
 #define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC_FIRE (0xef), -1 } */
-#define SKILLS_EXTRA	(0x0ffe)	/* (struct { signed char attrib1, attrib2, attrib3, max_inc; })[52] */
-#define SKILLS_INDEX	(0x10ce)	/* (struct { signed char first, length; })[7] = { {0,9}, {9,10}, {19,7}, {26,6}, {32,9}, {41,9}, {50,2}, } */
+#define SPELL_DESCRIPTIONS	(0x099d)	/* (struct { char unkn0, unkn1, unkn2, unkn3, cost, unkn5, unkn6, unkn7, unkn8, unkn9; })[87] */
+#define SPELLS_INDEX	(0x0d03)	/* (struct { signed char first, length; })[8] = { {1,5}, {6,12}, {18,6}, {24,3}, {27,6}, {33,5}, {38,7}, {45,4} } */
+#define SPELLS_INDEX2	(0x0d13)	/* (struct { signed char first, length; })[4] = { {49,9}, {58,2}, {60,16}, {76,10} } */
+#define MAGIC_SCHOOL_DESCRIPTIONS	(0x0d97)	/* RealPt[9] */
+#define SPELL_HANDLERS	(0x0dbb)	/* function pointer[86] */
+#define MON_SPELL_DESCRIPTIONS	(0x0f13)	/* (struct { char cost, mode, unknown1, attrib1, attrib2, attrib3, unknown2, ani_id, unknown3; })[15] */
+#define MON_SPELL_REPERTOIRE	(0x0f8b)	/* (struct { char spells[5]; })[11] */
+#define MON_SPELL_HANDLERS	(0x0fc2)	/* function pointer[15] */
+#define SKILL_DESCRIPTIONS	(0x0ffe)	/* (struct { signed char attrib1, attrib2, attrib3, max_inc; })[52] */
+#define SKILLS_INDEX	(0x10ce)	/* (struct { signed char first, length; })[7] = { {0,9}, {9,10}, {19,7}, {26,6}, {32,9}, {41,9}, {50,2} } */
 #define TWO_FIELDED_SPRITE_ID	(0x25f9)	/* char[5] array */
 #define FOOD_MESSAGE_SHOWN	(0x26a4)	/* signed char[6] */
 #define EMS_ENABLED	(0x26ab)

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -180,6 +180,7 @@
 #define CITYINDEX	(0x4222)
 #define TYPEINDEX	(0x4224)
 #define TRV_RETURN	(0x4336)	/* signed short {-1, 0, 1, 2} + ? */
+#define CAMP_INCIDENT	(0x434f)	/* signed short, -1 = not determined or will not happen, 0,1,2 = guard that will be affected */
 #define KNOWN_MONSTERS	(0x4351)	/* signed short[82] */
 #define ARSENAL_MONEY	(0x43a3)	/* signed short {-1, 0 - 60 } */
 #define ANNOUNCE_DAY	(0x43a5)	/* signed char, UNUSED */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -12,6 +12,7 @@
 #define POISON_POTIONS	(0x08d3)	/* s16 array with item IDs of poisons */
 #define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC FIRE (0xef), -1 } */
 #define TWO_FIELDED_SPRITE_ID	(0x25f9)	/* char[5] array */
+#define FOOD_MESSAGE_SHOWN	(0x26a4)	/* signed char[6] */
 #define EMS_ENABLED	(0x26ab)
 #define FIG_INITIATIVE	(0x26ac)	/* signed char, 0 = random, 1 = enemies, 2 = heroes (attack first) */
 #define FIG_MSG_COUNTER	(0x26ad)	/* signed short */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -42,6 +42,8 @@
 #define TEXT_FILE_INDEX	(0x26bd)	/* unsigned short */
 #define BUF1_FILE_INDEX	(0x26bf)	/* signed short, index of file currently stored in buffer1 */
 #define FIG_DISCARD	(0x26c1)	/* ?16 {0, 1}, whether to discard the fight data after the fight */
+#define PP20_INDEX (0x2845)	/* signed char, archive file index of current pp20 */
+#define REQUEST_REFRESH (0x2846)	/* signed short {0,1} */
 #define DEFAULT_MOUSE_CURSOR	(0x2848)	/* unsigned char[64] */
 #define ACTION_TABLE_MENU	(0x29cc)	/* (struct { signed short x1, x2, y1, y2; unsigned short action; })[2] */
 #define ACTION_TABLE_PRIMARY	(0x29e0) /* RealPt */
@@ -340,7 +342,7 @@
 #define HERO_STARTUP_ITEMS	(0xae40)	/* (struct of size 8)[13] */
 #define PREVENT_DROP_EQUIPPED_ITEMS	(0xae46)	/* unsigned char {0, 1} */
 #define HERO_STARTUP_ITEMS_ALL	(0xaea8)	/* signed short[4] */
-#define USE_SPECIAL_ITEM_HANDLERS	(0xaeb0)	/* signed short[4] */
+#define USE_SPECIAL_ITEM_HANDLERS	(0xaeb0)	/* signed short[14] */
 #define LIGHT_TYPE	(0xaee8)	/* ?16 0 = none, 1 = torch, 2 = lantern */
 #define TRAVEL_EVENT_HANDLERS	(0xaeea)	/* function pointers, long[146] */
 #define TRAVEL_EVENT_ACTIVE	(0xb132)	/* signed char {0,1} */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -151,6 +151,7 @@
 #define ALRIK_DERONDAN	(0x3f78)	/* unsigned char {0, 1} */
 #define INGERIMM_SACRIFICE	(0x3f9f)	/* unsigned char {0, 1} */
 #define INGERIMM_HINT	(0x3fa0)	/* unsigned char {0, 1} */
+
 #define UNCONSCIOUS_MESSAGE	(0x4212)	/* unsigned char[7] */
 #define FOOD_MESSAGE	(0x4219)	/* unsigned char[7] */
 #define CITYINDEX	(0x4222)
@@ -317,8 +318,8 @@
 #define SPELL_SELECT_ONES	(0xac30)	/* signed char[12] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 } */
 #define ANALUES_ITEMS	(0xac3c)	/* (struct { signed short item_id, barrier; signed char dtp; })[28] */
 #define MONSTER_SPELL_COST	(0xaccc)	/* signed short */
-#define SELECT_TALENT_LVLUP	(0xacce)	/* char[6] = "%s~%d" */
-#define SELECT_TALENT_DEFAULTS	(0xacd4)	/* signed char[6] = {44, 45, 46, -1, -1, -1} */
+#define SELECT_SKILL_LVLUP	(0xacce)	/* char[6] = "%s~%d" */
+#define SELECT_SKILL_DEFAULTS	(0xacd4)	/* signed char[6] = {44, 45, 46, -1, -1, -1} */
 #define ALCHEMY_RECIPES	(0xacda)	/* (struct of size 28)[12?] */
 #define HERO_STARTUP_ITEMS	(0xae40)	/* (struct of size 8)[13] */
 #define PREVENT_DROP_EQUIPPED_ITEMS	(0xae46)	/* unsigned char {0, 1} */
@@ -377,7 +378,7 @@
 #define SCENARIO_BUF	(0xbd2c)
 #define FIGHTOBJ_BUF	(0xbd30)	/* RealPt */
 #define HEROS	(0xbd34)
-#define RADIO_NAME_LIST	(0xbf95)	/* RealPt[15], used for items, heroes, spells, talents, recipes */
+#define RADIO_NAME_LIST	(0xbf95)	/* RealPt[15], used for items, heroes, spells, skills, recipes */
 #define TEXTBOX_WIDTH	(0xbffd)	/* signed short */
 #define TEXTBOX_POS_X	(0xbfff)	/* signed short, coordinate of upper left corner */
 #define TEXTBOX_POS_Y	(0xc001)	/* signed short, coordinate of upper left corner */
@@ -390,7 +391,7 @@
 #define TEXT_LTX	(0xc3b5)
 #define ACTION	(0xc3d9)	/* ? short */
 #define BUFFER9_PTR	(0xc3db)	/* RealPt to buffer of size 180000 (or 203000 if LARGE_BUF), used for NVF */
-#define ANI_MAIN_PTR	(0xce35)
+#define ANI_MAIN_PTR	(0xce35)	/* RealPt */
 #define GUI_TEXT_BUFFER	(0xce87)	/* unsigned char[64] */
 #define BUFFER9_PTR2	(0xd015)	/* RealPt, copy of BUFFER9_PTR */
 #define BUFFER9_PTR3	(0xd019)	/* RealPt, copy of BUFFER9_PTR */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -9,6 +9,9 @@
 #if !defined SYMBOLS_H
 #define SYMBOLS_H
 
+#define CD_INIT_SUCCESSFUL	(0x0095)	/* unsigned short {0,1} */
+#define CD_AUDIO_PAUSED	(0x00a1)	/* unsigned short {0,1} */
+#define WEARABLE_ITEMS	(0x0634)	/* RealPt[13], items wearable depending on hero type */
 #define POISON_POTIONS	(0x08d3)	/* signed short[10] = { SHURINKNOLLENGIFT (0x37), ARAXGIFT (0x38), ANGSTGIFT (0x39), SCHLAFGIFT (0x3a), GOLDLEIM (0x3b), LOTUSGIFT (0x8d), KUKRIS (0x8e), BANNSTAUB (0x8f), KROETENSCHEMELGIFT (0x90), 0xff } */
 #define HERBS_TOXIC	(0x08e7)	/* signed short[5] = { SHURINKNOLLE (0x7a), ALRAUNE (0x7e), LOTUSBLUTE (0x84), EITRIGER KROTENSCHEMEL (0x3e), 0xff } */
 #define HERBS_UNEATABLE	(0x08f1)	/* signed short[7] = { ILMENBLATT (0x80), FINAGEBÄUMCHEN (0x81), JORUGAWURZEL (0x82), KAIRANHALM (0x9d), OLGINWURZEL (0x9c), DONFSTENGEL (0x7c), 0xff } */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -479,7 +479,9 @@
 #define FIG_ACTOR_GRAMMAR_ID	(0xe2ba)	/* unsigned short */
 #define FIG_TARGET_GRAMMAR_TYPE	(0xe2bc)	/* unsigned short, 2 = hero, 1 = monster */
 #define FIG_TARGET_GRAMMAR_ID	(0xe2be)	/* unsigned short */
-#define DELAY_TIMER	(0xe2d0)
+#define DELAY_TIMER	(0xe2d0)	/* unsigned short */
+#define SAVED_FILES_BUF	(0xe2d2)	/* RealPt */
+#define LAST_SAVE_TIME	(0xe2d6)	/* signed long */
 #define SAVEGAME_NAMES	(0xe2da)	/* (char[9])[5] */
 #define DIALOG_TITLE	(0xe308)	/* RealPt */
 #define DIALOG_INFORMER	(0xe30c)	/* signed short */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -40,7 +40,7 @@
 #define CHECK_DISEASE	(0x26b9)	/* ?16 {0, 1} */
 #define CHECK_POISON	(0x26bb)	/* ?16 {0, 1} */
 #define TEXT_FILE_INDEX	(0x26bd)	/* unsigned short */
-#define BUF1_FILE_INDEX	(0x26bf)	/* signed short, index of file currently stored in buffer1 */
+#define TX_FILE_INDEX	(0x26bf)	/* signed short, index of file stored with load_tx */
 #define FIG_DISCARD	(0x26c1)	/* ?16 {0, 1}, whether to discard the fight data after the fight */
 #define PP20_INDEX (0x2845)	/* signed char, archive file index of current pp20 */
 #define REQUEST_REFRESH (0x2846)	/* signed short {0,1} */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -276,7 +276,7 @@
 #define ALL_CHR_WILDCARD3	(0x5e64)	/* char[6] = "*.CHR" */
 #define PP20_BUFFERS	(0x5e6a)	/* RealPt[9] */
 #define PP20_BUFFER_LENGTHS	(0x5e8e)	/* unsigned long[9] */
-#define CURRENT_FIGHT_NR	(0x5eb2)	/* unsigned short */
+#define CURRENT_FIGHT_ID	(0x5eb2)	/* unsigned short */
 #define INFORMER_TAB	(0x5ed6)	/* struct informer[15] */
 #define FIG_DROPPED_COUNTER	(0x5f12)	/* signed short */
 #define MAX_ENEMIES	(0x5f16)	/* signed short: an upper bound for the number of enemies */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -481,12 +481,14 @@
 #define FIG_TARGET_GRAMMAR_ID	(0xe2be)	/* unsigned short */
 #define DELAY_TIMER	(0xe2d0)
 #define SAVEGAME_NAMES	(0xe2da)	/* (char[9])[5] */
-#define DIALOG_INFORMER	(0xe30c)	/* ?16 */
-#define DIALOG_DONE	(0xe310)	/* ?16 {0, 1} */
-#define DIALOG_STATE	(0xe312)	/* ?16 */
-#define TLK_ID	(0xe314)	/* ?16 */
-#define CURRENT_FIG_NR	(0xe316)
-#define AUTOFIGHT	(0xe318)	/* ?16 */
+#define DIALOG_TITLE	(0xe308)	/* RealPt */
+#define DIALOG_INFORMER	(0xe30c)	/* signed short */
+#define DIALOG_NEXT_STATE	(0xe30e)	/* signed short */
+#define DIALOG_DONE	(0xe310)	/* signed short {0, 1} */
+#define DIALOG_STATE	(0xe312)	/* signed short */
+#define TLK_ID	(0xe314)	/* signed short */
+#define CURRENT_FIG_NR	(0xe316)	/* unsigned short */
+#define AUTOFIGHT	(0xe318)	/* signed short */
 #define FIG_DROPPED_WEAPONS	(0xe31a)	/* signed short[30] */
 #define BUFFER_WEAPANIDAT	(0xe374)	/* pointer to WEAPANI.DAT */
 #define BUFFER_ANIDAT	(0xe378)	/* pointer to ANI.DAT buffer */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -10,7 +10,9 @@
 #define SYMBOLS_H
 
 #define POISON_POTIONS	(0x08d3)	/* s16 array with item IDs of poisons */
-#define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC FIRE (0xef), -1 } */
+#define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC_FIRE (0xef), -1 } */
+#define SKILLS_EXTRA	(0x0ffe)	/* (struct { signed char attrib1, attrib2, attrib3, max_inc; })[52] */
+#define SKILLS_INDEX	(0x10ce)	/* (struct { signed char first, length; })[7] = { {0,9}, {9,10}, {19,7}, {26,6}, {32,9}, {41,9}, {50,2}, } */
 #define TWO_FIELDED_SPRITE_ID	(0x25f9)	/* char[5] array */
 #define FOOD_MESSAGE_SHOWN	(0x26a4)	/* signed char[6] */
 #define EMS_ENABLED	(0x26ab)

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -184,6 +184,7 @@
 #define MUSIC_ENABLED	(0x4476)	/* unsigned char {0,1} */
 #define SND_EFFECTS_ENABLED	(0x4477)	/* unsigned char {0,1} */
 #define MUSIC_CURRENT_TRACK	(0x447a)	/* signed short */
+#define STR_FILE_MISSING_PTR	(0x4480)	/* unsigned long == RealMake(datseg, 0x48b5) == 0x14fc'48b5 */
 #define PAUSE_STRING	(0x448a)	/* char[10] = "P A U S E" */
 #define CHECK_PARTY	(0x4495)
 #define FOOD_MOD	(0x4496)
@@ -214,6 +215,7 @@
 #define SND_TXT_HW_NOT_FOUND	(0x486d)	/* char[31] = "SOUND HARDWARE NICHT GEFUNDEN!" */
 #define FNAME_SOUND_ADV	(0x488c)	/* char[10] = "SOUND.ADV" */
 #define SND_TXT_HW_NOT_FOUND2	(0x4896)	/* char[31] == SND_TXT_HW_NOT_FOUND */
+#define STR_FILE_MISSING	(0x48b5)	/* char[20] = "FILE %s IS MISSING!" */
 #define FNAME_SCHICK_DAT	(0x48ca)	/* char[11] = "SCHICK.DAT" */
 #define SND_TXT_DISABLED_MEM2	(0x48d5)	/* char[43] = "MUSIK ABGESCHALTET - NICHT GENUG SPEICHER!" */
 #define DIARY_STRING1	(0x4900)	/* char[14] = "%2d-~%-8s~%s." */
@@ -236,7 +238,7 @@
 #define WALLCLOCK_PALETTE_NIGHT	(0x4afa)	/* (struct { unsigned char r,g,b; })[3] */
 #define COLOR_PAL_BLACK	(0x4b03)	/* char[3] = {0x3f,0x3f,0x3f} */
 #define DELAY_FACTOR	(0x4b66)
-#define STR_TEMP_XX_PTR	(0x4b68)	/* unsigned long == RealMake(datseg, 0x4b95) */
+#define STR_TEMP_XX_PTR	(0x4b68)	/* unsigned long == RealMake(datseg, 0x4b95) == 0x14fc'4b95 */
 #define FIG_STAR_COLORS	(0x4b6b)	/* signed char[13] */
 #define FIG_STAR_COUNTER	(0x4b78)	/* signed char */
 #define FIG_STAR_TIMER	(0x4b79)	/* signed short */
@@ -251,7 +253,9 @@
 #define TMAP_X	(0x4c12)	/* signed short[10] */
 #define TMAP_Y	(0x4c26)	/* signed short[10] */
 #define LOCATION_HANDLERS	(0x4c3b)	/* (void (*)(void))[19] */
+#define STR_TEMP_XX_PTR2	(0x4c88)	/* unsigned long == RealMake(datseg, 0x515e) == 0x14fc'515e */
 #define FNAMES	(0x4c8c)
+#define STR_TEMP_XX2	(0x515e)	/* char[8] = "TEMP\XX" */
 #define CHR_FILE_SUFFIX	(0x5e3e)	/* char[5] = ".CHR" */
 #define SAVEGAME_SUFFIX	(0x5e43)	/* char[5] = ".GAM" */
 #define ALL_FILES_WILDCARD	(0x5e48)	/* char[4] = "*.*" */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -11,6 +11,7 @@
 
 #define POISON_POTIONS	(0x08d3)	/* s16 array with item IDs of poisons */
 #define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC_FIRE (0xef), -1 } */
+#define STAFFSPELL_DESCRIPTIONS	(0x0973)	/* (struct { char attrib1, attrib2, attrib3, bonus, cost, ae_mod;  })[7] */
 #define SPELL_DESCRIPTIONS	(0x099d)	/* (struct { char unkn0, unkn1, unkn2, unkn3, cost, unkn5, unkn6, unkn7, unkn8, unkn9; })[87] */
 #define SPELLS_INDEX	(0x0d03)	/* (struct { signed char first, length; })[8] = { {1,5}, {6,12}, {18,6}, {24,3}, {27,6}, {33,5}, {38,7}, {45,4} } */
 #define SPELLS_INDEX2	(0x0d13)	/* (struct { signed char first, length; })[4] = { {49,9}, {58,2}, {60,16}, {76,10} } */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -68,7 +68,13 @@
 #define FIGHT_ROUND	(0x2cd7)
 #define SKILLED_HERO_POS	(0x2cdb)	/* s16 {-1, 0..6} */
 #define MR_MODIFICATORS	(0x2d27)	/* signed char[13] */
-#define CURRENT_GROUP	(0x2d35)
+
+/*
+ * Here starts the status area of the datseg,
+ * which is stored one to one in savegame files
+ */
+#define DATSEG_STATUS_START	(0x2d34)	/* unsigned char, 99 = game finished */
+#define CURRENT_GROUP	(0x2d35)	/* signed char */
 #define GROUP_MEMBER_COUNTS	(0x2d36)	/* signed char[6], members per group */
 #define TOTAL_HERO_COUNTER	(0x2d3c)	/* signed char */
 #define DIRECTION	(0x2d3d)
@@ -169,7 +175,6 @@
 #define ALRIK_DERONDAN	(0x3f78)	/* unsigned char {0, 1} */
 #define INGERIMM_SACRIFICE	(0x3f9f)	/* unsigned char {0, 1} */
 #define INGERIMM_HINT	(0x3fa0)	/* unsigned char {0, 1} */
-
 #define UNCONSCIOUS_MESSAGE	(0x4212)	/* unsigned char[7] */
 #define FOOD_MESSAGE	(0x4219)	/* unsigned char[7] */
 #define CITYINDEX	(0x4222)
@@ -181,6 +186,8 @@
 #define KNOWN_PERSONS	(0x43a6)	/* signed short[14] */
 #define DIARY_ENTRIES	(0x43b4)	/* (struct { short day, month, year, town; })[23] */
 #define DIARY_ENTRY_COUNTER	(0x43ba)	/* signed short */
+#define DATSEG_STATUS_END	(0x4474)
+
 #define MUSIC_ENABLED	(0x4476)	/* unsigned char {0,1} */
 #define SND_EFFECTS_ENABLED	(0x4477)	/* unsigned char {0,1} */
 #define MUSIC_CURRENT_TRACK	(0x447a)	/* signed short */

--- a/src/custom/schick/rewrite_m302de/symbols.h
+++ b/src/custom/schick/rewrite_m302de/symbols.h
@@ -9,8 +9,12 @@
 #if !defined SYMBOLS_H
 #define SYMBOLS_H
 
-#define POISON_POTIONS	(0x08d3)	/* s16 array with item IDs of poisons */
-#define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATIKUM (0xee), ITEM_HYLAILIC_FIRE (0xef), -1 } */
+#define POISON_POTIONS	(0x08d3)	/* signed short[10] = { SHURINKNOLLENGIFT (0x37), ARAXGIFT (0x38), ANGSTGIFT (0x39), SCHLAFGIFT (0x3a), GOLDLEIM (0x3b), LOTUSGIFT (0x8d), KUKRIS (0x8e), BANNSTAUB (0x8f), KROETENSCHEMELGIFT (0x90), 0xff } */
+#define HERBS_TOXIC	(0x08e7)	/* signed short[5] = { SHURINKNOLLE (0x7a), ALRAUNE (0x7e), LOTUSBLUTE (0x84), EITRIGER KROTENSCHEMEL (0x3e), 0xff } */
+#define HERBS_UNEATABLE	(0x08f1)	/* signed short[7] = { ILMENBLATT (0x80), FINAGEBÄUMCHEN (0x81), JORUGAWURZEL (0x82), KAIRANHALM (0x9d), OLGINWURZEL (0x9c), DONFSTENGEL (0x7c), 0xff } */
+#define ELIXIR_POTIONS	(0x08ff)	/* signed short[8] = { MU ELIXIER (0x93), KL ELIXIER (0x94), CH ELIXIER (0x95), FF ELIXIER (0x96), GE ELIXIER (0x97), IN ELIXIER (0x98), KK ELIXIER (0x99), 0xff } */
+#define BAD_ELIXIRS	(0x090f)	/* signed short[8] = { MU ELIXIER (0xe2), KL ELIXIER (0xe3), CH ELIXIER (0xe4), FF ELIXIER (0xe5), GE ELIXIER (0xe6), IN ELIXIER (0xe7), KK ELIXIER (0xe8), 0xff } */
+#define ATTACK_ITEMS	(0x091f)	/* signed short[3] = { ITEM_MIASTHMATICUM (0xee), ITEM_HYLAILIC_FIRE (0xef), -1 } */
 #define STAFFSPELL_DESCRIPTIONS	(0x0973)	/* (struct { char attrib1, attrib2, attrib3, bonus, cost, ae_mod;  })[7] */
 #define SPELL_DESCRIPTIONS	(0x099d)	/* (struct { char unkn0, unkn1, unkn2, unkn3, cost, unkn5, unkn6, unkn7, unkn8, unkn9; })[87] */
 #define SPELLS_INDEX	(0x0d03)	/* (struct { signed char first, length; })[8] = { {1,5}, {6,12}, {18,6}, {24,3}, {27,6}, {33,5}, {38,7}, {45,4} } */

--- a/src/custom/schick/schick_m302de.cpp
+++ b/src/custom/schick/schick_m302de.cpp
@@ -2018,7 +2018,7 @@ static int n_seg046(unsigned short offs)
 	}
 	case 0x08d: {
 		RealPt hero = CPU_Pop32();
-		unsigned short talent = CPU_Pop16();
+		unsigned short skill = CPU_Pop16();
 		unsigned short ftig = CPU_Pop16();
 		unsigned short x1 = CPU_Pop16();
 		unsigned short x2 = CPU_Pop16();
@@ -2027,12 +2027,12 @@ static int n_seg046(unsigned short offs)
 		CPU_Push16(x2);
 		CPU_Push16(x1);
 		CPU_Push16(ftig);
-		CPU_Push16(talent);
+		CPU_Push16(skill);
 		CPU_Push32(hero);
 
 		D1_LOG("status_show_spell(%s, %d,%d,%d,%d,%d);\n",
-			schick_getCharname(hero), talent, ftig, x1, x2, yg);
-		status_show_talent(Real2Host(hero), talent,
+			schick_getCharname(hero), skill, ftig, x1, x2, yg);
+		status_show_skill(Real2Host(hero), skill,
 			ftig, x1, x2, yg);
 
 		return 1;
@@ -2041,10 +2041,10 @@ static int n_seg046(unsigned short offs)
 		RealPt hero = CPU_Pop32();
 		CPU_Push32(hero);
 
-		D1_LOG("status_show_talents(%s);\n",
+		D1_LOG("status_show_skills(%s);\n",
 			schick_getCharname(hero));
 
-		status_show_talents(Real2Host(hero));
+		status_show_skills(Real2Host(hero));
 
 		return 1;
 	}
@@ -3454,7 +3454,7 @@ static int n_seg103(unsigned short offs)
 {
 	switch (offs) {
 	case 0x040f: {
-		// Talentprobe
+		// Skill test
 		RealPt hero = CPU_Pop32();
 		Bit16s skill = CPU_Pop16();
 		Bit16s bonus = CPU_Pop16();
@@ -3462,7 +3462,7 @@ static int n_seg103(unsigned short offs)
 		CPU_Push16(skill);
 		CPU_Push32(hero);
 
-		D1_LOG("Talentprobe: %s %+d\n ",
+		D1_LOG("Skill test: %s %+d\n ",
 			names_skill[skill], (signed char)bonus);
 
 		reg_ax = test_skill(Real2Host(hero), skill, (signed char)bonus);
@@ -3470,8 +3470,8 @@ static int n_seg103(unsigned short offs)
 		return 1;
 	}
 	case 0x0537: {
-		reg_ax = select_talent();
-		D1_LOG("select_talent() = %s\n", names_skill[reg_ax]);
+		reg_ax = select_skill();
+		D1_LOG("select_skill() = %s\n", names_skill[reg_ax]);
 		return 1;
 	}
 	case 0x06bf: {
@@ -3482,9 +3482,9 @@ static int n_seg103(unsigned short offs)
 		CPU_Push16(bonus);
 		CPU_Push16(hero);
 
-		reg_ax = use_talent(hero, (signed char)bonus, skill);
+		reg_ax = use_skill(hero, (signed char)bonus, skill);
 
-		D1_LOG("use_talent(): %s %+d\n",
+		D1_LOG("use_skill(): %s %+d\n",
 			names_skill[skill], (signed char)bonus);
 
 		return 1;
@@ -5367,7 +5367,7 @@ static int seg002(unsigned short offs) {
 		return 1;
 	}
 	case 0x504e: {
-		/* Talent-/Zauber-Probe */
+		/* Skill/spell test */
 		unsigned hero = CPU_Pop32();
 		unsigned short attrib1 = CPU_Pop16();
 		unsigned short attrib2 = CPU_Pop16();
@@ -10665,7 +10665,7 @@ static int seg102(unsigned short offs)
 
 static int seg103(unsigned short offs) {
 	switch (offs) {
-		case 0x20: { // Talentprobe
+		case 0x20: { // Skill test
 			RealPt hero = CPU_Pop32();
 			Bit16s skill = CPU_Pop16();
 			Bit16s bonus = CPU_Pop16();
@@ -10673,7 +10673,7 @@ static int seg103(unsigned short offs) {
 			CPU_Push16(skill);
 			CPU_Push32(hero);
 
-			D1_LOG("Talentprobe : %s %+d ",
+			D1_LOG("Skill test: %s %+d ",
 				names_skill[skill], (signed char)bonus);
 
 			reg_ax = test_skill(Real2Host(hero), skill,
@@ -10707,8 +10707,8 @@ static int seg103(unsigned short offs) {
 			CPU_Push16(bonus);
 			CPU_Push16(hero_pos);
 
-			reg_ax = GUI_use_talent(hero_pos, (Bit8s)bonus);
-			D1_LOG("GUI_use_talent(%d, %d) = %d\n",
+			reg_ax = GUI_use_skill(hero_pos, (Bit8s)bonus);
+			D1_LOG("GUI_use_skill(%d, %d) = %d\n",
 				hero_pos, (Bit8s)bonus, (Bit16s)reg_ax);
 			return 1;
 		}
@@ -10718,9 +10718,9 @@ static int seg103(unsigned short offs) {
 			CPU_Push16(flag);
 			CPU_Push32(hero);
 
-			reg_ax = LVL_select_talent(Real2Host(hero), flag);
+			reg_ax = LVL_select_skill(Real2Host(hero), flag);
 
-			D1_LOG("LVL_select_talent(%s, %d) = %d\n",
+			D1_LOG("LVL_select_skill(%s, %d) = %d\n",
 					schick_getCharname(hero), flag, reg_ax);
 			return 1;
 		}
@@ -10730,8 +10730,8 @@ static int seg103(unsigned short offs) {
 			CPU_Push32(msg);
 			CPU_Push16(bonus);
 
-			reg_ax = GUI_use_talent2(bonus, Real2Host(msg));
-			D1_LOG("GUI_use_talent2(%d, %s) = %d\n", bonus, Real2Host(msg), reg_ax);
+			reg_ax = GUI_use_skill2(bonus, Real2Host(msg));
+			D1_LOG("GUI_use_skill2(%d, %s) = %d\n", bonus, Real2Host(msg), reg_ax);
 			return 1;
 		}
 		default:
@@ -10774,11 +10774,11 @@ static int seg104(unsigned short offs)
 			CPU_Push32(patient);
 			CPU_Push32(healer);
 
-			reg_ax = talent_cure_disease(Real2Host(healer),
+			reg_ax = skill_cure_disease(Real2Host(healer),
 							Real2Host(patient),
 							handycap, flag);
 
-			D1_LOG("talent_cure_disease(%s, %s, %d, %d) = %d\n",
+			D1_LOG("skill_cure_disease(%s, %s, %d, %d) = %d\n",
 				schick_getCharname(healer),
 				schick_getCharname(patient),
 				handycap, flag, reg_ax);

--- a/src/custom/schick/schick_m302de.cpp
+++ b/src/custom/schick/schick_m302de.cpp
@@ -3462,7 +3462,7 @@ static int n_seg103(unsigned short offs)
 		CPU_Push16(skill);
 		CPU_Push32(hero);
 
-		D1_LOG("Skill test: %s %+d\n ",
+		D1_LOG("Talentprobe: %s %+d\n ",
 			names_skill[skill], (signed char)bonus);
 
 		reg_ax = test_skill(Real2Host(hero), skill, (signed char)bonus);
@@ -10673,7 +10673,7 @@ static int seg103(unsigned short offs) {
 			CPU_Push16(skill);
 			CPU_Push32(hero);
 
-			D1_LOG("Skill test: %s %+d ",
+			D1_LOG("Talentprobe: %s %+d ",
 				names_skill[skill], (signed char)bonus);
 
 			reg_ax = test_skill(Real2Host(hero), skill,

--- a/src/custom/schick/schick_m302de.cpp
+++ b/src/custom/schick/schick_m302de.cpp
@@ -6957,8 +6957,8 @@ static int seg026(unsigned short offs) {
 	}
 	case 0x52: {
 		Bit16s index = CPU_Pop16();
-		D1_LOG("load_buffer_1(%s)\n", get_fname(index));
-		load_buffer_1(index);
+		D1_LOG("load_tx(%s)\n", get_fname(index));
+		load_tx(index);
 		CPU_Push16(index);
 		return 1;
 	}

--- a/src/custom/schick/schick_status.cpp
+++ b/src/custom/schick/schick_status.cpp
@@ -271,7 +271,7 @@ static void schick_cmp_heros()
 	for (i = 0; i < 7; i++, hero += SIZEOF_HERO) {
 		/* check for invalid skill_attempts */
 		if ((signed char)host_readb(hero + 0x13c) < 0) {
-			D1_ERR("Original-Bug: %s hat negative Talentsteigerungen\n", (char*)(hero + 0x10));
+			D1_ERR("Original bug: %s has negative skill increasements\n", (char*)(hero + 0x10));
 			host_writeb(hero + 0x13c, 0);
 		}
 

--- a/src/custom/schick/schick_status.cpp
+++ b/src/custom/schick/schick_status.cpp
@@ -271,7 +271,7 @@ static void schick_cmp_heros()
 	for (i = 0; i < 7; i++, hero += SIZEOF_HERO) {
 		/* check for invalid skill_attempts */
 		if ((signed char)host_readb(hero + 0x13c) < 0) {
-			D1_ERR("Original bug: %s has negative skill increasements\n", (char*)(hero + 0x10));
+			D1_ERR("Original-Bug: %s hat negative Talentsteigerungen\n", (char*)(hero + 0x10));
 			host_writeb(hero + 0x13c, 0);
 		}
 


### PR DESCRIPTION
Apart from some new global vars and doxygen commits that are not covered by my last pull request (#26), this PR mainly addresses the problem that `fight_id` is used both for the id of enemies and heroes in the `FIG_LIST` (cf. global var `FIG_LIST_HEAD`) and for the id of fight descriptions in the file `FIGHT.LST`. In the latter case, I also found the alternative name `fight_nr`.

For more clarity, I propose to call the id of enemies and heroes `fighter_id` since it's the id of a fighter in the current fight, while `fight_id` (which now completely replaces `fight_nr`) is only used to describe a fight.
