### PR TITLE
M302de: BC: Fix wrong item label.

### DIFF
--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -642,7 +642,7 @@ void spell_brenne(void)
 			torch_pos = get_item_pos(get_spelluser(), ITEM_TORCH_OFF);
 		}
 
-		lantern_pos = get_item_pos(get_spelluser(), ITEM_LANTERN_ON);
+		lantern_pos = get_item_pos(get_spelluser(), ITEM_LANTERN_OFF);
 	}
 
 	if (torch_pos != -1) {


### PR DESCRIPTION
Tiny fix for a (critical) typo introduced in the last commit.