### PR TITLE
M302de: BC: Introduce enum HERO_TYPE_* and NPC_*

### DIFF
--- a/src/custom/schick/rewrite_m302de/common.h
+++ b/src/custom/schick/rewrite_m302de/common.h
@@ -80,7 +80,7 @@ enum {
     HERO_NAME           = 0x000,
     HERO_NAME2          = 0x010,
     HERO_KS_TAKEN       = 0x020,
-    HERO_TYPE           = 0x021,
+    HERO_TYPE           = 0x021, /* See enum HERO_TYPE_* below. */
     HERO_SEX            = 0x022,
     HERO_HEIGHT         = 0x023,
     HERO_WEIGHT         = 0x024,
@@ -161,7 +161,7 @@ enum {
     HERO_ENEMY_ID       = 0x086, /* last enemy in fight */
     HERO_GROUP_NO       = 0x087,
     HERO_TEMPLE_ID      = 0x088,
-    HERO_NPC_ID         = 0x089, /* Held = 0, NARIELL = 1, HARIKA = 2, CURIAN = 3, ARDORA = 4, GARSVIK = 5, ERWO = 6 */
+    HERO_NPC_ID         = 0x089, /* See enum NPC_* below. */
     HERO_GROUP_POS      = 0x08A, /* 0x01 bis 0x06, 0x00 = not in group */
     HERO_HEAL_TIMER     = 0x08B,
     HERO_STAFFSPELL_TIMER   = 0x08F,
@@ -239,6 +239,33 @@ enum {
 };
 
 #define SIZEOF_HERO (0x6da)
+
+enum {
+    NPC_NONE = 0,
+    NPC_NARIELL = 1,
+    NPC_HARIKA = 2,
+    NPC_CURIAN = 3,
+    NPC_ARDORA = 4,
+    NPC_GARSVIK = 5,
+    NPC_ERWO = 6
+};
+
+enum {
+    HERO_TYPE_NONE = 0,
+    HERO_TYPE_JUGGLER = 1,
+    HERO_TYPE_HUNTER = 2,
+    HERO_TYPE_WARRIOR = 3,
+    HERO_TYPE_ESTRAY = 4,
+    HERO_TYPE_THORWALIAN = 5,
+    HERO_TYPE_DWARF = 6,
+    /* Magic users > 6 */
+    HERO_TYPE_WITCH = 7,
+    HERO_TYPE_DRUID = 8,
+    HERO_TYPE_MAGE = 9,
+    HERO_TYPE_GREEN_ELF = 10, /* Auelf */
+    HERO_TYPE_ICE_ELF = 11, /* Firnelf */
+    HERO_TYPE_SYLVAN_ELF = 12, /* Waldelf */
+};
 
 enum {
     FIG_ACTION_MOVE = 1,

--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -1603,7 +1603,7 @@ void handle_gui_input(void)
 
 			if (ds_readws(0xc3cf) != 0) {
 
-				if ((host_readbs(get_hero(l_si - 241) + HERO_TYPE) != 0) &&
+				if ((host_readbs(get_hero(l_si - 241) + HERO_TYPE) != HERO_TYPE_NONE) &&
 						host_readbs(get_hero(l_si - 241) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					status_menu(l_si - 241);
@@ -1613,7 +1613,7 @@ void handle_gui_input(void)
 				}
 			} else {
 				if ((ds_readws(0x29b4) != 0) &&
-					(host_readbs(get_hero(l_si - 241) + HERO_TYPE) != 0) &&
+					(host_readbs(get_hero(l_si - 241) + HERO_TYPE) != HERO_TYPE_NONE) &&
 						host_readbs(get_hero(l_si - 241) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					GRP_move_hero(l_si - 241);
@@ -1810,7 +1810,7 @@ void game_loop(void)
 
 		}
 
-		if ((host_readbs(get_hero(6) + HERO_TYPE) != 0) &&
+		if ((host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE) &&
 			((ds_readbs(CURRENT_TOWN) != 0) || (ds_readws(0xc3c1) == 99)) &&
 			(ds_readws(NPC_MONTHS) >= 1) &&
 			(ds_readbs(0x4494) != ds_readws(NPC_MONTHS)))
@@ -1897,7 +1897,7 @@ void timers_daily(void)
 	hero_i = get_hero(0);
 	for (i = 0; i <=6; i++, hero_i += SIZEOF_HERO) {
 
-		if ((host_readb(get_hero(i) + HERO_TYPE) != 0) &&
+		if ((host_readb(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero_i + HERO_RECIPE_TIMER) > 0))
 		{
 			dec_ptr_bs(hero_i + HERO_RECIPE_TIMER);
@@ -2262,13 +2262,9 @@ void do_timers(void)
 
 		for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-			/* check typus */
-			if ((host_readb(hero_i + HERO_TYPE) != 0) &&
-				/* unknown flag */
+			if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readb(hero_i + HERO_JAIL) != 0))
 			{
-
-				/* reset flag */
 				host_writeb(hero_i + HERO_JAIL, 0);
 
 				ds_writeb(GROUPS_LOCATION + host_readbs(hero_i + HERO_GROUP_NO),
@@ -2288,9 +2284,7 @@ void do_timers(void)
 		hero_i = get_hero(0);
 
 		for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-			/* check typus */
-			if ((host_readb(hero_i + HERO_TYPE) != 0) &&
-				/* check drunken */
+			if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readb(hero_i + HERO_DRUNK) != 0))
 			{
 				hero_get_sober(hero_i);
@@ -2311,10 +2305,7 @@ void do_timers(void)
 
 			for (i = 0; i <= 6; i++, ptr += SIZEOF_HERO) {
 
-				/* check typus */
-				if (host_readb(ptr + HERO_TYPE) != 0) {
-
-					/* get group nr */
+				if (host_readb(ptr + HERO_TYPE) != HERO_TYPE_NONE) {
 					di = host_readbs(ptr + HERO_GROUP_NO);
 
 					/* hero is in group and in mage dungeon */
@@ -2406,7 +2397,7 @@ void do_timers(void)
 			}
 
 			/* increment the months the NPC is in the group */
-			if (host_readb(get_hero(6) + HERO_TYPE) != 0) {
+			if (host_readb(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE) {
 				inc_ds_ws(NPC_MONTHS);
 			}
 
@@ -2709,8 +2700,7 @@ void seg002_2f7a(Bit32s fmin)
 	hero_i = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		/* check class */
-		if (host_readb(hero_i + HERO_TYPE) != 0) {
+		if (host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) {
 
 			/* Timer to the next healing attempt */
 			if (host_readds(hero_i + HERO_HEAL_TIMER) > 0) {
@@ -2772,8 +2762,7 @@ void sub_light_timers(Bit32s quarter)
 	hero_i = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		/* check class */
-		if (host_readb(hero_i + HERO_TYPE) != 0) {
+		if (host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) {
 
 			if (quarter > 120) {
 				tmp = 120;
@@ -2836,8 +2825,7 @@ void magical_chainmail_damage(void)
 
 	for (i = 0; i <= 6; i++) {
 
-		/* check typus */
-		if (host_readb(get_hero(i) + HERO_TYPE) != 0) {
+		if (host_readb(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) {
 
 			hero_i = get_hero(i);
 
@@ -2872,7 +2860,7 @@ void herokeeping(void)
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
 		/* consume food and set messages */
-		if (host_readb(hero + HERO_TYPE) != 0 &&		/* valid hero */
+		if (host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			ds_readb(0x4649) != 0 &&
 			check_hero_no3(hero) &&			/* must be vital */
 			!host_readbs(hero + HERO_JAIL) &&
@@ -3029,7 +3017,7 @@ void herokeeping(void)
 			!ds_readbs(0xbcda))
 		{
 
-			if ((host_readb(hero + HERO_TYPE) != 0) &&
+			if ((host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero) &&
 				(!ds_readb(TRAVELING) || ds_readb(FOOD_MESSAGE_SHOWN + i) != ds_readb(FOOD_MESSAGE + i))) {
@@ -3060,7 +3048,7 @@ void herokeeping(void)
 		/* print unconscious message */
 		if ((ds_readb(UNCONSCIOUS_MESSAGE + i) != 0) && !ds_readbs(0x2c98)) {
 
-			if (host_readb(hero + HERO_TYPE) != 0 &&
+			if (host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero)) {
 
@@ -3099,7 +3087,7 @@ void check_level_up(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				!hero_dead(hero) &&
 				(host_readbs(hero + HERO_LEVEL) < 20) &&
 				(ds_readds(LEVEL_AP_TAB + 4 * host_readbs(hero + HERO_LEVEL)) < host_readds(hero + HERO_AP)))
@@ -4203,8 +4191,8 @@ void sub_ae_splash(Bit8u *hero, signed short ae)
 		signed short tmp = ds_readw(0xc3cb);
 		ds_writew(0xc3cb, 0);
 
-		/* If Mage has 4th Staffspell */
-		if ((host_readb(hero + HERO_TYPE) == 9) && (host_readbs(hero + HERO_STAFFSPELL_LVL) >= 4)) {
+		if ((host_readb(hero + HERO_TYPE) == HERO_TYPE_MAGE) &&
+		    (host_readbs(hero + HERO_STAFFSPELL_LVL) >= 4)) {
 			ae -= 2;
 			if (ae < 0)
 				ae = 0;
@@ -4347,8 +4335,7 @@ void sub_hero_le(Bit8u *hero, signed short le)
 
 				hero_i = get_hero(0);
 				for (i = 0; i <=6; i++, hero_i += SIZEOF_HERO) {
-					/* no typus */
-					if ((host_readbs(hero_i + HERO_TYPE) != 0) &&
+					if ((host_readbs(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 						(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 					{
 						hero_disappear(hero_i, i, -1);
@@ -4474,8 +4461,7 @@ void add_group_le(signed short le)
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		/* check class and group */
-		if ((host_readb(hero + HERO_TYPE) != 0) &&
+		if ((host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
 			add_hero_le(hero, le);
@@ -4678,8 +4664,7 @@ signed short get_random_hero(void)
 		Bit8u *hero = get_hero(0);
 		for (int i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			/* Check if hero has a class */
-			if (host_readbs(hero + HERO_TYPE) == 0)
+			if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_NONE)
 				continue;
 			/* Check if in current group */
 			if (host_readbs(hero + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP))
@@ -4696,9 +4681,7 @@ signed short get_random_hero(void)
 #endif
 
 	} while (!host_readbs(get_hero(cur_hero) + HERO_TYPE) ||
-			/* Check if in current group */
 			(host_readbs(get_hero(cur_hero) + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)) ||
-			/* Check if dead */
 			hero_dead(get_hero(cur_hero)));
 
 	return cur_hero;
@@ -4718,7 +4701,6 @@ Bit32s get_party_money(void)
 	hero = get_hero(0);
 
 	for (i=0; i < 6; i++, hero += SIZEOF_HERO) {
-		/* Check if hero has a class and is in the current group */
 		if (host_readbs(hero + HERO_TYPE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
@@ -4829,7 +4811,6 @@ void add_group_ap(Bit32s ap)
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		/* Check class, group and deadness */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero_i))
@@ -4855,7 +4836,6 @@ void add_hero_ap_all(signed short ap)
 	hero_i = get_hero(0);
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		/* Check class, group and deadness */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero_i))
@@ -4885,7 +4865,6 @@ void sub_hero_ap_all(signed short ap)
 	hero_i = get_hero(0);
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		/* Check class, group and deadness */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero_i))
@@ -4963,7 +4942,6 @@ signed short get_first_hero_with_item(signed short item)
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		/* Check class and group */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
@@ -4995,7 +4973,6 @@ signed short get_first_hero_with_item_in_group(signed short item, signed short g
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		/* Check class and group */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(host_readbs(hero_i + HERO_GROUP_NO) == (signed char)group))
 		{
@@ -5104,7 +5081,6 @@ signed short count_heros_available(void)
 	hero_i = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		/* Check class */
 		/* Check if hero is available */
 		if (host_readbs(hero_i + HERO_TYPE) &&
 			(check_hero(hero_i) || check_hero_no2(hero_i)))

--- a/src/custom/schick/rewrite_m302de/seg004.cpp
+++ b/src/custom/schick/rewrite_m302de/seg004.cpp
@@ -420,7 +420,7 @@ void update_status_bars(void)
 
 			for (i = 0; i <= 6; i++) {
 
-				if (host_readbs(get_hero(i) + HERO_TYPE) != 0) {
+				if (host_readbs(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) {
 
 					hero = get_hero(i);
 

--- a/src/custom/schick/rewrite_m302de/seg025.cpp
+++ b/src/custom/schick/rewrite_m302de/seg025.cpp
@@ -163,7 +163,7 @@ void do_house(void)
 
 		for (i = 0; i < 6; i++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero) &&
 				(test_skill(hero, 17, -2) <= 0))

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -530,7 +530,7 @@ signed short save_game_state(void)
 		/* create a CHR-file for each hero in TEMP */
 		for (tw_bak = 0; tw_bak < 6; tw_bak++) {
 
-			if (host_readbs(get_hero(tw_bak) + HERO_TYPE) != 0) {
+			if (host_readbs(get_hero(tw_bak) + HERO_TYPE) != HERO_TYPE_NONE) {
 
 				/* save position on the playmask */
 				host_writebs(get_hero(tw_bak) + HERO_GROUP_POS, tw_bak + 1);
@@ -547,7 +547,7 @@ signed short save_game_state(void)
 		}
 
 		/* save the current NPC in TEMP */
-		if (host_readbs(get_hero(6) + HERO_TYPE) != 0) {
+		if (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE) {
 
 			host_writeb(get_hero(6) + HERO_GROUP_POS, 7);
 			save_npc(host_readbs(get_hero(6) + HERO_NPC_ID) + 225);

--- a/src/custom/schick/rewrite_m302de/seg028.cpp
+++ b/src/custom/schick/rewrite_m302de/seg028.cpp
@@ -518,7 +518,6 @@ void load_npc(signed short index)
 
 	if (host_readb(npc_dst + HERO_SEX) == 1) {
 		/* female */
-		/* set an unknown variable to typus + 11 */
 		host_writeb(npc_dst + HERO_SPRITE_NO, host_readb(npc_dst + HERO_TYPE) + 11);
 		if (host_readbs(npc_dst + HERO_SPRITE_NO) > 21)
 			host_writeb(npc_dst + HERO_SPRITE_NO, 21);

--- a/src/custom/schick/rewrite_m302de/seg029.cpp
+++ b/src/custom/schick/rewrite_m302de/seg029.cpp
@@ -147,7 +147,7 @@ void draw_status_line(void)
 			ds_readw(HERO_PIC_POSX + i * 2), 190,
 			ds_readw(HERO_PIC_POSX + i * 2) + 41, 197, 0);
 
-		if (host_readb(get_hero(i) + HERO_TYPE) != 0) {
+		if (host_readb(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) {
 
 			copy_forename(Real2Host(ds_readd(DTP2)),
 				get_hero(i) + HERO_NAME2);
@@ -245,7 +245,6 @@ void clear_hero_icon(unsigned short pos)
 	do_fill_rect((RealPt)ds_readd(0xd2ff), ds_readw(HERO_PIC_POSX + pos * 2), 157,
 		ds_readw(HERO_PIC_POSX + pos * 2) + 31, 188, 0);
 
-	/* return if the hero has a class */
 	if (!host_readbs(get_hero(pos) + HERO_TYPE))
 		/* fill bars area black */
 		do_fill_rect((RealPt)ds_readd(0xd2ff), ds_readw(HERO_PIC_POSX + pos * 2) + 33, 157,

--- a/src/custom/schick/rewrite_m302de/seg031.cpp
+++ b/src/custom/schick/rewrite_m302de/seg031.cpp
@@ -378,7 +378,7 @@ void drink_while_drinking(signed short amount)
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero)) {
 
@@ -411,7 +411,7 @@ void eat_while_drinking(signed short amount)
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero)) {
 

--- a/src/custom/schick/rewrite_m302de/seg032.cpp
+++ b/src/custom/schick/rewrite_m302de/seg032.cpp
@@ -168,7 +168,7 @@ signed short FIG_choose_next_hero(void)
 
 	/* search for a hero who has a class, is in the current group and
 		something still unknown */
-	} while (host_readb(get_hero(retval) + HERO_TYPE) == 0 ||
+	} while (host_readb(get_hero(retval) + HERO_TYPE) == HERO_TYPE_NONE ||
 			host_readb(get_hero(retval) + HERO_GROUP_NO) != ds_readb(CURRENT_GROUP) ||
 			host_readb(get_hero(retval) + HERO_ACTIONS) == 0);
 
@@ -311,8 +311,7 @@ signed short FIG_get_first_active_hero(void)
 	hero_i = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		/* check class */
-		if ((host_readb(hero_i + HERO_TYPE) != 0) &&
+		if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 			!hero_dead(hero_i) &&
 			!hero_stoned(hero_i) &&
@@ -344,7 +343,7 @@ unsigned short seg032_02db(void)
 	if (FIG_get_first_active_hero() == -1) {
 		hero_i = get_hero(0);
 		for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-			if ((host_readb(hero_i + HERO_TYPE) != 0) &&
+			if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 				!hero_dead(hero_i) &&
 				(host_readb(hero_i + HERO_ACTION_ID) == FIG_ACTION_UNKNOWN1))
@@ -411,7 +410,7 @@ void FIG_do_round(void)
 
 		hero = (RealPt)ds_readd(HEROS) + SIZEOF_HERO * i;
 
-		if ((host_readbs(Real2Host(hero) + HERO_TYPE) != 0) &&
+		if ((host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			(host_readbs(Real2Host(hero) + HERO_ACTION_ID) != FIG_ACTION_UNKNOWN1))
 		{
@@ -1007,7 +1006,7 @@ signed short do_fight(signed short fight_id)
 		hero = get_hero(0);
 		for (l_di = 0; l_di <=6; l_di++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0)
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE)
 				&& (host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 			{
 
@@ -1035,7 +1034,7 @@ signed short do_fight(signed short fight_id)
 					ptr = get_hero(0);
 					for (l1 = 0; l1 <=6; l1++, ptr += SIZEOF_HERO) {
 
-						if ((host_readbs(ptr + HERO_TYPE) != 0)
+						if ((host_readbs(ptr + HERO_TYPE) != HERO_TYPE_NONE)
 							&& (host_readbs(ptr + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 						{
 							hero_disappear(ptr, l1, -2);

--- a/src/custom/schick/rewrite_m302de/seg036.cpp
+++ b/src/custom/schick/rewrite_m302de/seg036.cpp
@@ -803,7 +803,7 @@ void KI_hero(Bit8u *hero, signed short hero_pos, signed short x, signed short y)
 	host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_MOVE);
 	if (host_readbs(hero + HERO_NPC_ID) > 0) {
 
-		if (host_readbs(hero + HERO_NPC_ID) == 1) {
+		if (host_readbs(hero + HERO_NPC_ID) == NPC_NARIELL) {
 			/* equip LONGBOW and ARROWS in the first round,
 			 * if the hero has them in the inventory */
 			if ((ds_readws(FIGHT_ROUND) == 0) &&
@@ -818,7 +818,7 @@ void KI_hero(Bit8u *hero, signed short hero_pos, signed short x, signed short y)
 				}
 			}
 
-		} else if (host_readbs(hero + HERO_NPC_ID) == 2) {
+		} else if (host_readbs(hero + HERO_NPC_ID) == NPC_HARIKA) {
 
 			if (host_readws(hero + HERO_LE) <= 12) {
 
@@ -840,7 +840,7 @@ void KI_hero(Bit8u *hero, signed short hero_pos, signed short x, signed short y)
 				}
 			}
 
-		} else if (host_readbs(hero + HERO_NPC_ID) == 3) {
+		} else if (host_readbs(hero + HERO_NPC_ID) == NPC_CURIAN) {
 
 			if ((host_readws(hero + HERO_LE) < 10) &&
 				(host_readws(hero + HERO_AE) < 10))
@@ -848,20 +848,20 @@ void KI_hero(Bit8u *hero, signed short hero_pos, signed short x, signed short y)
 				host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_UNKNOWN1);
 			}
 
-		} else if (host_readbs(hero + HERO_NPC_ID) == 4) {
+		} else if (host_readbs(hero + HERO_NPC_ID) == NPC_ARDORA) {
 
 			if (host_readws(hero + HERO_LE) < 8)
 			{
 				host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_UNKNOWN1);
 			}
 
-		} else if (host_readbs(hero + HERO_NPC_ID) == 5) {
+		} else if (host_readbs(hero + HERO_NPC_ID) == NPC_GARSVIK) {
 
 			if (!KI_count_heros(hero_pos)) {
 				host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_UNKNOWN1);
 			}
 
-		} else if (host_readbs(hero + HERO_NPC_ID) == 6) {
+		} else if (host_readbs(hero + HERO_NPC_ID) == NPC_ERWO) {
 
 			if (host_readws(hero + HERO_LE) < 15)
 			{

--- a/src/custom/schick/rewrite_m302de/seg038.cpp
+++ b/src/custom/schick/rewrite_m302de/seg038.cpp
@@ -394,7 +394,7 @@ signed short seg038(Bit8u *in_ptr, signed short a1, signed short x_in, signed sh
 
 				hero_ptr = get_hero(i);
 
-				if ((host_readbs(hero_ptr + HERO_TYPE) != 0) &&
+				if ((host_readbs(hero_ptr + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero_ptr + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero_ptr))
 				{

--- a/src/custom/schick/rewrite_m302de/seg039.cpp
+++ b/src/custom/schick/rewrite_m302de/seg039.cpp
@@ -423,8 +423,7 @@ void FIG_init_heroes(void)
 	for (l_si = 0; l_si <= 6; l_si++) {
 		hero = get_hero(l_si);
 
-		/* check typus */
-		if (host_readb(hero + HERO_TYPE) == 0)
+		if (host_readb(hero + HERO_TYPE) == HERO_TYPE_NONE)
 			continue;
 		/* check group */
 		if (host_readb(hero + HERO_GROUP_NO) != ds_readb(CURRENT_GROUP))

--- a/src/custom/schick/rewrite_m302de/seg041.cpp
+++ b/src/custom/schick/rewrite_m302de/seg041.cpp
@@ -298,7 +298,7 @@ signed short FIG_get_hero_melee_attack_damage(Bit8u* hero, Bit8u* target, signed
 			p3 = p_datseg + 0x0668 + host_readbs(p2 + 4) * 8;
 
 			if (attack_hero != 0) {
-				if (host_readbs(target + HERO_TYPE) == 6) {
+				if (host_readbs(target + HERO_TYPE) == HERO_TYPE_DWARF) {
 					/* ZWERG / DWARF */
 					target_size = 2;
 				} else {
@@ -408,7 +408,7 @@ signed short FIG_get_hero_melee_attack_damage(Bit8u* hero, Bit8u* target, signed
 	}
 
 	if ((ds_readbs(0x3dda) != 0) &&
-		(host_readbs(hero + HERO_TYPE) == 6) &&
+		(host_readbs(hero + HERO_TYPE) == HERO_TYPE_DWARF) &&
 		(attack_hero == 0) &&
 		(host_readbs(enemy_p + ENEMY_SHEET_GFX_ID) == 0x18))
 	{

--- a/src/custom/schick/rewrite_m302de/seg042.cpp
+++ b/src/custom/schick/rewrite_m302de/seg042.cpp
@@ -228,7 +228,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 
 			/* after destroying the orc statuette between Oberorken and Felsteyn, dwarfs get a PA-bonus against orcs */
 			if ((ds_readbs(0x3dda) != 0) &&
-				(host_readbs(Real2Host(hero) + HERO_TYPE) == 6) &&
+				(host_readbs(Real2Host(hero) + HERO_TYPE) == HERO_TYPE_DWARF) &&
 				(attack_hero == 0) &&
 				(host_readbs(target_monster + ENEMY_SHEET_GFX_ID) == 24))
 			{

--- a/src/custom/schick/rewrite_m302de/seg043.cpp
+++ b/src/custom/schick/rewrite_m302de/seg043.cpp
@@ -188,7 +188,7 @@ void FIG_do_monster_action(RealPt monster, signed short monster_pos)
 
 				/* after destroying the orc statuette between Oberorken and Felsteyn, dwarfs get a PA-bonus against orcs */
 				if ((ds_readbs(0x3dda) != 0) &&
-					(host_readbs(hero + HERO_TYPE) == 6) &&
+					(host_readbs(hero + HERO_TYPE) == HERO_TYPE_DWARF) &&
 					(host_readbs(Real2Host(monster) + ENEMY_SHEET_GFX_ID) == 24))
 				{
 					pa++;

--- a/src/custom/schick/rewrite_m302de/seg044.cpp
+++ b/src/custom/schick/rewrite_m302de/seg044.cpp
@@ -181,7 +181,7 @@ void FIG_prepare_hero_fight_ani(signed short a1, Bit8u *hero, signed short weapo
 		dir = host_readbs(hero + HERO_VIEWDIR);
 	}
 
-	if ((weapon_type == -1) || ((host_readbs(hero + HERO_TYPE) == 9) && (weapon == 0x85))) {
+	if ((weapon_type == -1) || ((host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE) && (weapon == 0x85))) {
 
 		l1 = (f_action == 2) ? 45 :			/* melee attack */
 			(f_action == 102) ? 41 :		/* drink potion */
@@ -270,8 +270,8 @@ void FIG_prepare_hero_fight_ani(signed short a1, Bit8u *hero, signed short weapo
 		p1 += copy_ani_seq(p1, host_readws(p3 + l1 *2), 2);
 
 		if ((weapon_type != -1) && (weapon_type < 3) &&
-			(host_readb(hero + HERO_TYPE) != 9) &&
-			(host_readb(hero + HERO_TYPE) != 8))
+			(host_readb(hero + HERO_TYPE) != HERO_TYPE_MAGE) &&
+			(host_readb(hero + HERO_TYPE) != HERO_TYPE_DRUID))
 		{
 			for (l10 = 0; l10 < 5; l10++) {
 				host_writeb(p2++, 0xfb);
@@ -292,8 +292,8 @@ void FIG_prepare_hero_fight_ani(signed short a1, Bit8u *hero, signed short weapo
 			p1 += copy_ani_seq(p1, host_readws(p3 + l1 * 2), 2);
 
 			if ((weapon_type != -1) && (weapon_type < 3) &&
-				(host_readb(hero + HERO_TYPE) != 9) &&
-				(host_readb(hero + HERO_TYPE) != 8))
+				(host_readb(hero + HERO_TYPE) != HERO_TYPE_MAGE) &&
+				(host_readb(hero + HERO_TYPE) != HERO_TYPE_DRUID))
 			{
 				p2 += copy_ani_seq(p2,
 					ds_readw(0x25fe +
@@ -320,8 +320,8 @@ void FIG_prepare_hero_fight_ani(signed short a1, Bit8u *hero, signed short weapo
 		host_writebs(p1, -1);
 
 		if ( (weapon_type != -1) && (weapon_type < 3) &&
-			(host_readb(hero + HERO_TYPE) != 9) &&
-			(host_readb(hero + HERO_TYPE) != 8))
+			(host_readb(hero + HERO_TYPE) != HERO_TYPE_MAGE) &&
+			(host_readb(hero + HERO_TYPE) != HERO_TYPE_DRUID))
 		{
 			FIG_set_0f(host_readb(hero + HERO_FIGHTER_ID), a1 + 4);
 			host_writeb(p2, 0xff);

--- a/src/custom/schick/rewrite_m302de/seg047.cpp
+++ b/src/custom/schick/rewrite_m302de/seg047.cpp
@@ -42,8 +42,7 @@ unsigned short get_hero_CH_best()
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 
-		if ((host_readb(hero_i + HERO_TYPE) != 0) &&
-				/* check class */
+		if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 				/* check if in group */
 			(!hero_dead(hero_i)) &&
@@ -74,8 +73,7 @@ unsigned short get_hero_KK_best() {
 	hero_i = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		if ((host_readb(hero_i + HERO_TYPE) != 0) &&
-				/* check class */
+		if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 				/* check if in group */
 			(!hero_dead(hero_i)) &&
@@ -152,7 +150,7 @@ void hero_gets_diseased(Bit8u *hero, unsigned short disease)
 {
 #ifdef M302de_ORIGINAL_BUGFIX
 	/* not a real BUG, but very useless */
-	if (host_readb(hero + HERO_TYPE) == 0)
+	if (host_readb(hero + HERO_TYPE) == HERO_TYPE_NONE)
 		return;
 #endif
 
@@ -181,7 +179,7 @@ void hero_disease_test(Bit8u *hero, unsigned short disease, signed short probabi
 
 #ifdef M302de_ORIGINAL_BUGFIX
 	/* not a real BUG, but very useless */
-	if (host_readb(hero + HERO_TYPE) == 0) {
+	if (host_readb(hero + HERO_TYPE) == HERO_TYPE_NONE) {
 		D1_ERR("WARNING: called %s with an invalid hero\n", __func__);
 		return;
 	}
@@ -420,7 +418,7 @@ signed short select_hero_from_group(Bit8u *title)
 
 		hero = (RealPt)ds_readd(HEROS) + i * SIZEOF_HERO;
 
-		if (host_readb(Real2Host(hero) + HERO_TYPE) != 0 &&
+		if (host_readb(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readb(Real2Host(hero) + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 				/* TODO: find out what that means */
 				ds_readbs(0x64a2) != i) {
@@ -495,7 +493,7 @@ signed short select_hero_ok(Bit8u *title)
 
 	for (hero = (RealPt)ds_readd(HEROS), i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readb(Real2Host(hero) + HERO_TYPE) != 0 &&
+		if (host_readb(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readb(Real2Host(hero) + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 			check_hero(Real2Host(hero)) &&
 				/* TODO: find out what that means */
@@ -573,7 +571,7 @@ signed short select_hero_ok_forced(Bit8u *title)
 
 	for (hero = (RealPt)ds_readd(HEROS), i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readb(Real2Host(hero) + HERO_TYPE) != 0 &&
+		if (host_readb(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readb(Real2Host(hero) + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 			check_hero(Real2Host(hero)) &&
 				/* TODO: find out what that means */
@@ -635,7 +633,7 @@ signed short count_heroes_in_group(void)
 
 	for (hero_i = get_hero(0), i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
 		/* Check class, group and dead */
-		if ((host_readb(hero_i + HERO_TYPE) != 0) &&
+		if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 			(!hero_dead(hero_i))) {
 

--- a/src/custom/schick/rewrite_m302de/seg049.cpp
+++ b/src/custom/schick/rewrite_m302de/seg049.cpp
@@ -35,9 +35,9 @@ int GRP_compare_heros(const void *p1, const void *p2)
 	hero1 = (Bit8u*)p1;
 	hero2 = (Bit8u*)p2;
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 	{
 		if (host_readbs(hero1 + HERO_GROUP_POS) < host_readbs(hero2 + HERO_GROUP_POS))
@@ -48,25 +48,25 @@ int GRP_compare_heros(const void *p1, const void *p2)
 		}
 	}
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)))
 	{
 		return -1;
 	}
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 	{
 		return 1;
 	}
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)))
 	{
 		if (host_readbs(hero1 + HERO_GROUP_POS) < host_readbs(hero2 + HERO_GROUP_POS))
@@ -78,14 +78,14 @@ int GRP_compare_heros(const void *p1, const void *p2)
 	}
 
 	if (!(host_readbs(hero1 + HERO_TYPE)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 	{
 		return 1;
 	}
 
 	if (!(host_readbs(hero1 + HERO_TYPE)) &&
-		(host_readbs(hero2 + HERO_TYPE) != 0) &&
+		(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero2 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)))
 	{
 		return -1;
@@ -97,14 +97,14 @@ int GRP_compare_heros(const void *p1, const void *p2)
 		return 0;
 	}
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 		!(host_readbs(hero2 + HERO_TYPE)))
 	{
 		return -1;
 	}
 
-	if ((host_readbs(hero1 + HERO_TYPE) != 0) &&
+	if ((host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) &&
 		(host_readbs(hero1 + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP)) &&
 		!(host_readbs(hero2 + HERO_TYPE)))
 	{
@@ -167,7 +167,7 @@ void GRP_split(void)
 	signed short not_empty;
 	signed short answer;
 
-	if (count_heroes_available_in_group() <= (host_readbs(get_hero(6) + HERO_TYPE) != 0 ? 2 : 1)) {
+	if (count_heroes_available_in_group() <= (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE ? 2 : 1)) {
 
 		GUI_output(get_ltx(0x808));
 	} else {
@@ -193,7 +193,7 @@ void GRP_split(void)
 				dec_ds_bs_post(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP));
 			}
 
-		} while	(count_heroes_available_in_group() > (host_readbs(get_hero(6) + HERO_TYPE) != 0 ? 2 : 1));
+		} while	(count_heroes_available_in_group() > (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE ? 2 : 1));
 
 		if (not_empty) {
 			GRP_save_pos(new_group);
@@ -233,7 +233,7 @@ void GRP_merge(void)
 
 			for (i = 0; i <= 6; i++) {
 
-				if ((host_readbs(get_hero(i) + HERO_TYPE) != 0) &&
+				if ((host_readbs(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) &&
 					host_readbs(get_hero(i) + HERO_GROUP_NO) == answer)
 				{
 					host_writeb(get_hero(i) + HERO_GROUP_NO, ds_readbs(CURRENT_GROUP));
@@ -273,7 +273,7 @@ void GRP_switch_to_next(signed short mode)
 
 			for (i = 0; i < 6; i++) {
 
-				if ((host_readbs(get_hero(i) + HERO_TYPE) != 0) &&
+				if ((host_readbs(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(get_hero(i) + HERO_GROUP_NO) == group) &&
 					check_hero(get_hero(i)))
 				{

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -45,14 +45,14 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 	signed short randval;
 	struct dummy a = *(struct dummy*)(p_datseg + 0x6682);
 
-	if ((host_readbs(hero + HERO_TYPE) == 7) &&
+	if ((host_readbs(hero + HERO_TYPE) == HERO_TYPE_WITCH) &&
 		(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 2))
 	{
 		/* spell is a warlock spell */
 		l_di = 2;
 	}
 
-	if ((host_readbs(hero + HERO_TYPE) >= 10) &&
+	if ((host_readbs(hero + HERO_TYPE) >= HERO_TYPE_GREEN_ELF) &&
 		((ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 3) ||
 			(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 5) ||
 			(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 4)))
@@ -61,14 +61,14 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 		l_di = 2;
 	}
 
-	if ((host_readbs(hero + HERO_TYPE) == 8) &&
+	if ((host_readbs(hero + HERO_TYPE) == HERO_TYPE_DRUID) &&
 		(ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 0))
 	{
 		/* spell is a druid spell */
 		l_di = 2;
 	}
 
-	if (host_readbs(hero + HERO_TYPE) == 9) {
+	if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE) {
 
 		/* mages */
 		if (ds_readbs((SPELL_DESCRIPTIONS + 0) + 10 * spell) == 1) {
@@ -592,7 +592,7 @@ void level_up(signed short hero_pos)
 		add_hero_ae(hero, i - l_si);
 
 		/* change skill increasements into AE */
-		if (host_readbs(hero + HERO_TYPE) == 9 && ds_readws(GAME_MODE) == 2) {
+		if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE && ds_readws(GAME_MODE) == 2) {
 
 			if (GUI_bool(get_city(0xa0))) {
 				/* trade 10 skill increasements into 1W6+2 AE */
@@ -666,7 +666,7 @@ void level_up(signed short hero_pos)
 
 				switch (host_readbs(hero + HERO_TYPE)) {
 
-					case 7: {
+					case HERO_TYPE_WITCH: {
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
@@ -685,7 +685,7 @@ void level_up(signed short hero_pos)
 
 						break;
 					}
-					case 8: {
+					case HERO_TYPE_DRUID: {
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
@@ -704,7 +704,7 @@ void level_up(signed short hero_pos)
 
 						break;
 					}
-					case 9: {
+					case HERO_TYPE_MAGE: {
 
 						i = 0;
 
@@ -748,7 +748,7 @@ void level_up(signed short hero_pos)
 
 						break;
 					}
-					case 10: {
+					case HERO_TYPE_GREEN_ELF: {
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
@@ -776,7 +776,7 @@ void level_up(signed short hero_pos)
 
 						break;
 					}
-					case 11: {
+					case HERO_TYPE_ICE_ELF: {
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 
@@ -803,7 +803,7 @@ void level_up(signed short hero_pos)
 						}
 						break;
 					}
-					case 12: {
+					case HERO_TYPE_SYLVAN_ELF: {
 
 						while (host_readbs(hero + HERO_SP_RISE) != 0 && i < 86) {
 

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -324,7 +324,7 @@ void do_wildcamp(void)
 					hero = (RealPt)ds_readd(HEROS);
 
 					for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
-						if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+						if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							ds_readbs(WILDCAMP_GUARDSTATUS + i) < 2 &&
 							ds_readbs(WILDCAMP_MAGICSTATUS + i) != 1)
@@ -521,7 +521,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 						/* fill up all waterskins and remove thirst of all living heros in the current group */
 						hero2 = get_hero(0);
 						for (l_di = 0; l_di <= 6; l_di++, hero2 += SIZEOF_HERO) {
-							if (host_readbs(hero2 + HERO_TYPE) != 0 &&
+							if (host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dead(hero2))
 							{
@@ -551,7 +551,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 						/* remove hunger of all living heros in the current group */
 						hero2 = get_hero(0);
 						for (l_di = 0; l_di <= 6; l_di++, hero2 += SIZEOF_HERO) {
-							if (host_readbs(hero2 + HERO_TYPE) != 0 &&
+							if (host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dead(hero2))
 							{

--- a/src/custom/schick/rewrite_m302de/seg052.cpp
+++ b/src/custom/schick/rewrite_m302de/seg052.cpp
@@ -269,7 +269,7 @@ void do_citycamp(void)
 						hero = (RealPt)ds_readd(HEROS);
 						for (l_si = 0; l_si <= 6; l_si++, hero += SIZEOF_HERO) {
 
-							if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+							if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								ds_readbs(CITYCAMP_GUARDSTATUS + l_si) < 2 &&
 								ds_readbs(CITYCAMP_MAGICSTATUS + l_si) != 1)

--- a/src/custom/schick/rewrite_m302de/seg054.cpp
+++ b/src/custom/schick/rewrite_m302de/seg054.cpp
@@ -44,7 +44,7 @@ RealPt get_first_busy_hero(void)
 
 	hero = (RealPt)ds_readd(HEROS);
 	for (i = 0; i < 6; i++, hero += SIZEOF_HERO) {
-		if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+		if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(Real2Host(hero) + HERO_GROUP_NO) != ds_readbs(CURRENT_GROUP) &&
 			hero_busy(Real2Host(hero)) &&
 			host_readbs(Real2Host(hero) + HERO_HOSTEL_ID) == ds_readws(TYPEINDEX))
@@ -227,7 +227,7 @@ void do_inn(void)
 
 					for (i = 0, hero2 = get_hero(0); i <= 6; i++, hero2 += SIZEOF_HERO) {
 
-						if (host_readbs(hero2 + HERO_TYPE) != 0 &&
+						if (host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							!hero_dead(hero2))
 						{
@@ -386,7 +386,7 @@ void do_inn(void)
 					hero = (RealPt)ds_readd(HEROS);
 					for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-						if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+						if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 						{
 							if (booked_days > 1) {

--- a/src/custom/schick/rewrite_m302de/seg056.cpp
+++ b/src/custom/schick/rewrite_m302de/seg056.cpp
@@ -309,7 +309,7 @@ void buy_screen(void)
 						ds_readws(HERO_PIC_POSX + 2 * l_di) + 41,
 						197, 0);
 
-				if (host_readbs(hero1 + HERO_TYPE) != 0) {
+				if (host_readbs(hero1 + HERO_TYPE) != HERO_TYPE_NONE) {
 					copy_forename(Real2Host(ds_readd(DTP2)), hero1 + HERO_NAME2);
 					set_textcolor(255, 0);
 

--- a/src/custom/schick/rewrite_m302de/seg057.cpp
+++ b/src/custom/schick/rewrite_m302de/seg057.cpp
@@ -536,7 +536,7 @@ void sell_screen(Bit8u *shop_ptr)
 			hero_pos = ds_readws(ACTION) - 241;
 			hero3 = get_hero(hero_pos);
 
-			if ((host_readbs(hero3 + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero3 + HERO_TYPE) != HERO_TYPE_NONE) &&
 				host_readbs(hero3 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 			{
 				hero1 = get_hero(hero_pos);

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -156,7 +156,7 @@ void do_tavern(void)
 
 					ds_writeb(FOOD_MESSAGE + i, ds_writeb(FOOD_MESSAGE_SHOWN + i, 0));
 
-					if (host_readbs(get_hero(i) + HERO_TYPE) != 0 &&
+					if (host_readbs(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(get_hero(i) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 					{
 

--- a/src/custom/schick/rewrite_m302de/seg061.cpp
+++ b/src/custom/schick/rewrite_m302de/seg061.cpp
@@ -420,7 +420,7 @@ void miracle_heal_hero(signed short le_in, Bit8u *str)
 	for (i = 0; i <= 6; i++) {
 		hero = get_hero(i);
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			!hero_dummy4(hero) &&
@@ -503,7 +503,7 @@ void miracle_modify(unsigned short offset, Bit32s timer_value, signed short mod)
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+		if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(Real2Host(hero)) &&
 			!hero_dummy4(Real2Host(hero)))
@@ -536,7 +536,7 @@ void miracle_weapon(Bit8u *str, signed short mode)
 
 		hero = get_hero(j);
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			!hero_dummy4(hero))

--- a/src/custom/schick/rewrite_m302de/seg062.cpp
+++ b/src/custom/schick/rewrite_m302de/seg062.cpp
@@ -193,7 +193,7 @@ void ask_miracle(void)
 						for (i = 0; i <= 6; i++) {
 							hero = get_hero(i);
 
-							if (host_readbs(hero + HERO_TYPE) != 0 &&
+							if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dummy4(hero))
 							{
@@ -316,7 +316,7 @@ void ask_miracle(void)
 						hero = get_hero(0);
 						for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-							if (host_readbs(hero + HERO_TYPE) != 0 &&
+							if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dead(hero) &&
 								!hero_dummy4(hero))
@@ -395,7 +395,7 @@ void ask_miracle(void)
 						for (i = 0; i <= 6; i++) {
 							hero = get_hero(i);
 
-							if (host_readbs(hero + HERO_TYPE) != 0 &&
+							if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dead(hero) &&
 								!hero_dummy4(hero))
@@ -451,7 +451,7 @@ void ask_miracle(void)
 							hero = get_hero(0);
 							for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-								if (host_readbs(hero + HERO_TYPE) != 0 &&
+								if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 									host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 									!hero_dead(hero) &&
 									!hero_dummy4(hero))

--- a/src/custom/schick/rewrite_m302de/seg063.cpp
+++ b/src/custom/schick/rewrite_m302de/seg063.cpp
@@ -315,7 +315,7 @@ void do_harbour(void)
 					hero = get_hero(0);
 					for (l_si = 0; l_si <= 6; l_si++, hero += SIZEOF_HERO) {
 
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 						{
 							GRP_hero_sleep(hero, a.a[ds_readbs(0xe3fa)]);
@@ -542,7 +542,7 @@ void sea_travel(signed short passage, signed short dir)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					GRP_hero_sleep(hero, a.a[ds_readbs(0xe3fa)]);

--- a/src/custom/schick/rewrite_m302de/seg068.cpp
+++ b/src/custom/schick/rewrite_m302de/seg068.cpp
@@ -550,7 +550,7 @@ void THO_academy(void)
 	hero = get_hero(0);
 	for (item_pos = cursed_hero_pos = 0; item_pos <= 6; item_pos++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			hero_cursed(hero))
 		{
@@ -750,7 +750,7 @@ signed short academy_get_equal_item(signed short price)
 		hero = get_hero(0);
 		for (i = 0; i < 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{

--- a/src/custom/schick/rewrite_m302de/seg070.cpp
+++ b/src/custom/schick/rewrite_m302de/seg070.cpp
@@ -166,7 +166,7 @@ void PHX_spielhaus(void)
 
 		for (pos = counter = answer = 0; pos <= 6; pos++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero) &&
 				(test_skill(hero, 43, 3) > 0))

--- a/src/custom/schick/rewrite_m302de/seg072.cpp
+++ b/src/custom/schick/rewrite_m302de/seg072.cpp
@@ -282,7 +282,7 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 			} else if (state == 2) {
 				/* is ERWO in the group ? */
 				ds_writew(DIALOG_NEXT_STATE,
-					host_readbs(get_hero(6) + HERO_NPC_ID) == 6 && is_hero_available_in_group(get_hero(6)) ? 3 : 15);
+					host_readbs(get_hero(6) + HERO_NPC_ID) == NPC_ERWO && is_hero_available_in_group(get_hero(6)) ? 3 : 15);
 			} else if (state == 6) {
 
 				/* copy the name */
@@ -543,7 +543,7 @@ void INF_olvir_asgrimm(signed short informer, signed short state)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if ((host_readbs(hero + HERO_TYPE) != 0) &&
+				if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero))
 				{

--- a/src/custom/schick/rewrite_m302de/seg074.cpp
+++ b/src/custom/schick/rewrite_m302de/seg074.cpp
@@ -189,7 +189,7 @@ signed short is_group_in_prison(signed short group_nr)
 
 	for (i = 0; i < 6; i++, hero += SIZEOF_HERO) {
 
-		if ((host_readbs(hero + HERO_TYPE) != 0) &&
+		if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == group_nr))
 		{
 			return host_readbs(hero + HERO_JAIL);

--- a/src/custom/schick/rewrite_m302de/seg075.cpp
+++ b/src/custom/schick/rewrite_m302de/seg075.cpp
@@ -884,10 +884,10 @@ signed short DNG_check_climb_tools(void)
 	/* check for a mage with staffspell > 2 */
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if ((host_readbs(hero + HERO_TYPE) != 0) &&
+		if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero) &&
-			(host_readbs(hero + HERO_TYPE) == 9) &&
+			(host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE) &&
 			(host_readbs(hero + HERO_STAFFSPELL_LVL) > 2))
 		{
 			return i + 1;

--- a/src/custom/schick/rewrite_m302de/seg076.cpp
+++ b/src/custom/schick/rewrite_m302de/seg076.cpp
@@ -355,7 +355,7 @@ void DNG_fallpit_test(signed short max_damage)
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
 			/* TODO: need to check if the hero is dead ? */
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 			{
 				sub_hero_le(hero, random_schick(max_damage));
@@ -861,7 +861,7 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 			hero = get_hero(0);
 			for (l_di = 0; l_di <= 6; l_di++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -898,7 +898,7 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 			hero = get_hero(0);
 			for (hero_refilled_counter = l_di = 0; l_di <= 6; l_di++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{

--- a/src/custom/schick/rewrite_m302de/seg077.cpp
+++ b/src/custom/schick/rewrite_m302de/seg077.cpp
@@ -121,7 +121,7 @@ signed short DNG01_handler(void)
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
 				if (random_schick(100) <= 10 &&
-					host_readbs(hero + HERO_TYPE) != 0 &&
+					host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					sub_hero_le(hero, 2);
@@ -149,7 +149,7 @@ signed short DNG01_handler(void)
 
 			GUI_dialogbox(ds_readfp(DTP2), get_ltx(0xbd0), get_dtp(0x24), 0);
 
-			if (host_readbs(get_hero(6) + HERO_TYPE) != 0)
+			if (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE)
 			{
 				remove_npc(host_readbs(get_hero(6) + HERO_NPC_ID) + 19,
 						31,

--- a/src/custom/schick/rewrite_m302de/seg078.cpp
+++ b/src/custom/schick/rewrite_m302de/seg078.cpp
@@ -150,7 +150,7 @@ signed short DNG02_handler(void)
 		hero = get_hero(0);
 		for (i = weight_sum = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 			{
 				weight_sum += get_hero_weight(hero);
@@ -189,7 +189,7 @@ signed short DNG02_handler(void)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -201,7 +201,7 @@ signed short DNG02_handler(void)
 			hero = get_hero(0);
 			for (i = mod_slot = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					!hero_dummy3(hero))
@@ -239,7 +239,7 @@ signed short DNG02_handler(void)
 		hero = get_hero(0);
 		for (i = weight_sum = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 			{
 				weight_sum += get_hero_weight(hero);
@@ -267,7 +267,7 @@ signed short DNG02_handler(void)
 				hero = get_hero(0);
 				for (mod_slot = 0; mod_slot <= 6; mod_slot++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == i)
 					{
 						weight_sum += get_hero_weight(hero);
@@ -328,7 +328,7 @@ signed short DNG02_handler(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				host_readbs(hero + HERO_MR) < 8)
@@ -632,7 +632,7 @@ void DNG02_chest04_func3(RealPt)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					sub_hero_le(hero, random_schick(6));

--- a/src/custom/schick/rewrite_m302de/seg079.cpp
+++ b/src/custom/schick/rewrite_m302de/seg079.cpp
@@ -73,7 +73,7 @@ signed short DNG03_handler(void)
 				{
 					sub_ae_splash(hero, random_schick(6));
 
-				} else if (host_readbs(hero + HERO_TYPE) != 0)
+				} else if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE)
 				{
 					sub_hero_le(hero, random_schick(6));
 				}
@@ -98,7 +98,7 @@ signed short DNG03_handler(void)
 			{
 				sub_ae_splash(hero, random_schick(6));
 
-			} else if (host_readbs(hero + HERO_TYPE) != 0)
+			} else if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE)
 			{
 				sub_hero_le(hero, random_schick(6));
 			}
@@ -125,7 +125,7 @@ signed short DNG03_handler(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 10, 2) <= 0)
@@ -165,7 +165,7 @@ signed short DNG03_handler(void)
 				{
 					sub_ae_splash(hero, random_schick(6));
 
-				} else if (host_readbs(hero + HERO_TYPE) != 0)
+				} else if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE)
 				{
 					sub_hero_le(hero, random_schick(6));
 				}
@@ -208,7 +208,7 @@ signed short DNG03_handler(void)
 		}
 
 		if ((hero = Real2Host(get_second_hero_available_in_group())) &&
-			host_readbs(hero + HERO_TYPE) != 0 &&
+			host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_skill(hero, 50, 4) <= 0)
@@ -245,7 +245,7 @@ signed short DNG03_handler(void)
 
 		if ((hero = Real2Host(get_second_hero_available_in_group())) &&
 			(j == 2 ||
-			(host_readbs(hero + HERO_TYPE) != 0 &&
+			(host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_attrib(hero, 4, 2) <= 0)))
@@ -386,7 +386,7 @@ signed short DNG03_handler(void)
 			{
 				sub_ae_splash(hero, random_schick(6));
 
-			} else if (host_readbs(hero + HERO_TYPE) != 0)
+			} else if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE)
 			{
 				sub_hero_le(hero, random_schick(6));
 			}
@@ -580,7 +580,7 @@ void DNG03_chest11_func3(RealPt)
 		hero = get_hero(0);
 		for (l_di = counter = l_si = 0; l_di <= 6; l_di++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{

--- a/src/custom/schick/rewrite_m302de/seg080.cpp
+++ b/src/custom/schick/rewrite_m302de/seg080.cpp
@@ -104,7 +104,7 @@ signed short DNG04_handler(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6 ; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 13, 2) <= 0)
@@ -151,7 +151,7 @@ signed short DNG04_handler(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6 ; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 13, 4) <= 0)
@@ -235,7 +235,7 @@ signed short DNG04_handler(void)
 			for (i = 0; i <= 6 ; i++, hero += SIZEOF_HERO)
 			{
 				if (random_schick(100) <= 5 &&
-					host_readbs(hero + HERO_TYPE) != 0 &&
+					host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -260,7 +260,7 @@ signed short DNG04_handler(void)
 			{
 				/* Original-Bug: forgot to check if the hero is dead */
 				if (random_schick(100) <= 10 &&
-					host_readbs(hero + HERO_TYPE) != 0 &&
+					host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					sub_hero_le(hero, 2);

--- a/src/custom/schick/rewrite_m302de/seg081.cpp
+++ b/src/custom/schick/rewrite_m302de/seg081.cpp
@@ -102,7 +102,7 @@ signed short DNG06_handler(void)
 		hero = get_hero(0);
 		for (i = l3 = 0; i < 2; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{
@@ -136,7 +136,7 @@ signed short DNG06_handler(void)
 		hero = get_hero(0);
 		for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 50, 5) > 0)
@@ -155,7 +155,7 @@ signed short DNG06_handler(void)
 				hero = get_hero(0);
 				for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 50, 5) > 0)
@@ -194,7 +194,7 @@ signed short DNG06_handler(void)
 		hero = get_hero(0);
 		for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 51, 10) > 0)
@@ -270,7 +270,7 @@ signed short DNG06_handler(void)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					test_skill(hero, 11, host_readbs(hero + HERO_RS_BONUS1)) <= 0)
@@ -301,7 +301,7 @@ signed short DNG06_handler(void)
 					hero = get_hero(0);
 					for (l4 = 0; l4 <= 6; l4++, hero += SIZEOF_HERO)
 					{
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == i)
 						{
 							l3 = 1;
@@ -343,7 +343,7 @@ signed short DNG06_handler(void)
 					hero = get_hero(0);
 					for (l4 = 0; l4 <= 6; l4++, hero += SIZEOF_HERO)
 					{
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == i)
 						{
 							l3 = 1;
@@ -511,7 +511,7 @@ void DNG06_chest2(RealPt chest)
 	hero = get_hero(0);
 	for (i = 0; i <=6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_skill(hero, 38, 0) > 0)
@@ -538,7 +538,7 @@ void DNG09_pitfall(void)
 	{
 		for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 50, 4) > 0)

--- a/src/custom/schick/rewrite_m302de/seg082.cpp
+++ b/src/custom/schick/rewrite_m302de/seg082.cpp
@@ -183,7 +183,7 @@ signed short DNG07_handler(void)
 			/* ORIGINAL-BUG: forgot to set hero */
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readb(hero + HERO_TYPE) != 0 &&
+				if (host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -264,7 +264,7 @@ signed short DNG07_handler(void)
 			/* ORIGINAL-BUG: forgot to set hero */
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readb(hero + HERO_TYPE) != 0 &&
+				if (host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					hero_dummy6(hero))
 				{
 					sub_ptr_bs(hero + HERO_MU, 3);
@@ -375,7 +375,7 @@ void DNG09_statues(signed short prob, signed short bonus)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readb(hero + HERO_TYPE) != 0 &&
+				if (host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{

--- a/src/custom/schick/rewrite_m302de/seg083.cpp
+++ b/src/custom/schick/rewrite_m302de/seg083.cpp
@@ -162,7 +162,7 @@ signed short DNG08_handler(void)
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -189,7 +189,7 @@ signed short DNG08_handler(void)
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -314,7 +314,7 @@ signed short DNG08_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 10, 2) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg084.cpp
+++ b/src/custom/schick/rewrite_m302de/seg084.cpp
@@ -94,7 +94,7 @@ signed short DNG09_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 4) <= 0)
@@ -130,7 +130,7 @@ signed short DNG09_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 4) <= 0)
@@ -155,7 +155,7 @@ signed short DNG09_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 4) <= 0)
@@ -183,7 +183,7 @@ signed short DNG09_handler(void)
 	{
 		for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 50, 2) > 0)
@@ -210,7 +210,7 @@ signed short DNG09_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 4) <= 0)
@@ -241,7 +241,7 @@ signed short DNG09_handler(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 4) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg085.cpp
+++ b/src/custom/schick/rewrite_m302de/seg085.cpp
@@ -255,7 +255,7 @@ signed short DNG10_handler(void)
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -334,7 +334,7 @@ signed short DNG10_handler(void)
 
 				for (answer = result = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 13, host_readbs(hero + HERO_RS_BONUS1) + 3) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg086.cpp
+++ b/src/custom/schick/rewrite_m302de/seg086.cpp
@@ -115,7 +115,7 @@ signed short DNG11_handler(void)
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -135,7 +135,7 @@ signed short DNG11_handler(void)
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -170,7 +170,7 @@ signed short DNG11_handler(void)
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					hero_disappear(hero, answer, -1);

--- a/src/custom/schick/rewrite_m302de/seg087.cpp
+++ b/src/custom/schick/rewrite_m302de/seg087.cpp
@@ -378,10 +378,10 @@ signed short DNG14_handler(void)
 			hero = get_hero(0);
 			for (hero_pos = 0; hero_pos <= 6; hero_pos++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
-					host_readbs(hero + HERO_TYPE) == 9 &&
+					host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE &&
 					host_readbs(hero + HERO_STAFFSPELL_LVL) > 2)
 				{
 					/* mage with staffspell-level > 2 => can transform staff to rope */
@@ -401,7 +401,7 @@ signed short DNG14_handler(void)
 				hero = get_hero(0);
 				for (hero_pos = 0; hero_pos <= 6; hero_pos++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 10, 0) <= 0)
@@ -427,7 +427,7 @@ signed short DNG14_handler(void)
 				hero = get_hero(0);
 				for (hero_pos = 0; hero_pos <= 6; hero_pos++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 10, 4) <= 0)
@@ -467,7 +467,7 @@ signed short DNG14_handler(void)
 		hero = get_hero(0);
 		for (hero_pos = 0; hero_pos <= 6; hero_pos++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 11, 0) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg088.cpp
+++ b/src/custom/schick/rewrite_m302de/seg088.cpp
@@ -33,7 +33,7 @@ void DNG14_dive(signed short diver_pos, signed char mod, signed short dest_x)
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
 		if (i != diver_pos &&
-			host_readbs(hero + HERO_TYPE) != 0 &&
+			host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero))
 		{

--- a/src/custom/schick/rewrite_m302de/seg089.cpp
+++ b/src/custom/schick/rewrite_m302de/seg089.cpp
@@ -77,7 +77,7 @@ signed short DNG15_handler(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, -3) <= 0)
@@ -504,7 +504,7 @@ void DNG15_small_wounds(void)
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_attrib(hero, 4, -3) <= 0)
@@ -627,7 +627,7 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 			/* count failed GE-3 test */
 			for (i = cnt = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					test_attrib(hero, 4, -3) <= 0)
@@ -655,7 +655,7 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 			/* each hero gets 1W6 damage on a failed GE test */
 			for (i = cnt = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					test_attrib(hero, 4, 0) <= 0)
@@ -722,7 +722,7 @@ void DNG15_clear_way(Bit8u* ptr)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_attrib(hero, 4, 0) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg090.cpp
+++ b/src/custom/schick/rewrite_m302de/seg090.cpp
@@ -101,7 +101,7 @@ signed short DNG12_handler(void)
 					hero = get_hero(0);
 					for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							!hero_dead(hero))
 						{

--- a/src/custom/schick/rewrite_m302de/seg091.cpp
+++ b/src/custom/schick/rewrite_m302de/seg091.cpp
@@ -271,7 +271,7 @@ void DNG13_collapsing_ceiling(void)
 	hero = get_hero(0);
 	for (i = fails = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_skill(hero, 13, -4) <= 0)
@@ -321,7 +321,7 @@ void DNG13_collapsing_ceiling_easy(void)
 	hero = get_hero(0);
 	for (i = fails = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_skill(hero, 13, -1) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg094.cpp
+++ b/src/custom/schick/rewrite_m302de/seg094.cpp
@@ -258,7 +258,7 @@ void TM_func1(signed short route_nr, signed short backwards)
 				hero = get_hero(0);
 				for (ds_writew(0x4228, 0); ds_readws(0x4228) <= 6; inc_ds_ws(0x4228), hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{

--- a/src/custom/schick/rewrite_m302de/seg095.cpp
+++ b/src/custom/schick/rewrite_m302de/seg095.cpp
@@ -98,7 +98,7 @@ void npc_farewell(void)
 	signed short tmp;
 
 	/* no NPC there */
-	if (host_readb(get_hero(6) + HERO_TYPE) == 0)
+	if (host_readb(get_hero(6) + HERO_TYPE) == HERO_TYPE_NONE)
 		return;
 
 	/* no NPC in that group */
@@ -113,15 +113,13 @@ void npc_farewell(void)
 	load_tx(ARCHIVE_FILE_NSC_LTX);
 
 	switch (host_readbs(get_hero(6) + HERO_NPC_ID)) {
-		/* Nariell */
-		case 1: {
+		case NPC_NARIELL: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x14, 0x1f, 0xe2,
 					get_ltx(0xbc4), get_dtp(0x24));
 			break;
 		}
-		/* Harika */
-		case 2: {
+		case NPC_HARIKA: {
 			if (ds_readws(NPC_MONTHS) >= 2) {
 				if (ds_readws(NPC_MONTHS) >= 99 ||
 					ds_readb(CURRENT_TOWN) == 1 ||
@@ -147,29 +145,25 @@ void npc_farewell(void)
 			}
 			break;
 		}
-		/* Curian */
-		case 3: {
+		case NPC_CURIAN: {
 			if (ds_readws(NPC_MONTHS) >= 6)
 				remove_npc(0x19, 0x40, 0xe4,
 					get_ltx(0xbcc), get_dtp(0x74));
 			break;
 		}
-		/* Ardora */
-		case 4: {
+		case NPC_ARDORA: {
 			if (ds_readws(NPC_MONTHS) >= 1)
 				remove_npc(0x15, 0x1f, 0xe5,
 					get_ltx(0xbd0), get_dtp(0xac));
 			break;
 		}
-		/* Garsvik */
-		case 5: {
+		case NPC_GARSVIK: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x17, 0x1f, 0xe6,
 					get_ltx(0xbd4), get_dtp(0xd4));
 			break;
 		}
-		/* Erwo */
-		case 6: {
+		case NPC_ERWO: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x18, 0x1f, 0xe7,
 					get_ltx(0xbd8), get_dtp(0xfc));

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -371,7 +371,7 @@ signed short use_magic(RealPt hero)
 		case 1: {
 			/* Meditation */
 
-			if (host_readbs(Real2Host(hero) + HERO_TYPE) != 9) {
+			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_MAGE) {
 				/* not a mage, need thonnys */
 
 
@@ -426,7 +426,7 @@ signed short use_magic(RealPt hero)
 		case 2: {
 			/* Staffspell */
 
-			if (host_readbs(Real2Host(hero) + HERO_TYPE) != 9) {
+			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_MAGE) {
 				/* only for mages */
 				GUI_output(get_ltx(0x64c));
 				return 0;
@@ -790,7 +790,7 @@ signed short test_spell_group(signed short spell, signed char bonus)
 		/* Check class is magicuser */
 		if ((host_readbs(hero_i + HERO_TYPE) >= 7) &&
 			/* Check class  BOGUS */
-			(host_readbs(hero_i + HERO_TYPE) != 0) &&
+			(host_readbs(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			/* Check in group */
 			(host_readbs(hero_i + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			/* Check if dead */

--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -786,8 +786,7 @@ void spell_silentium(void)
 	hero = get_hero(0);
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
-		/* check class */
-		if ((host_readb(hero + HERO_TYPE) != 0) &&
+		if ((host_readb(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			/* check group */
 			(host_readb(hero + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 			/* check dead */

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -136,8 +136,7 @@ RealPt get_proper_hero(signed short skill)
 	hero_i = (RealPt)ds_readd(HEROS);
 
 	for (i = 0; i <= 6; i++, hero_i += SIZEOF_HERO) {
-		/* Check class */
-		if ((host_readbs(Real2Host(hero_i) + HERO_TYPE) != 0) &&
+		if ((host_readbs(Real2Host(hero_i) + HERO_TYPE) != HERO_TYPE_NONE) &&
 			/* Check if in current group */
 			(host_readb(Real2Host(hero_i) + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 			/* Check hero is not dead */
@@ -742,8 +741,8 @@ signed short bargain(Bit8u *hero, signed short items, Bit32s price,
 
 	signed char mod = mod_init;
 
-	/* maybe a special NPC ? */
-	if (host_readb(get_hero(6) + HERO_NPC_ID) == 2) {
+	/* NPC Harika gets a bonus on bargain */
+	if (host_readb(get_hero(6) + HERO_NPC_ID) == NPC_HARIKA) {
 		mod -= 2;
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -268,7 +268,7 @@ signed short plan_alchemy(Bit8u *hero)
 								if (ds_readbs(LOCATION) != 6) {
 									hero_p = get_hero(0);
 									for (i = 0; i <= 6; i++, hero_p += SIZEOF_HERO) {
-										if ((host_readbs(hero_p + HERO_TYPE) != 0) &&
+										if ((host_readbs(hero_p + HERO_TYPE) != HERO_TYPE_NONE) &&
 											(host_readbs(hero_p + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 										{
 											GRP_hero_sleep(hero_p, ds_readbs(SLEEP_QUALITY));
@@ -507,7 +507,7 @@ RealPt get_heaviest_hero(void)
 	hero = (RealPt)ds_readd(HEROS);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if ((host_readbs(Real2Host(hero) + HERO_TYPE) != 0) &&
+		if ((host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
 			weight = host_readws(Real2Host(hero) + HERO_WEIGHT) + host_readws(Real2Host(hero) + HERO_LOAD);
@@ -542,7 +542,7 @@ signed short get_skilled_hero_pos(signed short skill)
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if ((host_readbs(hero + HERO_TYPE) != 0) &&
+		if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 		{
 

--- a/src/custom/schick/rewrite_m302de/seg106.cpp
+++ b/src/custom/schick/rewrite_m302de/seg106.cpp
@@ -658,7 +658,7 @@ void startup_equipment(Bit8u *hero)
 
 	move_item(5, 9, hero);
 
-	if (host_readbs(hero + HERO_SEX) != 0 && host_readbs(hero + HERO_TYPE) != 3 && host_readbs(hero + HERO_TYPE) != 9) {
+	if (host_readbs(hero + HERO_SEX) != 0 && host_readbs(hero + HERO_TYPE) != HERO_TYPE_WARRIOR && host_readbs(hero + HERO_TYPE) != HERO_TYPE_MAGE) {
 		give_hero_new_item(hero, 48, 1, 1);
 		move_item(2, 9, hero);
 	}
@@ -673,17 +673,17 @@ void startup_equipment(Bit8u *hero)
 		}
 	}
 
-	if (host_readbs(hero + HERO_TYPE) == 3) {
+	if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_WARRIOR) {
 		move_item(2, get_item_pos(hero, 53), hero);
 	}
 
-	if (host_readbs(hero + HERO_TYPE) == 9) {
+	if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE) {
 		move_item(2, get_item_pos(hero, 75), hero);
 	}
 
-	if (host_readbs(hero + HERO_TYPE) == 2 ||
-		host_readbs(hero + HERO_TYPE) == 10 ||
-		host_readbs(hero + HERO_TYPE) == 12)
+	if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_HUNTER ||
+		host_readbs(hero + HERO_TYPE) == HERO_TYPE_GREEN_ELF ||
+		host_readbs(hero + HERO_TYPE) == HERO_TYPE_SYLVAN_ELF)
 	{
 		give_hero_new_item(hero, 10, 1, 20);
 		move_item(4, get_item_pos(hero, 10), hero);

--- a/src/custom/schick/rewrite_m302de/seg109.cpp
+++ b/src/custom/schick/rewrite_m302de/seg109.cpp
@@ -537,7 +537,7 @@ void TRV_ford_test(signed short mod, signed short time)
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero))
 		{
@@ -715,7 +715,7 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 	hero = get_hero(0);
 	for (i = l_di = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if ((host_readbs(hero + HERO_TYPE) != 0) &&
+		if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 			!hero_dead(hero) &&
 			test_skill(hero, 13, (signed char)mod1) <= 0)
@@ -871,7 +871,7 @@ void TRV_barrier(signed short text_start)
 			hero = get_hero(0);
 			for (i = l_di = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					l_di+=hero_count_item(hero, 121);

--- a/src/custom/schick/rewrite_m302de/seg110.cpp
+++ b/src/custom/schick/rewrite_m302de/seg110.cpp
@@ -98,7 +98,7 @@ void TRV_swim2(signed char mod, signed short percent)
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero))
 		{
@@ -382,7 +382,7 @@ void tevent_029(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{

--- a/src/custom/schick/rewrite_m302de/seg111.cpp
+++ b/src/custom/schick/rewrite_m302de/seg111.cpp
@@ -98,7 +98,7 @@ void tevent_057(void)
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 				{
 					sub_hero_le(hero, random_schick(3));
@@ -111,7 +111,7 @@ void tevent_057(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 10, 3) <= 0)
@@ -269,7 +269,7 @@ void tevent_060(void)
 
 					for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							!hero_dead(hero) &&
 							test_skill(hero, 10, 0) <= 0)
@@ -314,7 +314,7 @@ void tevent_060(void)
 
 					for (i = has_magic_rope = nr_items = 0; i <= 6 ; i++, hero += SIZEOF_HERO){
 
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							!hero_dead(hero))
 						{
@@ -451,7 +451,7 @@ void tevent_063(void)
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP) &&
 			!hero_dead(hero))
 		{
@@ -546,7 +546,7 @@ void tevent_064(void)
 
 				for (i = l_di = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 13, 0) <= 0)
@@ -737,7 +737,7 @@ void tevent_066(void)
 				hero = get_hero(0);
 				for (l_di = count = 0; l_di <= 6; l_di++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 13, -2) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg112.cpp
+++ b/src/custom/schick/rewrite_m302de/seg112.cpp
@@ -57,7 +57,7 @@ void tevent_067(void)
 			hero = get_hero(0);
 			for (i = count = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					test_attrib(hero, 4, 0) > 0)
@@ -86,7 +86,7 @@ void tevent_067(void)
 				hero = get_hero(0);
 				for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 					{
 						sub_hero_le(hero, random_schick(8));
@@ -301,7 +301,7 @@ void TRV_swimm(signed short mod, signed short percent)
 
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero))
 		{
@@ -489,7 +489,7 @@ void tevent_074(void)
 				hero = get_hero(0);
 				for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{
@@ -605,7 +605,7 @@ void tevent_075(void)
 				hero = get_hero(0);
 				for (i = answer = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_skill(hero, 13, 0) <= 0)
@@ -730,7 +730,7 @@ void tevent_077(void)
 				hero = get_hero(0);
 				for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{

--- a/src/custom/schick/rewrite_m302de/seg113.cpp
+++ b/src/custom/schick/rewrite_m302de/seg113.cpp
@@ -203,7 +203,7 @@ void tevent_086(void)
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP))
 			{
 				sub_hero_le(hero, 2);
@@ -284,7 +284,7 @@ void tevent_098(void)
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero))
 				{
@@ -344,7 +344,7 @@ void tevent_098(void)
 				for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
 					if (i != hero_pos &&
-						host_readbs(hero + HERO_TYPE) != 0 &&
+						host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{
@@ -630,7 +630,7 @@ void tevent_104(void)
 
 		for (i = l_si = nr_heros = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{
@@ -802,7 +802,7 @@ void tevent_107(void)
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 10, 1) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg114.cpp
+++ b/src/custom/schick/rewrite_m302de/seg114.cpp
@@ -49,7 +49,7 @@ void tevent_110(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 10, 0) <= 0)
@@ -124,7 +124,7 @@ void tevent_111(void)
 		hero = get_hero(0);
 		for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				test_skill(hero, 13, -5) <= 0)
@@ -240,7 +240,7 @@ void tevent_111(void)
 						hero = get_hero(0);
 						for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 						{
-							if (host_readbs(hero + HERO_TYPE) != 0 &&
+							if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 								host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 								!hero_dead(hero) &&
 								test_attrib(hero, 4, 2) <= 0)
@@ -403,7 +403,7 @@ void tevent_114(void)
 			{
 				for (i = 0, hero = get_hero(0); i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero) &&
 						test_attrib(hero, 4, 4) <= 0)
@@ -453,7 +453,7 @@ void tevent_114(void)
 
 				for (i = 0, hero = get_hero(0); i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{
@@ -470,7 +470,7 @@ void tevent_114(void)
 
 				for (i = 0, hero = get_hero(0); i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{
@@ -507,7 +507,7 @@ void tevent_117(void)
 
 	for (hero = get_hero(0), i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
-		if (host_readbs(hero + HERO_TYPE) != 0 &&
+		if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 			host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 			!hero_dead(hero) &&
 			test_attrib(hero, 4, 0) <= 0)
@@ -609,7 +609,7 @@ void tevent_123(void)
 			hero = get_hero(0);
 			for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
-				if (host_readbs(hero + HERO_TYPE) != 0 &&
+				if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 					host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 					!hero_dead(hero) &&
 					test_attrib(hero, 8, 0) > 0)
@@ -650,7 +650,7 @@ void tevent_123(void)
 				hero = get_hero(0);
 				for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{
@@ -708,7 +708,7 @@ void tevent_123(void)
 					hero = get_hero(0);
 					for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 					{
-						if (host_readbs(hero + HERO_TYPE) != 0 &&
+						if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 							host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 							!hero_dead(hero))
 						{
@@ -724,7 +724,7 @@ void tevent_123(void)
 				hero = get_hero(0);
 				for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 				{
-					if (host_readbs(hero + HERO_TYPE) != 0 &&
+					if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 						host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 						!hero_dead(hero))
 					{

--- a/src/custom/schick/rewrite_m302de/seg115.cpp
+++ b/src/custom/schick/rewrite_m302de/seg115.cpp
@@ -242,7 +242,7 @@ void tevent_095(void)
 
 		for (i = counter_failed = counter_heros = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -164,7 +164,7 @@ void tevent_133(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero))
 			{
@@ -373,7 +373,7 @@ void tevent_137(void)
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if ((host_readbs(hero + HERO_TYPE) != 0) &&
+				if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero))
 				{
@@ -429,7 +429,7 @@ void tevent_139(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero))
 			{
@@ -528,7 +528,7 @@ void tevent_143(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)))
 			{
 				sub_hero_le(hero, random_schick(2) + 1);

--- a/src/custom/schick/rewrite_m302de/seg117.cpp
+++ b/src/custom/schick/rewrite_m302de/seg117.cpp
@@ -101,7 +101,7 @@ void hunt_karen(void)
 			/* make a STEALTH+2 test and count the heroes who passed it */
 			for (i = passed = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if ((host_readbs(hero + HERO_TYPE) != 0) &&
+				if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero) &&
 					(test_skill(hero, 13, 2) > 0))
@@ -119,7 +119,7 @@ void hunt_karen(void)
 				hero = get_hero(0);
 				for (i = passed = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if ((host_readbs(hero + HERO_TYPE) != 0) &&
+					if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 						(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 						!hero_dead(hero) &&
 						(test_skill(hero, 7, 0) > 0))
@@ -183,7 +183,7 @@ void hunt_wildboar(void)
 			/* make a STEALTH+0 test and count the heroes who passed it */
 			for (i = passed = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-				if ((host_readbs(hero + HERO_TYPE) != 0) &&
+				if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero) &&
 					(test_skill(hero, 13, 0) > 0))
@@ -201,7 +201,7 @@ void hunt_wildboar(void)
 				hero = get_hero(0);
 				for (i = passed = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-					if ((host_readbs(hero + HERO_TYPE) != 0) &&
+					if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 						(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 						!hero_dead(hero) &&
 						(test_skill(hero, 7, 0) > 0))
@@ -260,7 +260,7 @@ void hunt_cavebear(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if ((host_readbs(hero + HERO_TYPE) != 0) &&
+			if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) &&
 				(host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 				!hero_dead(hero))
 			{
@@ -317,7 +317,7 @@ void hunt_viper(void)
 		/* hero is not dead */
 		/* check GE+0 */
 		/* Original-Bug: something was forgotten */
-		if ((host_readb(hero_i + HERO_TYPE) != 0) &&
+		if ((host_readb(hero_i + HERO_TYPE) != HERO_TYPE_NONE) &&
 			(host_readb(hero_i + HERO_GROUP_NO) == ds_readb(CURRENT_GROUP)) &&
 			(!hero_dead(hero_i)) &&
 			(test_attrib(hero_i, 4, 0) < l_di))
@@ -377,7 +377,7 @@ void octopus_attack(void)
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				!overboard[i])
@@ -706,7 +706,7 @@ void TLK_way_to_ruin(signed short state)
 			hero = (RealPt)ds_readds(HEROS) + SIZEOF_HERO * ds_readws(0xb21b);
 			inc_ds_ws(0xb21b);
 
-			if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(Real2Host(hero))) {
 
@@ -760,7 +760,7 @@ void TLK_way_to_ruin(signed short state)
 
 		for (i = ds_writews(0xb21b, 0); i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(Real2Host(hero)) &&
 				test_skill(Real2Host(hero), 28, 0) > 0) {
@@ -789,7 +789,7 @@ void TLK_way_to_ruin(signed short state)
 
 		for (i = ds_writews(0xb21b, 0); i <= 6; i++, hero += SIZEOF_HERO) {
 
-			if (host_readbs(Real2Host(hero) + HERO_TYPE) != 0 &&
+			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(Real2Host(hero) + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(Real2Host(hero)) &&
 				test_skill(Real2Host(hero), 28, 0) > 0) {

--- a/src/custom/schick/rewrite_m302de/seg118.cpp
+++ b/src/custom/schick/rewrite_m302de/seg118.cpp
@@ -525,7 +525,7 @@ void tevent_124(void)
 		hero = get_hero(0);
 		for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
-			if (host_readbs(hero + HERO_TYPE) != 0 &&
+			if (host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE &&
 				host_readbs(hero + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP) &&
 				!hero_dead(hero) &&
 				(skill_ret = test_skill(hero, 10, -2)) <= 0)

--- a/src/custom/schick/rewrite_m302de/seg119.cpp
+++ b/src/custom/schick/rewrite_m302de/seg119.cpp
@@ -49,7 +49,7 @@ void disease_effect(void)
 
 	for (i = 0; i <= 6; i++) {
 
-		if ((host_readbs(get_hero(i) + HERO_TYPE) != 0) && !hero_dead(get_hero(i))) {
+		if ((host_readbs(get_hero(i) + HERO_TYPE) != HERO_TYPE_NONE) && !hero_dead(get_hero(i))) {
 
 			hero = (RealPt)ds_readd(HEROS) + SIZEOF_HERO * i;
 
@@ -142,7 +142,7 @@ void disease_effect(void)
 					hero2 = get_hero(0);
 
 					for (j = 0; j <= 6; j++, hero2 += SIZEOF_HERO) {
-						if ((host_readbs(hero2 + HERO_TYPE) != 0) &&
+						if ((host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 							(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 							!hero_dead(hero2) &&
 							(hero2 != Real2Host(hero)) &&
@@ -250,7 +250,7 @@ void disease_effect(void)
 					hero2 = get_hero(0);
 
 					for (j = 0; j <= 6; j++, hero2 += SIZEOF_HERO) {
-						if ((host_readbs(hero2 + HERO_TYPE) != 0) &&
+						if ((host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 							(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 							!hero_dead(hero2) &&
 							(hero2 != Real2Host(hero)) &&
@@ -359,7 +359,7 @@ void disease_effect(void)
 				if (host_readbs(disease_ptr + 1) > 7) {
 
 					/* 30 % for elfes, 20% for the all other types */
-					if (random_schick(100) <= (host_readbs(Real2Host(hero) + HERO_TYPE) >= 10 ? 30 : 20)) {
+					if (random_schick(100) <= (host_readbs(Real2Host(hero) + HERO_TYPE) >= HERO_TYPE_GREEN_ELF ? 30 : 20)) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
 							(char*)get_ltx(0x910),
@@ -395,7 +395,7 @@ void disease_effect(void)
 
 							hero2 = get_hero(j);
 
-							if ((host_readbs(hero2 + HERO_TYPE) != 0) &&
+							if ((host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 								(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 								!hero_dead(hero2) &&
 								(hero2 != Real2Host(hero)) &&
@@ -405,7 +405,7 @@ void disease_effect(void)
 							}
 						}
 
-						sub_hero_le(Real2Host(hero), dice_roll((host_readbs(Real2Host(hero) + HERO_TYPE) >= 10 ? 2 : 1),
+						sub_hero_le(Real2Host(hero), dice_roll((host_readbs(Real2Host(hero) + HERO_TYPE) >= HERO_TYPE_GREEN_ELF ? 2 : 1),
 										6, host_readbs(disease_ptr + 1) - 1));
 					}
 				}
@@ -521,7 +521,7 @@ void disease_effect(void)
 					for (j = 0; j <= 6; j++, hero2 += SIZEOF_HERO) {
 
 
-						if ((host_readbs(hero2 + HERO_TYPE) != 0) &&
+						if ((host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 							(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 							!hero_dead(hero2) &&
 							(hero2 != Real2Host(hero)) &&

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -216,7 +216,7 @@ void rabies(RealPt hero, signed short hero_pos)
 			for (l_di = 0; l_di <= 6; l_di++, hero2 += SIZEOF_HERO) {
 
 				if ((l_di != hero_pos) &&
-					(host_readbs(hero2 + HERO_TYPE) != 0) &&
+					(host_readbs(hero2 + HERO_TYPE) != HERO_TYPE_NONE) &&
 					(host_readbs(hero2 + HERO_GROUP_NO) == ds_readbs(CURRENT_GROUP)) &&
 					!hero_dead(hero2))
 				{

--- a/src/custom/schick/rewrite_m302de/seg121.cpp
+++ b/src/custom/schick/rewrite_m302de/seg121.cpp
@@ -32,7 +32,7 @@ void poison_effect(void)
 
 	for (i = 0; i <= 6; i++, hero+=SIZEOF_HERO) {
 
-		if ((host_readbs(hero + HERO_TYPE) != 0) && !hero_dead(hero)) {
+		if ((host_readbs(hero + HERO_TYPE) != HERO_TYPE_NONE) && !hero_dead(hero)) {
 
 			poison_ptr = hero + HERO_POISON + POISON_SHURINKNOLLENGIFT * 5;
 


### PR DESCRIPTION
The value of `HERO_TYPE` in the hero sheet is a `char` taking values between 1 and 12 (for the character types Juggler, Hunter, Warrior etc. up to Sylvan Elf). The value 0 is often checked to determine if there is a hero in a given hero slot. Because only the last six of the types can cast spells, the current type is often compared with HERO_TYPE_DWARF (6) to determine the spell casting ability.

I introduce the enum `HERO_TYPE_*` encoding the meaning of each of these values. 

Furthermore, the enum `NPC_*` encodes the internal number of each of the six NPCs (Nariell, Harika, Curian, Ardora, Garsvik, Erwo) occuring in the game.