### PR TITLE
get_tx numbering

### DIFF
--- a/src/custom/schick/rewrite_m302de/seg002.cpp
+++ b/src/custom/schick/rewrite_m302de/seg002.cpp
@@ -1660,7 +1660,7 @@ void handle_gui_input(void)
 			l_di = ds_readws(TEXTBOX_WIDTH);
 			ds_writew(TEXTBOX_WIDTH, 5);
 			ds_writew(GUI_TEXT_CENTERED, 1);
-			GUI_output(get_ttx(0x628));
+			GUI_output(get_ttx(394));
 			ds_writew(GUI_TEXT_CENTERED, 0);
 			ds_writew(TEXTBOX_WIDTH, l_di);
 
@@ -3053,12 +3053,12 @@ void herokeeping(void)
 				(!ds_readb(SHOW_TRAVEL_MAP) || ds_readb(FOOD_MESSAGE_SHOWN + i) != ds_readb(FOOD_MESSAGE + i))) {
 
 					sprintf(buffer,
-						(ds_readb(FOOD_MESSAGE + i) == 1) ? (char*)get_ttx(0x380):
-							((ds_readb(FOOD_MESSAGE + i) == 2) ? (char*)get_ttx(0x37c) :
-							((ds_readb(FOOD_MESSAGE + i) == 3) ? (char*)get_ttx(0xc74) :
-							((ds_readb(FOOD_MESSAGE + i) == 4) ? (char*)get_ttx(0xc78) :
-							((ds_readb(FOOD_MESSAGE + i) == 5) ? (char*)get_ttx(0xc7c) :
-							(char*)get_ttx(0xc80))))),
+						(ds_readb(FOOD_MESSAGE + i) == 1) ? (char*)get_ttx(224):
+							((ds_readb(FOOD_MESSAGE + i) == 2) ? (char*)get_ttx(223) :
+							((ds_readb(FOOD_MESSAGE + i) == 3) ? (char*)get_ttx(797) :
+							((ds_readb(FOOD_MESSAGE + i) == 4) ? (char*)get_ttx(798) :
+							((ds_readb(FOOD_MESSAGE + i) == 5) ? (char*)get_ttx(799) :
+							(char*)get_ttx(800))))),
 
 						(char*)hero + HERO_NAME2, (char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 1)));
 
@@ -3083,7 +3083,7 @@ void herokeeping(void)
 				!hero_dead(hero)) {
 
 					/* prepare output */
-					sprintf(buffer, (char*)get_ttx(0xc54),
+					sprintf(buffer, (char*)get_ttx(789),
 						(char*)hero + HERO_NAME2);
 
 					/* print output */
@@ -5242,7 +5242,7 @@ int schick_main(int argc, char** argv)
 		ds_writew(GAME_MODE, -1);
 
 		while (ds_readws(GAME_MODE) == -1) {
-			ds_writew(GAME_MODE, GUI_radio(get_ttx(0x14), 2, get_ttx(0x18), get_ttx(0x1c)));
+			ds_writew(GAME_MODE, GUI_radio(get_ttx(5), 2, get_ttx(6), get_ttx(7)));
 		}
 
 		if (copy_protection()) {
@@ -5253,7 +5253,7 @@ int schick_main(int argc, char** argv)
 
 			if (l3 < 0) {
 
-				sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0xc9c), -l3);
+				sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(807), -l3);
 				GUI_output(Real2Host(ds_readd(DTP2)));
 				cleanup_game();
 
@@ -5261,7 +5261,7 @@ int schick_main(int argc, char** argv)
 
 				/* ask for generation or game */
 				do {
-					l_di = GUI_radio(get_ttx(0xcd0), 2, get_ttx(0xcd4), get_ttx(0xcd8)) - 1;
+					l_di = GUI_radio(get_ttx(820), 2, get_ttx(821), get_ttx(822)) - 1;
 
 				} while (l_di == -1);
 
@@ -5331,7 +5331,7 @@ signed short copy_protection(void)
 
 			/* prepare the string */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x9c),
+				(char*)get_tx(39),
 				ds_readbs((QUESTIONS_HANDBOOK + 3) + 19 * l_di),
 				ds_readbs((QUESTIONS_HANDBOOK + 2) + 19 * l_di),
 				ds_readbs((QUESTIONS_HANDBOOK + 1) + 19 * l_di),
@@ -5362,9 +5362,9 @@ signed short copy_protection(void)
 
 			/* prepare the string */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0xa0),
-				get_tx(4 * (0x29 + ds_readbs((QUESTIONS_MAP + 0) + 3 * l_di))),
-				get_ttx(4 * (0xeb + ds_readbs((QUESTIONS_MAP + 1) + 3 * l_di))));
+				(char*)get_tx(40),
+				get_tx(41 + ds_readbs((QUESTIONS_MAP + 0) + 3 * l_di)),
+				get_ttx(235 + ds_readbs((QUESTIONS_MAP + 1) + 3 * l_di)));
 
 			/* print version number */
 			GUI_print_string(p_datseg + GAME_VERSION, 290, 190);
@@ -5380,7 +5380,7 @@ signed short copy_protection(void)
 					toupper(host_readbs(Real2Host(ds_readd(TEXT_INPUT_BUF)) + i)));
 			}
 
-			if (!strcmp((char*)get_ttx(4 * (0xeb + ds_readbs((QUESTIONS_MAP + 2) + 3 * l_di))), (char*)Real2Host(ds_readd(TEXT_INPUT_BUF)))) {
+			if (!strcmp((char*)get_ttx(235 + ds_readbs((QUESTIONS_MAP + 2) + 3 * l_di)), (char*)Real2Host(ds_readd(TEXT_INPUT_BUF)))) {
 				return 1;
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg003.cpp
+++ b/src/custom/schick/rewrite_m302de/seg003.cpp
@@ -194,7 +194,7 @@ void loot_corpse(RealPt chest_ptr, Bit8u *text, Bit8u *flag)
 	signed short answer;
 
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-		(char*)(!host_readbs(flag) ? get_ttx(0x82c) : get_ttx(0x83c)),
+		(char*)(!host_readbs(flag) ? get_ttx(523) : get_ttx(527)),
 		text);
 
 	if (!host_readbs(flag))
@@ -202,9 +202,9 @@ void loot_corpse(RealPt chest_ptr, Bit8u *text, Bit8u *flag)
 		ds_writew(TEXTBOX_WIDTH, 7);
 
 		answer = GUI_radio(Real2Host(ds_readd(TEXT_OUTPUT_BUF)), 3,
-					get_ttx(0x830),
-					get_ttx(0x834),
-					get_ttx(0x838)) - 1;
+					get_ttx(524),
+					get_ttx(525),
+					get_ttx(526)) - 1;
 
 		ds_writew(TEXTBOX_WIDTH, 3);
 

--- a/src/custom/schick/rewrite_m302de/seg005.cpp
+++ b/src/custom/schick/rewrite_m302de/seg005.cpp
@@ -238,7 +238,7 @@ unsigned short fight_printer(void)
 //					case 3: /* enemy attack fails */
 
 					sprintf(getString(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(idx * 4),
+						(char*)get_tx(idx),
 					getString(FIG_name_3rd_case(ds_readw(FIG_ACTOR_GRAMMAR_TYPE), ds_readw(FIG_ACTOR_GRAMMAR_ID))));
 				} else if (f_action == 2 || f_action == 4 || f_action == 7) {
 //					case 2: /* hero parade fails */
@@ -246,7 +246,7 @@ unsigned short fight_printer(void)
 //					case 7:	/* hero get unconscious */
 
 					sprintf(getString(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(idx * 4),
+						(char*)get_tx(idx),
 					getString(FIG_name_3rd_case(ds_readw(FIG_TARGET_GRAMMAR_TYPE), ds_readw(FIG_TARGET_GRAMMAR_ID))));
 
 
@@ -255,13 +255,13 @@ unsigned short fight_printer(void)
 //					case 11:	/* hero hits enemy */
 
 					sprintf(getString(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(idx * 4),
+						(char*)get_tx(idx),
 					getString(FIG_name_1st_case(ds_readw(FIG_ACTOR_GRAMMAR_TYPE), ds_readw(FIG_ACTOR_GRAMMAR_ID))),
 					getString(FIG_name_4th_case(ds_readw(FIG_TARGET_GRAMMAR_TYPE), ds_readw(FIG_TARGET_GRAMMAR_ID))));
 				} else {
 					/* case 5: hero successful parade */
 					/* case 6: weapon broke */
-					strcpy(getString(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(idx * 4));
+					strcpy(getString(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(idx));
 				}
 
 				GUI_print_string(Real2Host(ds_readd(TEXT_OUTPUT_BUF)),

--- a/src/custom/schick/rewrite_m302de/seg024.cpp
+++ b/src/custom/schick/rewrite_m302de/seg024.cpp
@@ -162,26 +162,26 @@ Bit16u diary_print_entry(Bit16u line)
 	do {
 		day = host_readw(ptr);
 		month = host_readw(ptr + 2);
-		city_name = (char*)get_ttx((host_readw(ptr + 6) + 0xeb) * 4);
+		city_name = (char*)get_ttx(host_readw(ptr + 6) + 0xeb);
 
 		if (di == 0) {
 			if ((signed short)strlen(city_name) > 24) {
 				sprintf(getString(ds_readd(DTP2)),
 					(char*)(p_datseg + DIARY_STRING1),
 					host_readw(ptr),
-					(char*)get_ttx((host_readw(ptr + 2) + 0x15) * 4),
+					(char*)get_ttx(host_readw(ptr + 2) + 0x15),
 					city_name);
 			} else if ((signed short)strlen(city_name) > 15 ) {
 				sprintf(getString(ds_readd(DTP2)),
 					(char*)(p_datseg + DIARY_STRING2),
 					host_readw(ptr),
-					(char*)get_ttx((host_readw(ptr + 2) + 0x15) * 4),
+					(char*)get_ttx(host_readw(ptr + 2) + 0x15),
 					city_name);
 			} else {
 				sprintf(getString(ds_readd(DTP2)),
 					(char*)(p_datseg + DIARY_STRING3),
 					host_readw(ptr),
-					(char*)get_ttx((host_readw(ptr + 2) + 0x15) * 4),
+					(char*)get_ttx(host_readw(ptr + 2) + 0x15),
 					city_name);
 			}
 		} else {

--- a/src/custom/schick/rewrite_m302de/seg025.cpp
+++ b/src/custom/schick/rewrite_m302de/seg025.cpp
@@ -79,7 +79,7 @@ void show_entrance(void)
 	load_ani(34);
 	init_ani(1);
 
-	if (GUI_bool(get_ttx(0xbe0))) {
+	if (GUI_bool(get_ttx(760))) {
 
 		init_ani_busy_loop(2);
 		DNG_enter_dungeon(ds_readws(TYPEINDEX));
@@ -107,7 +107,7 @@ void show_citizen(void)
 			init_ani(ds_writew(REQUEST_REFRESH, 0));
 
 			strcpy((char*)Real2Host((RealPt)ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_tx(ds_readw(CITYINDEX) * 4));
+				(char*)get_tx(ds_readw(CITYINDEX)));
 
 			if (ds_readbs(YEAR) == 15 && ds_readbs(MONTH) == 1 && random_schick(100) <= 20) {
 
@@ -142,9 +142,9 @@ void do_house(void)
 	Bit8u *hero;
 
 	/* prepare the question */
-	strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(4 * ds_readws(CITYINDEX)));
+	strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(ds_readws(CITYINDEX)));
 
-	strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x9bc));
+	strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(623));
 
 	ds_writew(MENU_DEFAULT_SELECT, 1);
 
@@ -157,7 +157,7 @@ void do_house(void)
 		init_ani(0);
 
 		/* print a randomized text */
-		GUI_output(get_ttx(4 * (random_schick(8) + 623)));
+		GUI_output(get_ttx(random_schick(8) + 623));
 
 		hero = get_hero(0);
 
@@ -176,7 +176,7 @@ void do_house(void)
 
 					/* sneak test failed in a town with guards */
 
-					GUI_output(get_ttx(0x9e0));
+					GUI_output(get_ttx(632));
 
 					l_di = 0;
 
@@ -211,7 +211,7 @@ void do_house(void)
 
 						timewarp_until(HOURS(6));
 
-						GUI_output(get_ttx(0x9e4));
+						GUI_output(get_ttx(633));
 					}
 				}
 				break;
@@ -283,7 +283,7 @@ void show_treasure_map(void)
 
 	if (count == 0) {
 		/* no treasure map parts found */
-		GUI_output(get_ttx(0x984));
+		GUI_output(get_ttx(609));
 	} else {
 		ds_writeb(SPECIAL_SCREEN, 1);
 		pp20_index_bak = ds_readbs(PP20_INDEX);
@@ -351,7 +351,7 @@ void show_treasure_map(void)
 			tw_bak = ds_readws(TEXTBOX_WIDTH);
 			ds_writew(TEXTBOX_WIDTH, 3);
 
-			GUI_output(get_ttx(0xca0));
+			GUI_output(get_ttx(808));
 
 			ds_writew(TEXTBOX_WIDTH, tw_bak);
 			ds_writeb(TMAP_DOUBLE1, 0);
@@ -362,7 +362,7 @@ void show_treasure_map(void)
 			tw_bak = ds_readws(TEXTBOX_WIDTH);
 			ds_writew(TEXTBOX_WIDTH, 3);
 
-			GUI_output(get_ttx(0xca4));
+			GUI_output(get_ttx(809));
 
 			ds_writew(TEXTBOX_WIDTH, tw_bak);
 			ds_writeb(TMAP_DOUBLE2, 0);
@@ -376,7 +376,7 @@ void show_treasure_map(void)
 
 			/* */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_ttx(0xb5c),
+				(char*)get_ttx(727),
 				(char*)get_hero(get_random_hero()) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -473,7 +473,7 @@ signed short game_options(void)
 		/* if the party is in a town */
 		load_tx(ARCHIVE_FILE_MAPTEXT_LTX);
 
-		GUI_print_header(get_tx(4 * (ds_readbs(CURRENT_TOWN) - 1)));
+		GUI_print_header(get_tx(ds_readbs(CURRENT_TOWN) - 1));
 
 		load_tx(ds_readbs(CURRENT_TOWN) + (ARCHIVE_FILE_CITY_DAT-1));
 
@@ -528,16 +528,16 @@ signed short game_options(void)
 		if (ds_readw(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
 			/* use the radio menu */
-			answer = GUI_radio(get_ttx(0x938), 9,
-						get_ttx(0x390),
-						get_ttx(0x394),
-						get_ttx(0x494),
-						get_ttx(0x980),
-						get_ttx(0xcf8),
-						get_ttx(0xcf0),
-						get_ttx(0xcfc),
-						get_ttx(0x930),
-						get_ttx(0x934)) - 1;
+			answer = GUI_radio(get_ttx(590), 9,
+						get_ttx(228),
+						get_ttx(229),
+						get_ttx(293),
+						get_ttx(608),
+						get_ttx(830),
+						get_ttx(828),
+						get_ttx(831),
+						get_ttx(588),
+						get_ttx(589)) - 1;
 
 			if (answer != -2) {
 				ds_writew(ACTION, answer + 129);
@@ -579,7 +579,7 @@ signed short game_options(void)
 		} else if (ds_readws(ACTION) == 134) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xcec),
+				(char*)get_ttx(827),
 				ds_readws(DELAY_FACTOR));
 
 			new_delay = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -594,7 +594,7 @@ signed short game_options(void)
 
 		} else if (ds_readws(ACTION) == 136) {
 
-			if (GUI_bool(get_ttx(0x4ac))) {
+			if (GUI_bool(get_ttx(299))) {
 
 				done = -1;
 				ds_writew(GAME_STATE, GAME_STATE_QUIT);
@@ -665,7 +665,7 @@ signed short show_storytext(void)
 
 	person = random_schick(17) - 1;
 
-	ptr = get_tx(4 * person);
+	ptr = get_tx(person);
 
 	switch (person) {
 
@@ -816,7 +816,7 @@ void tumult(void)
 	ds_writew(TEXTBOX_WIDTH, 7);
 
 	/* print message */
-	GUI_output(get_ttx(0xbf0));
+	GUI_output(get_ttx(764));
 
 	/* each hero in the group looses 1W6 LE */
 	sub_group_le(random_schick(6));
@@ -824,12 +824,12 @@ void tumult(void)
 
 	/* the guards or a mob */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_ttx(0xbf4),
+		(char*)get_ttx(765),
 		((ds_readb(CURRENT_TOWN) == 39 ||	/* PREM */
 			ds_readb(CURRENT_TOWN) == 18 ||	/* PHEXCAER */
 			ds_readb(CURRENT_TOWN) == 1 ||	/* THORWAL */
 			ds_readb(CURRENT_TOWN) == 17)	/* OBERORKEN */
-				? (char*)get_ttx(0xbf8) : (char*)get_ttx(0xbfc)));
+				? (char*)get_ttx(766) : (char*)get_ttx(767)));
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
 

--- a/src/custom/schick/rewrite_m302de/seg026.cpp
+++ b/src/custom/schick/rewrite_m302de/seg026.cpp
@@ -213,7 +213,7 @@ signed short load_game_state(void)
 			p_datseg + (SAVEGAME_NAMES + 18),
 			p_datseg + (SAVEGAME_NAMES + 27),
 			p_datseg + (SAVEGAME_NAMES + 36),
-			get_ttx(0xb84)) -1;
+			get_ttx(737)) -1;
 
 	/* sanity check if answer is in range */
 	if (answer != -2 && answer != 5) {
@@ -225,7 +225,7 @@ signed short load_game_state(void)
 		/* open the game state file */
 		if ((handle_gs = bc_open(ds_readfp(TEXT_OUTPUT_BUF), 0x8001)) == -1)
 		{
-			GUI_output(get_ttx(0x9ec));
+			GUI_output(get_ttx(635));
 			retval = -1;
 			return retval;
 		}
@@ -454,7 +454,7 @@ signed short save_game_state(void)
 	if (ds_readws(GAME_STATE) == GAME_STATE_VICTORY) {
 
 		/* game done */
-		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0xca8));
+		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(810));
 
 	} else {
 
@@ -463,19 +463,19 @@ signed short save_game_state(void)
 			/* save outside the temple */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xcb4),
+				(char*)get_ttx(813),
 				1,
-				get_ttx(0x620),
+				get_ttx(392),
 				p_datseg + EMPTY_STRING1);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_ttx(4),
+				(char*)get_ttx(1),
 				(char*)Real2Host(ds_readd(DTP2)));
 		} else {
 
 			/* save inside a temple */
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_ttx(4),
+				(char*)get_ttx(1),
 				(char*)p_datseg + EMPTY_STRING2);
 		}
 	}
@@ -487,7 +487,7 @@ signed short save_game_state(void)
 			p_datseg + (SAVEGAME_NAMES + 9 * 2),
 			p_datseg + (SAVEGAME_NAMES + 9 * 3),
 			p_datseg + (SAVEGAME_NAMES + 9 * 4),
-			get_ttx(0xb84)) - 1;
+			get_ttx(737)) - 1;
 
 	ds_writew(TEXTBOX_WIDTH, tw_bak);
 
@@ -500,7 +500,7 @@ signed short save_game_state(void)
 			/* ask for filename */
 			ds_writew(GUI_ENTERING_SAVEGAME, 1);
 			strcpy((char*)Real2Host(ds_readd(TEXT_INPUT_BUF)), (char*)p_datseg + SAVEGAME_NAMES + 9 * slot);
-			GUI_input(get_ttx(0x9e8), 8);
+			GUI_input(get_ttx(634), 8);
 			ds_writew(GUI_ENTERING_SAVEGAME, 0);
 
 			if (host_readbs(Real2Host(ds_readd(TEXT_INPUT_BUF))) == 0) {
@@ -517,7 +517,7 @@ signed short save_game_state(void)
 
 				if (slot != tw_bak && !strcmp((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50)) {
 
-					GUI_output(get_ttx(0xc98));
+					GUI_output(get_ttx(806));
 					flag = 1;
 				}
 			}
@@ -569,7 +569,7 @@ signed short save_game_state(void)
 		strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)p_datseg + SAVEGAME_SUFFIX3);
 
 		while ((l_di = bc__creat((RealPt)ds_readd(TEXT_OUTPUT_BUF), 0)) == -1) {
-			GUI_output(get_ttx(0x570));
+			GUI_output(get_ttx(348));
 			return 0;
 		}
 
@@ -614,7 +614,7 @@ signed short save_game_state(void)
 
 		/* check if enough bytes were written */
 		if (status_len + 16 + 4L != filepos) {
-			GUI_output(get_ttx(0x570));
+			GUI_output(get_ttx(348));
 			bc_close(l_di);
 			return 0;
 		}
@@ -624,7 +624,7 @@ signed short save_game_state(void)
 		filepos += len;
 
 		if (len != 4 * 286) {
-			GUI_output(get_ttx(0x570));
+			GUI_output(get_ttx(348));
 			bc_close(l_di);
 			return 0;
 		}
@@ -650,7 +650,7 @@ signed short save_game_state(void)
 				filepos += len;
 
 				if ((Bit16u)host_readd(Real2Host(ds_readd(SAVED_FILES_BUF)) + 4 * tw_bak) != len) {
-					GUI_output(get_ttx(0x570));
+					GUI_output(get_ttx(348));
 					bc_close(l_di);
 					return 0;
 				}
@@ -704,7 +704,7 @@ signed short save_game_state(void)
 			len = bc__write(l_di, (RealPt)ds_readd(RENDERBUF_PTR), SIZEOF_HERO);
 
 			if (len != SIZEOF_HERO) {
-				GUI_output(get_ttx(0x570));
+				GUI_output(get_ttx(348));
 				bc_close(l_di);
 				return 0;
 			}
@@ -780,7 +780,7 @@ signed short read_chr_temp(RealPt fname, signed short hero_pos, signed short a2)
 		}
 
 	} else {
-		GUI_output(get_ttx(0x10));
+		GUI_output(get_ttx(4));
 		return 0;
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg030.cpp
+++ b/src/custom/schick/rewrite_m302de/seg030.cpp
@@ -117,24 +117,24 @@ void prepare_date_str(void)
 	if (ds_readbs(DAY_OF_MONTH) < 0) {
 		/* Days of the nameless */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x61c),
-			get_ttx((0x15d + ds_readbs(DAY_OF_WEEK)) * 4),
+			(char*)get_ttx(391),
+			get_ttx(349 + ds_readbs(DAY_OF_WEEK)),
 			ds_readbs(YEAR), hour);
 	} else {
 		/* Normal day */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x590),
-			get_ttx((0x15d + ds_readbs(DAY_OF_WEEK)) * 4),
+			(char*)get_ttx(356),
+			get_ttx(349 + ds_readbs(DAY_OF_WEEK)),
 			ds_readbs(DAY_OF_MONTH),
-			get_ttx((0x15 + ds_readbs(MONTH)) * 4),
-			get_ttx((0x227 + get_current_season()) * 4),
+			get_ttx(21 + ds_readbs(MONTH)),
+			get_ttx(551 + get_current_season()),
 			ds_readbs(YEAR), hour);
 	}
 
 	if (ds_readbs(SPECIAL_DAY) != 0) {
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)get_ttx(0x594),
-			get_ttx((0x165 + ds_readbs(SPECIAL_DAY)) * 4));
+			(char*)get_ttx(357),
+			get_ttx(357 + ds_readbs(SPECIAL_DAY)));
 
 		strcat((char*)Real2Host(ds_readd(DTP2)),
 			(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -195,7 +195,7 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 
 			txt_id = host_readws(state_ptr) & 0x7fff;
 
-			fmt = (char*)get_tx2(4 * (txt_id + txt_offset));
+			fmt = (char*)get_tx2(txt_id + txt_offset);
 
 			if (ds_readws(TLK_ID) == 11) {
 				if (ds_readws(DIALOG_INFORMER) == 2) {
@@ -260,15 +260,15 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 
 					if (txt_id == 21) {
 
-						sprintf(dst, fmt, (char*)get_ttx(0xa48));
+						sprintf(dst, fmt, (char*)get_ttx(658));
 
 					} else if (txt_id == 22) {
 
-						sprintf(dst, fmt, (char*)get_ttx(0xa58));
+						sprintf(dst, fmt, (char*)get_ttx(662));
 
 					} else if (txt_id == 23) {
 
-						sprintf(dst, fmt, (char*)get_ttx(0xa54));
+						sprintf(dst, fmt, (char*)get_ttx(661));
 
 					} else if (txt_id == 29) {
 
@@ -326,23 +326,23 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 
 						} else if (txt_id == 28) {
 
-							sprintf(dst, fmt, (char*)get_ttx(0xa5c));
+							sprintf(dst, fmt, (char*)get_ttx(663));
 
 						} else if (txt_id == 29) {
 
-							sprintf(dst, fmt, (char*)get_ttx(0xa60));
+							sprintf(dst, fmt, (char*)get_ttx(664));
 
 						} else if (txt_id == 30) {
 
-							sprintf(dst, fmt, (char*)get_ttx(0xa80));
+							sprintf(dst, fmt, (char*)get_ttx(672));
 
 						} else if (txt_id == 38) {
 
-							sprintf(dst, fmt, (char*)get_ttx(4 * (235 + ds_readb(SWAFNILD_TP4))));
+							sprintf(dst, fmt, (char*)get_ttx(235 + ds_readb(SWAFNILD_TP4)));
 
 						} else if (txt_id == 49) {
 
-							sprintf(dst, fmt, (char*)get_ttx(4 * (235 + ds_readb(SWAFNILD_TP4))));
+							sprintf(dst, fmt, (char*)get_ttx(235 + ds_readb(SWAFNILD_TP4)));
 
 							ds_writebs(CURRENT_TOWN, ds_readbs(SWAFNILD_TP4));
 
@@ -352,18 +352,18 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 						} else if (txt_id == 52) {
 
 							sprintf(dst, fmt,
-								(char*)get_ttx(4 * (235 + ds_readb(SWAFNILD_TP1))),
-								(char*)get_ttx(4 * (235 + ds_readb(SWAFNILD_TP2))),
-								(char*)get_ttx(4 * (235 + ds_readb(SWAFNILD_TP3))));
+								(char*)get_ttx(235 + ds_readb(SWAFNILD_TP1)),
+								(char*)get_ttx(235 + ds_readb(SWAFNILD_TP2)),
+								(char*)get_ttx(235 + ds_readb(SWAFNILD_TP3)));
 
 						} else if (txt_id == 59) {
 
-							sprintf(dst, fmt, (char*)get_ttx(4 * (235 + (
+							sprintf(dst, fmt, (char*)get_ttx(235 + (
 							    ds_readb(SWAFNILD_DESTINATION) == 1 ?
                                     ds_readb(SWAFNILD_TP1)
                                 : (ds_readb(SWAFNILD_DESTINATION) == 2 ?
                                     ds_readb(SWAFNILD_TP2)
-                                : ds_readb(SWAFNILD_TP3))))));
+                                : ds_readb(SWAFNILD_TP3)))));
 
 						} else {
 							strcpy(dst, fmt);
@@ -497,9 +497,9 @@ void do_talk(signed short talk_id, signed short tlk_informer)
 			}
 
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), Real2Host(ds_readd(DIALOG_TITLE)), (Bit8u*)dst, optioncount,
-					get_tx2(4 * (host_readb(state_ptr + 2) + txt_offset)),
-					get_tx2(4 * (host_readb(state_ptr + 3) + txt_offset)),
-					get_tx2(4 * (host_readb(state_ptr + 4) + txt_offset)));
+					get_tx2(host_readb(state_ptr + 2) + txt_offset),
+					get_tx2(host_readb(state_ptr + 3) + txt_offset),
+					get_tx2(host_readb(state_ptr + 4) + txt_offset));
 		}
 
 
@@ -554,7 +554,7 @@ void talk_switch(void)
 				ds_writew(FIG_DISCARD, 1);
 
 				if (!do_fight(FIGHTS_DASP1A)) {
-					if (GUI_bool(get_tx(0x58))) {
+					if (GUI_bool(get_tx(22))) {
 
 						ds_writew(FIG_DISCARD, 0);
 

--- a/src/custom/schick/rewrite_m302de/seg031.cpp
+++ b/src/custom/schick/rewrite_m302de/seg031.cpp
@@ -101,7 +101,7 @@ void do_random_talk(signed short talk_id, signed short informer_id)
 		if (txt_id_raw != -1) {
 
 			txt_id = (4 * host_readw(state_ptr) + txt_id_rand) & 0x7fff;
-			fmt = (char*)get_tx(4 * (txt_id + txt_offset));
+			fmt = (char*)get_tx(txt_id + txt_offset);
 
 			if (ds_readws(TLK_ID) == 15) {
 
@@ -168,9 +168,9 @@ void do_random_talk(signed short talk_id, signed short informer_id)
 			}
 
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), dialog_title, (Bit8u*)dst, optioncount,
-					get_tx(4 * options[0].txt),
-					get_tx(4 * options[1].txt),
-					get_tx(4 * options[2].txt));
+					get_tx(options[0].txt),
+					get_tx(options[1].txt),
+					get_tx(options[2].txt));
 
 		} else {
 			options[0].goto_state = host_readb(state_ptr + 5);
@@ -224,7 +224,7 @@ RealPt get_informer_forename(void)
 		if (host_readbs(p_info + 2) == ds_readbs(CURRENT_TOWN)) {
 
 			i = 0;
-			informer_name = get_ttx(4 * host_readws(p_info));
+			informer_name = get_ttx(host_readws(p_info));
 
 			do {
 				tmp = host_readbs(informer_name);
@@ -232,7 +232,7 @@ RealPt get_informer_forename(void)
 				i++;
 			} while (tmp != ' ');
 
-			strncpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(4 * host_readws(p_info)), i);
+			strncpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(host_readws(p_info)), i);
 #ifdef M302de_ORIGINAL_BUGFIX
 			break;
 #endif
@@ -352,7 +352,7 @@ RealPt get_random_tavern_message(void)
 
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 			(char*)Real2Host(ptr),
-			(char*)get_ttx(4 * (ds_readbs(CURRENT_TOWN) + 235)));
+			(char*)get_ttx(ds_readbs(CURRENT_TOWN) + 235));
 
 		return (RealPt)ds_readd(TEXT_OUTPUT_BUF);
 	} else {

--- a/src/custom/schick/rewrite_m302de/seg033.cpp
+++ b/src/custom/schick/rewrite_m302de/seg033.cpp
@@ -108,7 +108,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 				/* prepare question with BP */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x48),
+					(char*)get_tx(18),
 					host_readbs(hero + HERO_BP_LEFT));
 
 				txt_tabpos_bak = ds_readws(TXT_TABPOS1);
@@ -122,37 +122,37 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					/* no weapon or weapon broken, use red color for "change weapon" */
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 						(char*)p_datseg + RED_STRING1,
-						get_tx(0x60));
+						get_tx(24));
 				} else {
 					/* good weapon, no special color */
-					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(0x60));
+					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(24));
 				}
 
 				if (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) * 110 <= host_readws(hero + HERO_LOAD)) {
 					/* too much weight, use red color for "drop item" */
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50,
 						(char*)p_datseg + RED_STRING2,
-						get_tx(0xb8));
+						get_tx(46));
 				} else {
 					/* weight ok, no special color */
-					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50, (char*)get_tx(0xb8));
+					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50, (char*)get_tx(46));
 				}
 
 				/* show radion menu */
 				selected = GUI_radio(Real2Host(ds_readd(DTP2)), l1 != 0 ? 13 : 12,
-							get_tx(0x4c),
-							get_tx(0x50),
-							get_tx(0x54),
-							get_tx(0x58),
-							get_tx(0x5c),
+							get_tx(19),
+							get_tx(20),
+							get_tx(21),
+							get_tx(22),
+							get_tx(23),
 							Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50,
 							Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-							get_tx(0x40),
-							get_tx(0x68),
-							get_tx(0x64),
-							get_tx(0x88),
-							get_tx(0xcc),
-							get_tx(0x6c));
+							get_tx(16),
+							get_tx(26),
+							get_tx(25),
+							get_tx(34),
+							get_tx(51),
+							get_tx(27));
 
 				update_mouse_cursor();
 				ds_writew(TXT_TABPOS1, txt_tabpos_bak);
@@ -205,14 +205,14 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					} else {
 						/* no BP left */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x44),
+							(char*)get_tx(17),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
 
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x1c),
+						(char*)get_tx(7),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
@@ -261,9 +261,9 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					if (target_id != -5) {
 
 						if ((target_id <= 0) || (target_id >= 50)) {
-							GUI_output(get_tx(0x70));
+							GUI_output(get_tx(28));
 						} else if (target_id == (hero_pos + 1)) {
-							GUI_output(get_tx(0x0c));
+							GUI_output(get_tx(3));
 						} else if (((target_id < 10) && hero_dead(get_hero(target_id - 1))) ||
 								((target_id >= 10) && (target_id < 30) &&
 										/* unconscious or dead */
@@ -274,7 +274,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 										(test_bit0(p_datseg + ((ENEMY_SHEETS - 30*SIZEOF_ENEMY_SHEET) + ENEMY_SHEET_STATUS1) + SIZEOF_ENEMY_SHEET * target_id) ||
 										test_bit6(p_datseg + ((ENEMY_SHEETS - 30*SIZEOF_ENEMY_SHEET) + ENEMY_SHEET_STATUS1) + SIZEOF_ENEMY_SHEET * target_id))))
 						{
-							GUI_output(get_tx(0x74));
+							GUI_output(get_tx(29));
 
 							host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_MOVE);
 
@@ -283,7 +283,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 						} else if ((range_weapon != -1) && (calc_beeline(x, y, target_x, target_y) < 2)) {
 
-							GUI_output(get_ttx(0x7f0));
+							GUI_output(get_ttx(508));
 
 							host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_MOVE);
 
@@ -300,10 +300,10 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 								do {
 									refresh_screen_size();
 
-									selected = GUI_radio(get_ttx(0x920), 3,
-											get_ttx(0x924),
-											get_ttx(0x928),
-											get_ttx(0x92c));
+									selected = GUI_radio(get_ttx(584), 3,
+											get_ttx(585),
+											get_ttx(586),
+											get_ttx(587));
 									update_mouse_cursor();
 								} while (selected == -1);
 
@@ -321,7 +321,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 				} else {
 					/* no BP left */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x44),
+						(char*)get_tx(17),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
@@ -339,7 +339,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 				} else {
 					/* no BP left */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x44),
+						(char*)get_tx(17),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
@@ -349,7 +349,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 				if (host_readbs(hero + HERO_TYPE) < 7) {
 					/* not a magic user */
-					GUI_output(get_ttx(0x35c));
+					GUI_output(get_ttx(215));
 				} else {
 
 					if (host_readbs(hero + HERO_BP_LEFT) >= 5) {
@@ -368,7 +368,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 							if (host_readbs(spell + 5) == -1) {
 
 								/* not a combat spell */
-								GUI_output(get_ttx(0x940));
+								GUI_output(get_ttx(592));
 
 							} else {
 
@@ -397,24 +397,24 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 									if (target_id != -99) {
 
 										if (target_id < 0) {
-											GUI_output(get_tx(0x70));
+											GUI_output(get_tx(28));
 
 										} else if ((target_id == 0) &&
 											(host_readbs(spell + 7) != 4))
 										{
-											GUI_output(get_tx(0x10));
+											GUI_output(get_tx(4));
 
 										} else if ((target_id < 10) &&
 											(host_readbs(spell + 7) != 2) &&
 											(host_readbs(spell + 7) != 3))
 										{
-											GUI_output(get_tx(0x14));
+											GUI_output(get_tx(5));
 										} else if ((target_id >= 10) &&
 											(target_id < 50) &&
 											(host_readbs(spell + 7) != 1) &&
 											(host_readbs(spell + 7) != 3))
 										{
-											GUI_output(get_tx(0x18));
+											GUI_output(get_tx(6));
 
 										} else {
 											host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_SPELL);
@@ -435,14 +435,14 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 							(get_spell_cost(host_readbs(hero + HERO_SPELL_ID), 1) > host_readws(hero + HERO_AE)))
 						{
 							/* not enough AE */
-							GUI_output(get_ttx(0x544));
+							GUI_output(get_ttx(337));
 							host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_MOVE);
 							done = 0;
 						}
 					} else {
 						/* no BP left */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x44),
+							(char*)get_tx(17),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
@@ -476,7 +476,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 						if ((host_readbs(hero + HERO_ENEMY_ID) < 0) || host_readbs(hero + HERO_ENEMY_ID) >= 50) {
 							host_writeb(hero + HERO_ENEMY_ID, 0);
-							GUI_output(get_tx(0x70));
+							GUI_output(get_tx(28));
 						} else {
 							/* set BP to 0 */
 							host_writeb(hero + HERO_BP_LEFT, 0);
@@ -487,7 +487,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					} else {
 						/* no BP left */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x44),
+							(char*)get_tx(17),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
@@ -517,17 +517,17 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 						if (radio_i == 0) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0xbb8),
+								(char*)get_ttx(750),
 								(char*)hero + HERO_NAME2);
 							GUI_output(Real2Host(ds_readd(DTP2)));
 						} else {
 							if (host_readws(hero + HERO_ITEM_LEFT) == 0) {
 								sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-									(char*)get_tx(0xf0),
+									(char*)get_tx(60),
 									(char*)hero + HERO_NAME2);
 							} else {
 								sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-									(char*)get_tx(0x7c),
+									(char*)get_tx(31),
 									(char*)hero + HERO_NAME2,
 									(char*)Real2Host(GUI_names_grammar((signed short)0x8002, host_readws(hero + HERO_ITEM_LEFT), 0)));
 							}
@@ -568,7 +568,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					} else {
 						/* no BP left */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x44),
+							(char*)get_tx(17),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
@@ -592,7 +592,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 								sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * radio_i)),
 									(char*)p_datseg + SPACE_SEPARATED_STRINGS, /* "%s %s" */
 									(char*)Real2Host(GUI_name_singular((Bit8u*)get_itemname(weapon_id))),
-									ks_broken(hero + HERO_ITEM_HEAD + 14 * slot_nr) ? get_ttx(0x778) : p_datseg + EMPTY_STRING3);
+									ks_broken(hero + HERO_ITEM_HEAD + 14 * slot_nr) ? get_ttx(478) : p_datseg + EMPTY_STRING3);
 
 								radio_i++;
 							}
@@ -600,12 +600,12 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 						if (radio_i == 0) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx(0x4),
+								(char*)get_tx(1),
 								(char*)hero + HERO_NAME2);
 							GUI_output(Real2Host(ds_readd(DTP2)));
 						} else {
 							sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-								(char*)get_tx(0x8),
+								(char*)get_tx(2),
 								(char*)hero + HERO_NAME2,
 								(char*)Real2Host(GUI_names_grammar((signed short)0x8002, host_readws(hero + HERO_ITEM_RIGHT), 0)));
 
@@ -666,7 +666,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					} else {
 						/* no BP left */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x44),
+							(char*)get_tx(17),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
@@ -760,11 +760,11 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 				}
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x0),
+					(char*)get_tx(0),
 					/* name */
 					(char*)hero + HERO_NAME2,
 					/* typus */
-					get_ttx(4 * ((host_readbs(hero + HERO_SEX) != 0 ? 0x251 : 9) + host_readbs(hero + HERO_TYPE))),
+					get_ttx((host_readbs(hero + HERO_SEX) != 0 ? 0x251 : 9) + host_readbs(hero + HERO_TYPE)),
 					/* level */
 					host_readbs(hero + HERO_LEVEL),
 					/* AT and PA value */
@@ -780,9 +780,9 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					/* AE */
 					host_readws(hero + HERO_AE), host_readws(hero + HERO_AE_ORIG),
 					/* poison */
-					hero_is_poisoned(hero) ? get_tx(0x90) : p_datseg + EMPTY_STRING4,
+					hero_is_poisoned(hero) ? get_tx(36) : p_datseg + EMPTY_STRING4,
 					/* cursed */
-					hero_cursed(hero) == 1 ? get_tx(0x98) : p_datseg + EMPTY_STRING5);
+					hero_cursed(hero) == 1 ? get_tx(38) : p_datseg + EMPTY_STRING5);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -804,7 +804,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 					refresh_screen_size();
 
 					/* use magic in autofight */
-					ds_writeb(AUTOFIGHT_MAGIC, GUI_bool(get_tx(0xd4)));
+					ds_writeb(AUTOFIGHT_MAGIC, GUI_bool(get_tx(53)));
 
 					update_mouse_cursor();
 
@@ -837,12 +837,12 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 					if (radio_i == 0) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xbb8),
+							(char*)get_ttx(750),
 							(char*)hero + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					} else {
 						sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-							(char*)get_tx(0xbc),
+							(char*)get_tx(47),
 							(char*)hero + HERO_NAME2);
 
 						refresh_screen_size();
@@ -882,7 +882,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 				} else {
 					/* no BP left */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x44),
+						(char*)get_tx(17),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
@@ -892,7 +892,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 
 				refresh_screen_size();
 
-				if (GUI_bool(get_tx(0xd0))) {
+				if (GUI_bool(get_tx(52))) {
 					done = 1;
 					ds_writew(IN_FIGHT, 0);
 					ds_writew(GAME_STATE, GAME_STATE_FIGQUIT);
@@ -918,7 +918,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 						&& (hero_dead(get_hero(host_readbs(hero + HERO_ENEMY_ID) - 1)))))
 					{
 
-						GUI_output(get_tx(0x74));
+						GUI_output(get_tx(29));
 						host_writebs(hero + HERO_ACTION_ID, FIG_ACTION_WAIT);
 						host_writebs(hero + HERO_ENEMY_ID, 0);
 						done = 0;
@@ -930,7 +930,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 						&& (hero_unkn3(get_hero(host_readbs(hero + HERO_ENEMY_ID) - 1)))))
 					{
 
-						/* GUI_output(get_tx(0x74)); */
+						/* GUI_output(get_tx(29)); */
 						host_writebs(hero + HERO_ACTION_ID, FIG_ACTION_WAIT);
 						host_writebs(hero + HERO_ENEMY_ID, 0);
 						done = 0;
@@ -938,7 +938,7 @@ void FIG_menu(Bit8u *hero, signed short hero_pos, signed short x, signed short y
 							(host_readbs(hero + HERO_ACTION_ID) == FIG_ACTION_RANGE_ATTACK)) &&
 							!check_hero_range_attack(hero, hero_pos))
 					{
-						/* GUI_output(get_tx(0x74)); */
+						/* GUI_output(get_tx(29)); */
 						host_writebs(hero + HERO_ACTION_ID, FIG_ACTION_WAIT);
 						host_writebs(hero + HERO_ENEMY_ID, 0);
 						done = 0;

--- a/src/custom/schick/rewrite_m302de/seg034.cpp
+++ b/src/custom/schick/rewrite_m302de/seg034.cpp
@@ -815,14 +815,14 @@ void FIG_move_hero(Bit8u *hero, signed short hero_pos, Bit8u *px, Bit8u *py)
 
 			if (!l_si) {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30), l13);
+					(char*)get_tx(12), l13);
 			}
 
 
-			GUI_print_string(l_si == 1 ? get_tx(0x34) :
-						(l_si == 3 ? get_tx(0x78) :
-						(l_si == 2 ? get_tx(0x80) :
-						(l_si == 4 ? get_tx(0xc0) : Real2Host(ds_readd(DTP2))))),
+			GUI_print_string(l_si == 1 ? get_tx(13) :
+						(l_si == 3 ? get_tx(30) :
+						(l_si == 2 ? get_tx(32) :
+						(l_si == 4 ? get_tx(48) : Real2Host(ds_readd(DTP2))))),
 					 5, 190);
 
 			set_textcolor(fg_bak, bg_bak);
@@ -847,7 +847,7 @@ void FIG_move_hero(Bit8u *hero, signed short hero_pos, Bit8u *px, Bit8u *py)
 
 			if (l_si == 1) {
 
-				if (GUI_bool(get_tx(0x8c))) {
+				if (GUI_bool(get_tx(35))) {
 					host_writeb(hero + HERO_ACTION_ID, FIG_ACTION_FLEE);
 					l_si = 0;
 				} else {
@@ -871,9 +871,9 @@ void FIG_move_hero(Bit8u *hero, signed short hero_pos, Bit8u *px, Bit8u *py)
 			}
 
 		} else if (l_si == 3) {
-			GUI_output(get_tx(0xc4));
+			GUI_output(get_tx(49));
 		} else if (l_si == 4) {
-			GUI_output(get_tx(0xc8));
+			GUI_output(get_tx(50));
 		}
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg035.cpp
+++ b/src/custom/schick/rewrite_m302de/seg035.cpp
@@ -132,7 +132,7 @@ void FIG_loot_monsters(void)
 					l6 = l3 - 14;
 				}
 
-				strcpy(a[l5], (char*)get_ttx(0xbbc));
+				strcpy(a[l5], (char*)get_ttx(751));
 			} else {
 				l_si = 0;
 				l5 = 0;
@@ -142,7 +142,7 @@ void FIG_loot_monsters(void)
 			textbox_width_bak = ds_readws(TEXTBOX_WIDTH);
 			ds_writew(TEXTBOX_WIDTH, 6);
 
-			l4 = GUI_radio(get_tx(0x38), l6,
+			l4 = GUI_radio(get_tx(14), l6,
 						a[0 + l_si], a[1 + l_si], a[2 + l_si], a[3 + l_si],
 						a[4 + l_si], a[5 + l_si], a[6 + l_si], a[7 + l_si],
 						a[8 + l_si], a[9 + l_si], a[10 + l_si], a[11 + l_si],
@@ -191,7 +191,7 @@ void FIG_loot_monsters(void)
 		make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 		sprintf((char*)(Real2Host(ds_readd(DTP2))),
-			(char*)get_tx(0x3c),
+			(char*)get_tx(15),
 			Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -254,7 +254,7 @@ void FIG_split_ap(void)
 	}
 
 	/* prepare output */
-	sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x84), ap);
+	sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(33), ap);
 	GUI_output(Real2Host(ds_readd(DTP2)));
 
 	/* give AP to the group */
@@ -296,7 +296,7 @@ signed short check_hero_range_attack(Bit8u *hero, signed short hero_pos)
 #endif
 	/* check that the range attack is in the same line */
 	if ((hero_x != target_x) && (hero_y != target_y)) {
-		GUI_output(get_tx(0xb4));
+		GUI_output(get_tx(45));
 		retval = 0;
 	}
 
@@ -321,7 +321,7 @@ signed short check_hero_range_attack(Bit8u *hero, signed short hero_pos)
 			for (i = hero_x; i < target_x; i++) {
 
 				if (!seg034_000(hero_x, hero_y, i, hero_y, 1, 0, 99)) {
-					GUI_output(get_tx(0xb4));
+					GUI_output(get_tx(45));
 					retval = 0;
 					break;
 				}
@@ -330,7 +330,7 @@ signed short check_hero_range_attack(Bit8u *hero, signed short hero_pos)
 			for (i = hero_y; i < target_y; i++) {
 
 				if (!seg034_000(hero_x, hero_y, hero_x, i, 0, 1, 99)) {
-					GUI_output(get_tx(0xb4));
+					GUI_output(get_tx(45));
 					retval = 0;
 					break;
 				}
@@ -339,7 +339,7 @@ signed short check_hero_range_attack(Bit8u *hero, signed short hero_pos)
 	} else {
 
 		if (host_readbs(hero + HERO_ACTION_ID) == FIG_ACTION_RANGE_ATTACK) {
-			GUI_output(get_ttx(0x7f0));
+			GUI_output(get_ttx(508));
 			retval = 0;
 		}
 	}

--- a/src/custom/schick/rewrite_m302de/seg041.cpp
+++ b/src/custom/schick/rewrite_m302de/seg041.cpp
@@ -86,7 +86,7 @@ signed short range_attack_check_ammo(Bit8u *hero, signed short arg)
 			if (arg != 2) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x20),
+					(char*)get_tx(8),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -107,7 +107,7 @@ signed short range_attack_check_ammo(Bit8u *hero, signed short arg)
 			if (arg != 2) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x24),
+					(char*)get_tx(9),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -126,7 +126,7 @@ signed short range_attack_check_ammo(Bit8u *hero, signed short arg)
 			if (arg != 2) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x28),
+					(char*)get_tx(10),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -494,7 +494,7 @@ signed short FIG_get_enemy_attack_damage(Bit8u *attacker, Bit8u *attacked, signe
 			/* 5% chance to loose this item */
 			if (random_schick(100) < 5) {
 				drop_item(hero, pos, 1);
-				GUI_output(get_tx(0x2c));
+				GUI_output(get_tx(11));
 			}
 		}
 

--- a/src/custom/schick/rewrite_m302de/seg042.cpp
+++ b/src/custom/schick/rewrite_m302de/seg042.cpp
@@ -693,7 +693,7 @@ void FIG_do_hero_action(RealPt hero, const signed short hero_pos)
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 						(char*)p_datseg + STRING_CASTS_SPELL,		/* "%s ZAUBERT %s" */
 						(char*)Real2Host(hero) + HERO_NAME2,
-						(char*)get_ttx(4 * (host_readbs(Real2Host(hero) + HERO_SPELL_ID) + 0x6a)));
+						(char*)get_ttx(host_readbs(Real2Host(hero) + HERO_SPELL_ID) + 0x6a));
 
 					GUI_print_string(Real2Host(ds_readd(TEXT_OUTPUT_BUF)), 1, 194);
 

--- a/src/custom/schick/rewrite_m302de/seg043.cpp
+++ b/src/custom/schick/rewrite_m302de/seg043.cpp
@@ -780,7 +780,7 @@ void FIG_use_item(Bit8u *hero, Bit8u *target_monster, Bit8u *target_hero, signed
 
 		if (host_readbs(hero + HERO_ENEMY_ID) >= 10) {
 
-			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x94));
+			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(37));
 
 			FIG_damage_enemy(target_monster, damage, 0);
 
@@ -793,7 +793,7 @@ void FIG_use_item(Bit8u *hero, Bit8u *target_monster, Bit8u *target_hero, signed
 
 			if (flag != 0) {
 
-				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x94));
+				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(37));
 
 				sub_hero_le(target_hero, damage);
 

--- a/src/custom/schick/rewrite_m302de/seg046.cpp
+++ b/src/custom/schick/rewrite_m302de/seg046.cpp
@@ -45,7 +45,7 @@ void status_show_spell(Bit8u *hero, unsigned short spell, unsigned short fsig,
 	group = spell - fsig;
 
 	/* print spellname */
-	GUI_print_string(get_ttx((spell + 0x6a) * 4), x1, gy + group * 7);
+	GUI_print_string(get_ttx(spell + 0x6a), x1, gy + group * 7);
 
 	/* convert value to string */
 	my_itoa(host_readbs(hero + HERO_SPELLS + spell) , str, 10);
@@ -73,7 +73,7 @@ void status_show_skill(Bit8u *hero, unsigned short skill, unsigned short ftig,
 	group = skill - ftig;
 
 	/* print skillname */
-	GUI_print_string(get_ttx((skill + 0x30) * 4), x1, gy + group * 7);
+	GUI_print_string(get_ttx(skill + 0x30), x1, gy + group * 7);
 
 	/* convert value to string */
 	my_itoa(host_readbs(hero + HERO_TA_FIGHT + skill) , str, 10);
@@ -95,26 +95,26 @@ void status_show_skills(Bit8u *hero) {
 	set_textcolor(0xff, 2);
 
 	/* print skill category names */
-	GUI_print_string(get_ttx(0x190),
-		GUI_get_first_pos_centered(get_ttx(0x190), 5, 100, 0), 55);
+	GUI_print_string(get_ttx(100),
+		GUI_get_first_pos_centered(get_ttx(100), 5, 100, 0), 55);
 
-	GUI_print_string(get_ttx(0x1a0),
-		GUI_get_first_pos_centered(get_ttx(0x1a0), 110, 100, 0), 55);
+	GUI_print_string(get_ttx(104),
+		GUI_get_first_pos_centered(get_ttx(104), 110, 100, 0), 55);
 
-	GUI_print_string(get_ttx(0x194),
-		GUI_get_first_pos_centered(get_ttx(0x194), 215, 100, 0), 55);
+	GUI_print_string(get_ttx(101),
+		GUI_get_first_pos_centered(get_ttx(101), 215, 100, 0), 55);
 
-	GUI_print_string(get_ttx(0x1a4),
-		GUI_get_first_pos_centered(get_ttx(0x1a4), 5, 100, 0), 125);
+	GUI_print_string(get_ttx(105),
+		GUI_get_first_pos_centered(get_ttx(105), 5, 100, 0), 125);
 
-	GUI_print_string(get_ttx(0x19c),
-		GUI_get_first_pos_centered(get_ttx(0x19c), 110, 100, 0), 125);
+	GUI_print_string(get_ttx(103),
+		GUI_get_first_pos_centered(get_ttx(103), 110, 100, 0), 125);
 
-	GUI_print_string(get_ttx(0x198),
-		GUI_get_first_pos_centered(get_ttx(0x198), 215, 100, 0), 132);
+	GUI_print_string(get_ttx(102),
+		GUI_get_first_pos_centered(get_ttx(102), 215, 100, 0), 132);
 
-	GUI_print_string(get_ttx(0x1a8),
-		GUI_get_first_pos_centered(get_ttx(0x1a8), 5, 100, 0), 174);
+	GUI_print_string(get_ttx(106),
+		GUI_get_first_pos_centered(get_ttx(106), 5, 100, 0), 174);
 
 	set_textcolor(0, 2);
 
@@ -275,13 +275,13 @@ void status_show(Bit16u index)
 
 		/* print height */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x84),
+			(char*)get_tx2(33),
 			host_readb(Real2Host(hero) + HERO_HEIGHT));
 		GUI_print_string(Real2Host(ds_readd(DTP2)), 158, 116);
 
 		/* print weight */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x88),
+			(char*)get_tx2(34),
 			host_readw(Real2Host(hero) + HERO_WEIGHT));
 		GUI_print_string(Real2Host(ds_readd(DTP2)), 59, 179);
 	} else {
@@ -309,7 +309,7 @@ void status_show(Bit16u index)
 
 	/* print level */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx2(0x1c),
+		(char*)get_tx2(7),
 		host_readbs(Real2Host(hero) + HERO_LEVEL));
 	GUI_print_string(Real2Host(ds_readd(DTP2)), 59, 33);
 
@@ -325,34 +325,34 @@ void status_show(Bit16u index)
 	/* dead, unconscious or drunk */
 	if (hero_dead(Real2Host(hero)))
 		/* print if dead */
-		GUI_print_string(get_tx2(0x00), 155, 9);
+		GUI_print_string(get_tx2(0), 155, 9);
 	else if (hero_unc(Real2Host(hero)))
 		/* print if uncounscious */
-		GUI_print_string(get_tx2(0x18), 155, 9);
+		GUI_print_string(get_tx2(6), 155, 9);
 	else if (host_readb(Real2Host(hero) + HERO_DRUNK))
 		/* print if drunk */
-		GUI_print_string(get_tx2(0xd8), 155, 9);
+		GUI_print_string(get_tx2(54), 155, 9);
 
 	/* print sleeps */
 	if (hero_sleeps(Real2Host(hero)))
-		GUI_print_string(get_tx2(0x04), 155, 16);
+		GUI_print_string(get_tx2(1), 155, 16);
 
 	/* print stoned */
 	if (hero_stoned(Real2Host(hero)))
-		GUI_print_string(get_tx2(0x08), 155, 23);
+		GUI_print_string(get_tx2(2), 155, 23);
 
 	/* print diseased */
 	if (hero_is_diseased(Real2Host(hero)))
-		GUI_print_string(get_tx2(0x10), 155, 30);
+		GUI_print_string(get_tx2(4), 155, 30);
 
 	/* print poison */
 	if (hero_is_poisoned(Real2Host(hero)))
-		GUI_print_string(get_tx2(0x0c), 155, 37);
+		GUI_print_string(get_tx2(3), 155, 37);
 
 	/* print hunger */
-	GUI_print_string(get_tx2(0x20), 220, 36);
+	GUI_print_string(get_tx2(8), 220, 36);
 	/* print thirst */
-	GUI_print_string(get_tx2(0x24), 220, 43);
+	GUI_print_string(get_tx2(9), 220, 43);
 
 
 	/* print page content */
@@ -364,7 +364,7 @@ void status_show(Bit16u index)
 			ds_writew(TXT_TABPOS1, 265);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x28),
+					(char*)get_tx2(10),
 					(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX_INDEX)) + (host_readbs(Real2Host(hero) + HERO_GOD) + 0x15) * 4)));
 			GUI_print_string(Real2Host(ds_readd(DTP2)), 200, 55);
 
@@ -379,19 +379,19 @@ void status_show(Bit16u index)
 					+ host_readbs(Real2Host(hero) + i * 3 + HERO_ATTRIB_MOD);
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + i * 10,
-					(char*)get_tx2(0xcc),
+					(char*)get_tx2(51),
 					host_readbs(Real2Host(hero) + i * 3 + 0x34) != val ?
-						(char*)get_tx2(0xc4) :
+						(char*)get_tx2(49) :
 						(char*)p_datseg + EMPTY_STRING6,
 					val,
 					host_readbs(Real2Host(hero) + i * 3 + 0x34) != val ?
-						(char*)get_tx2(0xc8) :
+						(char*)get_tx2(50) :
 						(char*)p_datseg + EMPTY_STRING7,
 					host_readbs(Real2Host(hero) + i * 3 + 0x34));
 
 			}
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x30),
+				(char*)get_tx2(12),
 				(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 				(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 70,
 				(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 10,
@@ -424,7 +424,7 @@ void status_show(Bit16u index)
 #ifdef M302de_ORIGINAL_BUGFIX
 				/* Original-Bugfix: show permanent damage red */
 				char le_fix[10];
-				set_status_string((char*)get_tx2(0x34));
+				set_status_string((char*)get_tx2(13));
 
 				if (host_readb(Real2Host(hero) + HERO_LE_MOD)) {
 					/* print max LE in red if hero has permanent damage */
@@ -435,7 +435,7 @@ void status_show(Bit16u index)
 				}
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x34),
+					(char*)get_tx2(13),
 					host_readw(Real2Host(hero) + HERO_LE), le_fix,			/* LE */
 					host_readw(Real2Host(hero) + HERO_AE), host_readw(Real2Host(hero) + HERO_AE_ORIG),	/* AE */
 					host_readbs(Real2Host(hero) + HERO_MR),			/* MR */
@@ -444,13 +444,13 @@ void status_show(Bit16u index)
 						host_readbs(Real2Host(hero) + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK)),		/* Ausdauer*/
 					host_readw(Real2Host(hero) + HERO_LOAD),				/* Last */
 					bp);							/* BP */
-				reset_status_string((char*)get_tx2(0x34));
+				reset_status_string((char*)get_tx2(13));
 				/* Original-Bugfix end */
 #else
 
 				/* Original Behaviour: print max LE in black */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x34),
+					(char*)get_tx2(13),
 					host_readw(Real2Host(hero) + HERO_LE), host_readw(Real2Host(hero) + HERO_LE_ORIG),	/* LE */
 					host_readw(Real2Host(hero) + HERO_AE), host_readw(Real2Host(hero) + HERO_AE_ORIG),	/* AE */
 					host_readbs(Real2Host(hero) + HERO_MR),			/* MR */
@@ -499,7 +499,7 @@ void status_show(Bit16u index)
 					pa = 0;
 #ifdef M302de_ORIGINAL_BUGFIX
 				/* Original-Bugfix: show permanent damage in red */
-				set_status_string((char*)get_tx2(0xd0));
+				set_status_string((char*)get_tx2(52));
 
 				if (host_readb(Real2Host(hero) + HERO_LE_MOD)) {
 					/* print max LE in red if hero has permanent damage */
@@ -511,7 +511,7 @@ void status_show(Bit16u index)
 
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0xd0),
+					(char*)get_tx2(52),
 					host_readw(Real2Host(hero) + HERO_LE), le_fix,			/* LE */
 					host_readw(Real2Host(hero) + HERO_AE), host_readw(Real2Host(hero) + HERO_AE_ORIG),	/* AE */
 					at, pa,							/* AT PA */
@@ -522,11 +522,11 @@ void status_show(Bit16u index)
 					host_readw(Real2Host(hero) + HERO_LOAD),				/* Last */
 					bp);							/* BP */
 
-				reset_status_string((char*)get_tx2(0xd0));
+				reset_status_string((char*)get_tx2(52));
 				/* Original-Bugfix end */
 #else
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0xd0),
+					(char*)get_tx2(52),
 					host_readw(Real2Host(hero) + HERO_LE), host_readw(Real2Host(hero) + HERO_LE_ORIG),	/* LE */
 					host_readw(Real2Host(hero) + HERO_AE), host_readw(Real2Host(hero) + HERO_AE_ORIG),	/* AE */
 					at, pa,							/* AT PA */
@@ -581,7 +581,7 @@ void status_show(Bit16u index)
 				pa = 0;
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x14),
+				(char*)get_tx2(5),
 				host_readbs(Real2Host(hero) + HERO_ATPA_BASIS),
 				(char*)Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX_INDEX)) + 0xc0)),
 

--- a/src/custom/schick/rewrite_m302de/seg047.cpp
+++ b/src/custom/schick/rewrite_m302de/seg047.cpp
@@ -164,7 +164,7 @@ void hero_gets_diseased(Bit8u *hero, unsigned short disease)
 #if !defined(__BORLANDC__)
 		D1_INFO("%s erkrankt an %s\n",
 			(char*)hero + HERO_NAME2,
-			(char*)get_ttx((disease + 0x193) * 4));
+			(char*)get_ttx(disease + 0x193));
 #endif
 
 		host_writeb(hero + disease * 5 + 0xae, 0xff);
@@ -278,7 +278,7 @@ void make_valuta_str(char *dst, Bit32s money) {
 		money -= 10;
 	}
 
-	sprintf(dst, (char*)get_ttx(0xbb0), d, s, (short)money);
+	sprintf(dst, (char*)get_ttx(748), d, s, (short)money);
 }
 
 /**
@@ -307,7 +307,7 @@ void update_atpa(Bit8u *hero)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x20), host_readbs(hero + HERO_ATPA_BASIS));
+			(char*)get_ttx(8), host_readbs(hero + HERO_ATPA_BASIS));
 
 		/* print message */
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -359,7 +359,7 @@ signed short menu_enter_delete(RealPt ptr, signed short entries, signed short mo
 			i++;
 		}
 
-		answer = GUI_radio( (mode == -1) ? get_ttx(0x8dc) : get_ttx(0x490),
+		answer = GUI_radio( (mode == -1) ? get_ttx(567) : get_ttx(292),
 				(signed char)i,
 				Real2Host(ds_readd(RADIO_NAME_LIST)),
 				Real2Host(ds_readd((RADIO_NAME_LIST + 4))),

--- a/src/custom/schick/rewrite_m302de/seg048.cpp
+++ b/src/custom/schick/rewrite_m302de/seg048.cpp
@@ -142,11 +142,11 @@ void status_menu(signed short hero_pos)
 						!is_in_word_array(
 						    host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO)),
 						    (signed short*)Real2Host(ds_readd((WEARABLE_ITEMS_INDEX - 4) + 4 * host_readbs(hero2 + HERO_TYPE)))
-                        ) ? p_datseg + EMPTY_STRING8 : get_tx2(0x108));
+                        ) ? p_datseg + EMPTY_STRING8 : get_tx2(66));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))))) {
 						strcat((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(4 * (48 + host_readbs(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))) + 3))));
+							(char*)get_ttx(48 + host_readbs(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))) + 3)));
 					}
 
 					GUI_print_string(Real2Host(ds_readd(DTP2)), 16, 192);
@@ -327,11 +327,11 @@ void status_menu(signed short hero_pos)
 						!is_in_word_array(
 						    host_readws(hero2 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO)),
 						    (signed short*)Real2Host(ds_readd((WEARABLE_ITEMS_INDEX - 4) + 4 * host_readbs(hero2 + HERO_TYPE)))
-                        ) ? p_datseg + EMPTY_STRING9 : get_tx2(0x108));
+                        ) ? p_datseg + EMPTY_STRING9 : get_tx2(66));
 
 					if (item_weapon(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))))) {
 						strcat((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(4 * (48 + host_readbs(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))) + 3))));
+							(char*)get_ttx(48 + host_readbs(get_itemsdat(host_readws(hero1 + HERO_ITEM_HEAD + 14 * ds_readbs(STATUSPAGE_SELITEM3_NO))) + 3)));
 					}
 
 					GUI_print_string(Real2Host(ds_readd(DTP2)), 16, 192);
@@ -453,7 +453,7 @@ void status_menu(signed short hero_pos)
 			hero_is_diseased(hero2))
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(4 * (25 + hero_is_diseased(hero2))),
+				(char*)get_tx2(25 + hero_is_diseased(hero2)),
 				(char*)(hero2 + HERO_NAME2),
 				Real2Host(GUI_get_ptr(host_readbs(hero2 + HERO_SEX), 1)));
 
@@ -498,11 +498,11 @@ void status_menu(signed short hero_pos)
 				}
 
 				l_di = GUI_radio((Bit8u*)NULL, (signed char)l1,
-						get_tx2(0x114),
-						get_tx2(0x40),
-						get_tx2(0x44),
-						get_ttx(0x350),
-						get_ttx(0x354),
+						get_tx2(69),
+						get_tx2(16),
+						get_tx2(17),
+						get_ttx(212),
+						get_ttx(213),
 						Real2Host(ds_readd((RADIO_NAME_LIST + 0x00))),
 						Real2Host(ds_readd((RADIO_NAME_LIST + 0x04))),
 						Real2Host(ds_readd((RADIO_NAME_LIST + 0x08))),
@@ -514,9 +514,9 @@ void status_menu(signed short hero_pos)
 					case 1: {
 						/* change name */
 						if (host_readbs(hero2 + HERO_NPC_ID) != 0) {
-							GUI_output(get_tx2(0x11c));
+							GUI_output(get_tx2(71));
 						} else {
-							GUI_input(get_tx2(0x118), 15);
+							GUI_input(get_tx2(70), 15);
 							strcpy((char*)hero2 + HERO_NAME2, (char*)Real2Host(ds_readd(TEXT_INPUT_BUF)));
 							ds_writew(REQUEST_REFRESH, 1);
 						}
@@ -525,7 +525,7 @@ void status_menu(signed short hero_pos)
 					case 2: {
 						/* use item */
 						if (hero1 != hero2) {
-							GUI_output(get_tx2(0x110));
+							GUI_output(get_tx2(68));
 						} else {
 							use_item(ds_readbs(STATUSPAGE_SELITEM3_NO), hero_pos);
 							reset_item_selector();
@@ -536,7 +536,7 @@ void status_menu(signed short hero_pos)
 					case 3: {
 						/* drop item */
 						if (hero1 != hero2) {
-							GUI_output(get_tx2(0x110));
+							GUI_output(get_tx2(68));
 						} else {
 							drop_item(hero2, ds_readbs(STATUSPAGE_SELITEM3_NO), -1);
 							reset_item_selector();
@@ -571,7 +571,7 @@ void status_menu(signed short hero_pos)
 							reset_item_selector();
 						} else if (l1 == 7) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx2(4 * (25 + flag3)),
+								(char*)get_tx2(25 + flag3),
 								(char*)(hero2 + HERO_NAME2),
 								Real2Host(GUI_get_ptr(host_readbs(hero2 + HERO_SEX), 1)));
 
@@ -597,7 +597,7 @@ void status_menu(signed short hero_pos)
 					case 8: {
 						/* show spells */
 						if (host_readbs(hero2 + HERO_TYPE) < 7) {
-							GUI_output(get_ttx(0x35c));
+							GUI_output(get_ttx(215));
 						} else {
 							reset_item_selector();
 							ds_writew(STATUS_PAGE_MODE, 4);
@@ -608,7 +608,7 @@ void status_menu(signed short hero_pos)
 					case 9: {
 						if (flag3 != 0) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx2(4 * (25 + flag3)),
+								(char*)get_tx2(25 + flag3),
 								(char*)(hero2 + HERO_NAME2),
 								Real2Host(GUI_get_ptr(host_readbs(hero2 + HERO_SEX), 1)));
 
@@ -630,21 +630,21 @@ void status_menu(signed short hero_pos)
 				/* from ATPA-page */
 
 				l_di = GUI_radio((Bit8u*)0, 8,
-						get_tx2(0x40),
-						get_tx2(0x44),
-						get_ttx(0x350),
-						get_ttx(0x354),
-						get_tx2(0x60),
-						get_tx2(0x50),
-						get_tx2(0x54),
-						get_tx2(0x3c));
+						get_tx2(16),
+						get_tx2(17),
+						get_ttx(212),
+						get_ttx(213),
+						get_tx2(24),
+						get_tx2(20),
+						get_tx2(21),
+						get_tx2(15));
 
 				if (l_di != -1) {
 					switch(l_di) {
 					case 1: {
 						/* use item */
 						if (hero1 != hero2) {
-							GUI_output(get_tx2(0x110));
+							GUI_output(get_tx2(68));
 						} else {
 							use_item(ds_readbs(STATUSPAGE_SELITEM3_NO), hero_pos);
 							reset_item_selector();
@@ -654,7 +654,7 @@ void status_menu(signed short hero_pos)
 					case 2: {
 						/* drop item */
 						if (hero1 != hero2) {
-							GUI_output(get_tx2(0x110));
+							GUI_output(get_tx2(68));
 						} else {
 							drop_item(hero2, ds_readbs(STATUSPAGE_SELITEM3_NO), -1);
 							reset_item_selector();
@@ -696,7 +696,7 @@ void status_menu(signed short hero_pos)
 					}
 					case 7: {
 						if (host_readbs(hero2 + HERO_TYPE) < 7) {
-							GUI_output(get_ttx(0x35c));
+							GUI_output(get_ttx(215));
 						} else {
 							reset_item_selector();
 							ds_writew(STATUS_PAGE_MODE, 4);
@@ -716,12 +716,12 @@ void status_menu(signed short hero_pos)
 			case 3: {
 				/* from skills-page */
 				l_di = GUI_radio((Bit8u*)0, 6,
-						get_ttx(0x350),
-						get_tx2(0x60),
-						get_tx2(0x4c),
-						get_tx2(0x54),
-						get_ttx(0x354),
-						get_tx2(0x3c));
+						get_ttx(212),
+						get_tx2(24),
+						get_tx2(19),
+						get_tx2(21),
+						get_ttx(213),
+						get_tx2(15));
 
 				if (l_di != -1) {
 					switch (l_di) {
@@ -748,7 +748,7 @@ void status_menu(signed short hero_pos)
 					}
 					case 4: {
 						if (host_readbs(hero2 + HERO_TYPE) < 7) {
-							GUI_output(get_ttx(0x35c));
+							GUI_output(get_ttx(215));
 						} else {
 							ds_writew(STATUS_PAGE_MODE, 4);
 							ds_writew(REQUEST_REFRESH, 1);
@@ -775,12 +775,12 @@ void status_menu(signed short hero_pos)
 			case 5:{
 				/* from spells-page */
 				l_di = GUI_radio((Bit8u*)0, 6,
-						get_ttx(0x354),
-						get_tx2(0x60),
-						get_tx2(0x4c),
-						get_tx2(0x50),
-						get_ttx(0x358),
-						get_tx2(0x3c));
+						get_ttx(213),
+						get_tx2(24),
+						get_tx2(19),
+						get_tx2(20),
+						get_ttx(214),
+						get_tx2(15));
 
 				if (l_di != -1) {
 					switch (l_di) {
@@ -854,7 +854,7 @@ void status_select_hero(void)
 	if (ds_readws(STATUSMENU_ALLOWED) == 0 || !ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
 		/* Yes, it was written that way! */
 	} else {
-		signed short hero_pos = select_hero_from_group(get_ttx(0x4b4));
+		signed short hero_pos = select_hero_from_group(get_ttx(301));
 
 		if (hero_pos != -1) {
 			status_menu(hero_pos);

--- a/src/custom/schick/rewrite_m302de/seg049.cpp
+++ b/src/custom/schick/rewrite_m302de/seg049.cpp
@@ -169,7 +169,7 @@ void GRP_split(void)
 
 	if (count_heroes_available_in_group() <= (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE ? 2 : 1)) {
 
-		GUI_output(get_ttx(0x808));
+		GUI_output(get_ttx(514));
 	} else {
 
 		not_empty = 0;
@@ -181,7 +181,7 @@ void GRP_split(void)
 
 		do {
 			ds_writeb(HERO_SEL_EXCLUDE, 6);
-			answer = select_hero_from_group(get_ttx(0x80c));
+			answer = select_hero_from_group(get_ttx(515));
 
 			if (answer == -1) {
 				break;
@@ -210,7 +210,7 @@ void GRP_merge(void)
 
 	if (answer == -1) {
 
-		GUI_output(get_ttx(0x810));
+		GUI_output(get_ttx(516));
 	} else {
 
 		do {
@@ -292,9 +292,9 @@ void GRP_switch_to_next(signed short mode)
 				if (mode == 0) {
 
 					if (!state) {
-						GUI_output(get_ttx(0x90));
+						GUI_output(get_ttx(36));
 					} else {
-						if ((state == 2) && GUI_bool(get_ttx(0xc14))) {
+						if ((state == 2) && GUI_bool(get_ttx(773))) {
 							timewarp_until(0x7e90);
 							done = 1;
 						}
@@ -401,11 +401,11 @@ void GRP_swap_heros(void)
 		return;
 	}
 
-	hero1_nr = select_hero_from_group(get_ttx(0x4b8));
+	hero1_nr = select_hero_from_group(get_ttx(302));
 
 	if ((hero1_nr != -1) && (hero1_nr < 6)) {
 
-		hero2_nr = select_hero_from_group(get_ttx(0x4bc));
+		hero2_nr = select_hero_from_group(get_ttx(303));
 
 		if ((hero2_nr != -1) && (hero1_nr != hero2_nr) && (hero2_nr < 6)) {
 
@@ -633,7 +633,7 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 			/* chance of motion sickness is 9% */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc70),
+				(char*)get_ttx(796),
 				hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -685,14 +685,14 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 
 						add_hero_le(hero, le_regen);
 
-						strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x620));
+						strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(392));
 
 						if (le_regen > 1) {
-							strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x624));
+							strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(393));
 						}
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x4fc),
+							(char*)get_ttx(319),
 							hero + HERO_NAME2,
 							le_regen,
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -719,14 +719,14 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 
 							add_hero_ae(hero, ae_regen);
 
-							strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x620));
+							strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(392));
 
 							if (ae_regen > 1) {
-								strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x624));
+								strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(393));
 							}
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x500),
+								(char*)get_ttx(320),
 								hero + HERO_NAME2,
 								ae_regen,
 								(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -746,7 +746,7 @@ void GRP_hero_sleep(Bit8u *hero, signed short quality)
 				}
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x8b8),
+					(char*)get_ttx(558),
 					hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));

--- a/src/custom/schick/rewrite_m302de/seg050.cpp
+++ b/src/custom/schick/rewrite_m302de/seg050.cpp
@@ -92,13 +92,13 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 
 		/* no increase is possible */
 
-		GUI_output(get_tx2(0xac));
+		GUI_output(get_tx2(43));
 
 	} else if (host_readbs(Real2Host(ds_readd(INC_SPELLS_COUNTER)) + 2 * spell) == 3) {
 
 		/* used up legal increase */
 
-		GUI_output(get_tx2(0xb0));
+		GUI_output(get_tx2(44));
 	} else {
 		/* try to increase */
 
@@ -114,7 +114,7 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 
 			/* success */
 
-			GUI_output(get_tx2(0x94));
+			GUI_output(get_tx2(37));
 
 			/* increment spell value */
 			inc_ptr_bs(hero + spell + HERO_SPELLS);
@@ -125,7 +125,7 @@ void inc_spell_advanced(Bit8u *hero, signed short spell)
 			inc_ptr_bs(Real2Host(ds_readd(INC_SPELLS_COUNTER)) + 2 * spell + 1);
 		} else {
 			/* fail */
-			GUI_output(get_ttx(0x548));
+			GUI_output(get_ttx(338));
 
 			/* increment the try counter */
 			inc_ptr_bs(Real2Host(ds_readd(INC_SPELLS_COUNTER)) + 2 * spell);
@@ -151,13 +151,13 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 
 		/* no increase is possible */
 
-		GUI_output(get_tx2(0xac));
+		GUI_output(get_tx2(43));
 
 	} else if (host_readbs(Real2Host(ds_readd(INC_SKILLS_COUNTER)) + 2 * skill) == 3) {
 
 		/* used up legal increase */
 
-		GUI_output(get_tx2(0xb0));
+		GUI_output(get_tx2(44));
 	} else {
 		/* try to increase */
 
@@ -173,7 +173,7 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 
 			/* success */
 
-			GUI_output(get_tx2(0x94));
+			GUI_output(get_tx2(37));
 
 			/* increment spell value */
 			inc_ptr_bs(hero + skill + HERO_TA_FIGHT);
@@ -187,17 +187,17 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 				/* increment a melee weapon skill */
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x6a8), get_ttx(4 * (48 + skill)));
+					(char*)get_ttx(426), get_ttx(48 + skill));
 
 				randval = -1;
 
 				/* AT - value */
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)get_ttx(0x6ac), host_readbs(hero + skill + 0x68));
+					(char*)get_ttx(427), host_readbs(hero + skill + 0x68));
 
 				/* PA - value */
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)) + 50,
-					(char*)get_ttx(0x6b0), host_readbs(hero + skill + 0x6f));
+					(char*)get_ttx(428), host_readbs(hero + skill + 0x6f));
 
 				do {
 					randval = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
@@ -214,7 +214,7 @@ void inc_skill_advanced(Bit8u *hero, signed short skill)
 
 		} else {
 			/* fail */
-			GUI_output(get_ttx(0x548));
+			GUI_output(get_ttx(338));
 
 			/* increment the try counter */
 			inc_ptr_bs(Real2Host(ds_readd(INC_SKILLS_COUNTER)) + 2 * skill);
@@ -391,7 +391,7 @@ void level_up(signed short hero_pos)
 
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_ttx(0x66c),
+		(char*)get_ttx(411),
 		(char*)hero + HERO_NAME2);
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
@@ -439,18 +439,18 @@ void level_up(signed short hero_pos)
 
 			ds_writew(BASEPOS_X, -30);
 
-			l_si = GUI_radio(get_tx2(0x8c), 7,
-						get_ttx(0x670),
-						get_ttx(0x674),
-						get_ttx(0x678),
-						get_ttx(0x67c),
-						get_ttx(0x680),
-						get_ttx(0x684),
-						get_ttx(0x688)) - 1;
+			l_si = GUI_radio(get_tx2(35), 7,
+						get_ttx(412),
+						get_ttx(413),
+						get_ttx(414),
+						get_ttx(415),
+						get_ttx(416),
+						get_ttx(417),
+						get_ttx(418)) - 1;
 
 			if (host_readbs(hero + HERO_ATTRIB_ORIG + 3 * l_si) >= 20) {
 				l_si = -2;
-				GUI_output(get_tx2(0xac));
+				GUI_output(get_tx2(43));
 			}
 
 		} while (l_si == -2);
@@ -479,18 +479,18 @@ void level_up(signed short hero_pos)
 
 		do {
 
-			l_si = GUI_radio(get_tx2(0x90), 7,
-						get_ttx(0x68c),
-						get_ttx(0x690),
-						get_ttx(0x694),
-						get_ttx(0x698),
-						get_ttx(0x69c),
-						get_ttx(0x6a0),
-						get_ttx(0x6a4)) - 1;
+			l_si = GUI_radio(get_tx2(36), 7,
+						get_ttx(419),
+						get_ttx(420),
+						get_ttx(421),
+						get_ttx(422),
+						get_ttx(423),
+						get_ttx(424),
+						get_ttx(425)) - 1;
 
 			if (host_readbs(hero + HERO_ATTRIB_ORIG + 3 * (l_si + 7)) <= 2) {
 				l_si = -2;
-				GUI_output(get_tx2(0xc0));
+				GUI_output(get_tx2(48));
 			}
 
 		} while (l_si == -2);
@@ -509,7 +509,7 @@ void level_up(signed short hero_pos)
 			dec_ptr_bs(hero + HERO_ATTRIB_ORIG + 3 * (l_si + 7));
 			dec_ptr_bs(hero + HERO_ATTRIB + 3 * (l_si + 7));
 
-			GUI_output(get_tx2(0x94));
+			GUI_output(get_tx2(37));
 
 			status_show(hero_pos);
 
@@ -518,7 +518,7 @@ void level_up(signed short hero_pos)
 			update_status_bars();
 		} else {
 
-			GUI_output(get_ttx(0x548));
+			GUI_output(get_ttx(338));
 		}
 	}
 
@@ -546,7 +546,7 @@ void level_up(signed short hero_pos)
 
 		/* show the user the new MR value */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0xa4),
+			(char*)get_tx2(41),
 			host_readbs(hero + HERO_MR));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -577,7 +577,7 @@ void level_up(signed short hero_pos)
 
 		/* show how many LE the hero may get */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x9c),
+			(char*)get_tx2(39),
 			i);
 
 		do {
@@ -599,7 +599,7 @@ void level_up(signed short hero_pos)
 		/* change skill increasements into AE */
 		if (host_readbs(hero + HERO_TYPE) == HERO_TYPE_MAGE && ds_readws(GAME_MODE) == 2) {
 
-			if (GUI_bool(get_tx2(0xa0))) {
+			if (GUI_bool(get_tx2(40))) {
 				/* trade 10 skill increasements into 1W6+2 AE */
 				add_ptr_bs(hero + HERO_SP_RISE, -10);
 				i = random_interval(3, 8);
@@ -613,7 +613,7 @@ void level_up(signed short hero_pos)
 
 		/* show how many LE the hero gets */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x98),
+			(char*)get_tx2(38),
 			i);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -847,10 +847,10 @@ void level_up(signed short hero_pos)
 
 		if ((host_readbs(hero + HERO_TYPE) >= 7) &&
 			(l_di = ds_readbs((LEVELUP_SPTA_CONV - 7) + host_readbs(hero + HERO_TYPE))) &&
-			GUI_bool(get_tx2(0xb4)))
+			GUI_bool(get_tx2(45)))
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0xb8), l_di);
+				(char*)get_tx2(46), l_di);
 
 			i = GUI_input(Real2Host(ds_readd(DTP2)), 1);
 
@@ -867,7 +867,7 @@ void level_up(signed short hero_pos)
 			} else {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0xbc), l_di);
+					(char*)get_tx2(47), l_di);
 
 				i = GUI_input(Real2Host(ds_readd(DTP2)), 1);
 
@@ -893,7 +893,7 @@ void level_up(signed short hero_pos)
 
 			} else if (l_si == -2) {
 
-				if (GUI_bool(get_tx2(0xa8))) {
+				if (GUI_bool(get_tx2(42))) {
 					break;
 				}
 			}
@@ -909,7 +909,7 @@ void level_up(signed short hero_pos)
 
 			} else if (l_si == -2) {
 
-				if (GUI_bool(get_tx2(0xa8))) {
+				if (GUI_bool(get_tx2(42))) {
 					break;
 				}
 			}

--- a/src/custom/schick/rewrite_m302de/seg051.cpp
+++ b/src/custom/schick/rewrite_m302de/seg051.cpp
@@ -74,13 +74,13 @@ void do_wildcamp(void)
 			set_var_to_zero();
 			load_ani(2);
 			init_ani(0);
-			GUI_print_loc_line(get_ttx(0x4c8));
+			GUI_print_loc_line(get_ttx(306));
 			set_audio_track(ARCHIVE_FILE_CAMP_XMI);
 			ds_writew(REQUEST_REFRESH, l_di = 0);
 		}
 
 		if (l_di) {
-			GUI_print_loc_line(get_ttx(0x4c8));
+			GUI_print_loc_line(get_ttx(306));
 			l_di = 0;
 		}
 
@@ -90,11 +90,11 @@ void do_wildcamp(void)
 
 			i = !ds_readb(GOOD_CAMP_PLACE) ? 6 : 7;
 
-			answer = GUI_radio(get_ttx(0x4cc), (signed char)i,
-						get_ttx(0x4d0), get_ttx(0x4d4),
-						get_ttx(0x350), get_ttx(0x4d8),
-						get_ttx(0x4ec), get_ttx(0x4f0),
-						get_ttx(0xcb8)) -1;
+			answer = GUI_radio(get_ttx(307), (signed char)i,
+						get_ttx(308), get_ttx(309),
+						get_ttx(212), get_ttx(310),
+						get_ttx(315), get_ttx(316),
+						get_ttx(814)) -1;
 
 			if (answer != -2) {
 				ds_writews(ACTION, answer + 129);
@@ -116,12 +116,12 @@ void do_wildcamp(void)
 			}
 
 			if (answer == -1) {
-				GUI_output(get_ttx(0x530));
+				GUI_output(get_ttx(332));
 			} else {
 
 				for (i = 0; i < 3; i++) {
 
-					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x504), i + 1);
+					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(321), i + 1);
 
 					do {
 						answer = select_hero_ok(Real2Host(ds_readd(DTP2)));
@@ -131,13 +131,13 @@ void do_wildcamp(void)
 							ds_readbs(WILDCAMP_HERBSTATUS + answer) != 0 ||
 							ds_readbs(WILDCAMP_REPLSTATUS + answer) != 0)
 						{
-							GUI_output(get_ttx(0x52c));
+							GUI_output(get_ttx(331));
 							answer = -1;
 						}
 
 						if (answer != -1) {
 							if (hero_busy(get_hero(answer))) {
-								GUI_output(get_ttx(0xb68));
+								GUI_output(get_ttx(730));
 								answer = -1;
 							}
 						}
@@ -163,15 +163,15 @@ void do_wildcamp(void)
 
 		} else if (ds_readws(ACTION) == 131) {
 
-			GUI_use_skill2(0, get_ttx(0x62c));
+			GUI_use_skill2(0, get_ttx(395));
 
 		} else if (ds_readws(ACTION) == 132) {
 
-			answer = select_hero_ok(get_ttx(0x4f4));
+			answer = select_hero_ok(get_ttx(317));
 
 			if (answer != -1) {
 				if (hero_busy(get_hero(answer))) {
-					GUI_output(get_ttx(0xb68));
+					GUI_output(get_ttx(730));
 					answer = -1;
 				}
 			}
@@ -187,18 +187,18 @@ void do_wildcamp(void)
 						ds_readbs(WILDCAMP_HERBSTATUS + answer) != 0 ||
 						ds_readbs(WILDCAMP_REPLSTATUS + answer) != 0)
 					{
-						GUI_output(get_ttx(0x52c));
+						GUI_output(get_ttx(331));
 
 					} else {
 
 						if (ds_readbs(WILDCAMP_MAGICSTATUS + answer) != 0) {
-							GUI_output(get_ttx(0x538));
+							GUI_output(get_ttx(334));
 						} else {
 							ds_writebs(WILDCAMP_MAGICSTATUS + answer, (signed char)use_magic(hero));
 						}
 					}
 				} else {
-					GUI_output(get_ttx(0x528));
+					GUI_output(get_ttx(330));
 				}
 			}
 
@@ -207,10 +207,10 @@ void do_wildcamp(void)
 
 			ds_writews(SKILLED_HERO_POS, get_skilled_hero_pos(TA_PFLANZENKUNDE));
 
-			answer = select_hero_ok(get_ttx(0x518));
+			answer = select_hero_ok(get_ttx(326));
 
 			if (answer != -1 && hero_busy(get_hero(answer))) {
-				GUI_output(get_ttx(0xb68));
+				GUI_output(get_ttx(730));
 				answer = -1;
 			}
 
@@ -220,7 +220,7 @@ void do_wildcamp(void)
 				{
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc8c),
+						(char*)get_ttx(803),
 						(char*)get_hero(answer) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -229,7 +229,7 @@ void do_wildcamp(void)
 						ds_readbs(WILDCAMP_REPLSTATUS + answer) != 0 ||
 						ds_readbs(WILDCAMP_MAGICSTATUS + answer) != 0)
 				{
-					GUI_output(get_ttx(0x52c));
+					GUI_output(get_ttx(331));
 
 				} else {
 
@@ -237,7 +237,7 @@ void do_wildcamp(void)
 					{
 						hero = (RealPt)ds_readd(HEROS) + SIZEOF_HERO * answer;
 
-						herb_hours = (signed char)GUI_input(get_ttx(0x51c), 1);
+						herb_hours = (signed char)GUI_input(get_ttx(327), 1);
 
 						if (herb_hours > 0)
 						{
@@ -250,13 +250,13 @@ void do_wildcamp(void)
 							}
 						}
 					} else {
-						GUI_output(get_ttx(0x540));
+						GUI_output(get_ttx(336));
 					}
 				}
 			}
 		} else if (ds_readws(ACTION) == 134) {
 
-			if (GUI_bool(get_ttx(0x4f8))) {
+			if (GUI_bool(get_ttx(318))) {
 
 				l3 = (signed char)(ds_readds(DAY_TIMER) / HOURS(1));
 
@@ -283,7 +283,7 @@ void do_wildcamp(void)
 				if (ds_readbs(WILDCAMP_GUARDS + l_si) != -1) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc18),
+						(char*)get_ttx(774),
 						(char*)get_hero(ds_readbs(WILDCAMP_GUARDS + l_si)) + HERO_NAME2);
 
 					GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
@@ -310,7 +310,7 @@ void do_wildcamp(void)
 						if (ds_readbs(WILDCAMP_GUARDS + l_si) != -1) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0xc18),
+								(char*)get_ttx(774),
 								(char*)get_hero(ds_readbs(WILDCAMP_GUARDS + l_si)) + HERO_NAME2);
 
 							GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
@@ -347,7 +347,7 @@ void do_wildcamp(void)
 						set_var_to_zero();
 						load_ani(2);
 						init_ani(0);
-						GUI_print_loc_line(get_ttx(0x4c8));
+						GUI_print_loc_line(get_ttx(306));
 						set_audio_track(ARCHIVE_FILE_CAMP_XMI);
 
 						ds_writew(REQUEST_REFRESH, l_di = 0);
@@ -416,7 +416,7 @@ signed short gather_herbs(Bit8u *hero, signed short hours, signed short mod)
 
 		/* print a sentence with all the herb names */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x520),
+			(char*)get_ttx(328),
 			(char*)hero + HERO_NAME2);
 
 		for (i = 0; i < 12; i++) {
@@ -448,7 +448,7 @@ signed short gather_herbs(Bit8u *hero, signed short hours, signed short mod)
 		/* no herbs found */
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x558),
+			(char*)get_ttx(342),
 			(char*)hero + HERO_NAME2);
 	}
 
@@ -477,10 +477,10 @@ signed short replenish_stocks(signed short mod, signed short tries)
 	mod += 5;
 
 	ds_writews(SKILLED_HERO_POS, get_skilled_hero_pos(TA_WILDNISLEBEN));
-	hero_pos = select_hero_ok(get_ttx(0x508));
+	hero_pos = select_hero_ok(get_ttx(322));
 
 	if (hero_pos != -1 && hero_busy(get_hero(hero_pos))) {
-		GUI_output(get_ttx(0xb68));
+		GUI_output(get_ttx(730));
 		hero_pos = -1;
 	}
 
@@ -489,7 +489,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 		if (ds_readb(WILDCAMP_REPLSTATUS + hero_pos) != 0) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc88),
+				(char*)get_ttx(802),
 				(char*)get_hero(hero_pos) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -500,7 +500,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 				ds_readb(WILDCAMP_MAGICSTATUS + hero_pos) != 0 ||
 				ds_readb(WILDCAMP_GUARDSTATUS + hero_pos) != 0)
 			{
-				GUI_output(get_ttx(0x52c));
+				GUI_output(get_ttx(331));
 
 			} else {
 
@@ -516,7 +516,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 
 						/* found water */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x510),
+							(char*)get_ttx(324),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						/* fill up all waterskins and remove thirst of all living heros in the current group */
@@ -539,7 +539,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 					} else {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x550),
+							(char*)get_ttx(340),
 							(char*)Real2Host(hero) + HERO_NAME2);
 					}
 
@@ -562,18 +562,18 @@ signed short replenish_stocks(signed short mod, signed short tries)
 
 						/* the group may get three food packages */
 						if (!get_item(45, 1, 3)) {
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x4c8));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(306));
 							ds_writew(REQUEST_REFRESH, 1);
 						} else {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x514),
+								(char*)get_ttx(325),
 								(char*)Real2Host(hero) + HERO_NAME2);
 						}
 
 					} else {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x554),
+							(char*)get_ttx(341),
 							(char*)Real2Host(hero) + HERO_NAME2);
 					}
 
@@ -581,7 +581,7 @@ signed short replenish_stocks(signed short mod, signed short tries)
 					delay_or_keypress(200);
 
 				} else {
-					GUI_output(get_ttx(0x50c));
+					GUI_output(get_ttx(323));
 				}
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg052.cpp
+++ b/src/custom/schick/rewrite_m302de/seg052.cpp
@@ -67,13 +67,13 @@ void do_citycamp(void)
 			set_var_to_zero();
 			load_ani(36);
 			init_ani(0);
-			GUI_print_loc_line(get_ttx(0x4c8));
+			GUI_print_loc_line(get_ttx(306));
 			set_audio_track(ARCHIVE_FILE_CAMP_XMI);
 			ds_writew(REQUEST_REFRESH, l3 = 0);
 		}
 
 		if (l3 != 0) {
-			GUI_print_loc_line(get_ttx(0x4c8));
+			GUI_print_loc_line(get_ttx(306));
 			l3 = 0;
 		}
 
@@ -82,12 +82,12 @@ void do_citycamp(void)
 		if (ds_readws(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
 			/* open citycamp radio menu */
-			answer = GUI_radio(get_ttx(0x4cc), 5,
-						get_ttx(0x4d0),
-						get_ttx(0x350),
-						get_ttx(0x4d8),
-						get_ttx(0x4f0),
-						get_ttx(0x75c)) - 1;
+			answer = GUI_radio(get_ttx(307), 5,
+						get_ttx(308),
+						get_ttx(212),
+						get_ttx(310),
+						get_ttx(316),
+						get_ttx(471)) - 1;
 
 			/* set action on a valid answer */
 			if (answer != -2) {
@@ -108,13 +108,13 @@ void do_citycamp(void)
 			}
 
 			if (answer == -1) {
-				GUI_output(get_ttx(0x530));
+				GUI_output(get_ttx(332));
 			} else {
 
 				for (l_si = 0; l_si < 3; l_si++) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x504),
+						(char*)get_ttx(321),
 						l_si + 1);
 
 					do {
@@ -122,12 +122,12 @@ void do_citycamp(void)
 						answer = select_hero_ok(Real2Host(ds_readd(DTP2)));
 
 						if (answer != -1 && ds_readbs(CITYCAMP_MAGICSTATUS + answer) != 0) {
-							GUI_output(get_ttx(0x52c));
+							GUI_output(get_ttx(331));
 							answer = -1;
 						}
 
 						if (answer != -1 && hero_busy(get_hero(answer))) {
-							GUI_output(get_ttx(0xb68));
+							GUI_output(get_ttx(730));
 							answer = -1;
 						}
 
@@ -140,14 +140,14 @@ void do_citycamp(void)
 
 		} else if (ds_readws(ACTION) == 130) {
 
-			GUI_use_skill2(0, get_ttx(0x62c));
+			GUI_use_skill2(0, get_ttx(395));
 
 		} else if (ds_readws(ACTION) == 131) {
 
-			answer = select_hero_ok(get_ttx(0x4f4));
+			answer = select_hero_ok(get_ttx(317));
 
 			if (answer != -1 && hero_busy(get_hero(answer))) {
-				GUI_output(get_ttx(0xb68));
+				GUI_output(get_ttx(730));
 				answer = -1;
 			}
 
@@ -158,23 +158,23 @@ void do_citycamp(void)
 				if (host_readbs(Real2Host(hero) + HERO_TYPE) >= 7) {
 
 					if (ds_readb(CITYCAMP_GUARDSTATUS + answer) != 0) {
-						GUI_output(get_ttx(0x52c));
+						GUI_output(get_ttx(331));
 					} else {
 						if (ds_readb(CITYCAMP_MAGICSTATUS + answer) != 0) {
-							GUI_output(get_ttx(0x538));
+							GUI_output(get_ttx(334));
 						} else {
 							ds_writebs(CITYCAMP_MAGICSTATUS + answer, (signed char)use_magic(hero));
 						}
 					}
 				} else {
-					GUI_output(get_ttx(0x528));
+					GUI_output(get_ttx(330));
 				}
 			}
 		} else if (ds_readws(ACTION) == 132) {
 
-			if (GUI_bool(get_ttx(0x4f8))) {
+			if (GUI_bool(get_ttx(318))) {
 
-				hours = (signed char)GUI_input(get_ttx(0xd04), 1);
+				hours = (signed char)GUI_input(get_ttx(833), 1);
 
 				if (hours > 0) {
 					l5 = hours / 3;
@@ -193,7 +193,7 @@ void do_citycamp(void)
 					if (ds_readbs(CITYCAMP_GUARDS + l_di) != -1) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xc18),
+							(char*)get_ttx(774),
 							(char*)get_hero(ds_readbs(CITYCAMP_GUARDS + l_di)) + 0x10);
 
 						GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
@@ -220,7 +220,7 @@ void do_citycamp(void)
 							if (ds_readbs(CITYCAMP_GUARDS + l_di) != -1) {
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xc18),
+									(char*)get_ttx(774),
 									(char*)get_hero(ds_readbs(CITYCAMP_GUARDS + l_di)) + 0x10);
 
 								GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
@@ -246,7 +246,7 @@ void do_citycamp(void)
 								set_var_to_zero();
 								load_ani(36);
 								init_ani(0);
-								GUI_print_loc_line(get_ttx(0x4c8));
+								GUI_print_loc_line(get_ttx(306));
 								set_audio_track(ARCHIVE_FILE_CAMP_XMI);
 								ds_writew(REQUEST_REFRESH, l3 = 0);
 							}
@@ -254,7 +254,7 @@ void do_citycamp(void)
 						} else {
 							/* in a city */
 							done = 0;
-							loose_random_item(get_hero(get_random_hero()), 100, get_ttx(0xd00));
+							loose_random_item(get_hero(get_random_hero()), 100, get_ttx(832));
 						}
 
 						if (l7 > 0) {

--- a/src/custom/schick/rewrite_m302de/seg053.cpp
+++ b/src/custom/schick/rewrite_m302de/seg053.cpp
@@ -36,7 +36,7 @@ unsigned short is_hero_healable(Bit8u *hero)
 
 	if (hero_dead(hero) || hero_stoned(hero)) {
 		/* this hero can not be helped */
-		GUI_output(get_ttx(0xc28));
+		GUI_output(get_ttx(778));
 		return 0;
 	} else {
 		return 1;
@@ -82,7 +82,7 @@ void do_healer(void)
 			load_ani(23);
 			init_ani(0);
 
-			GUI_print_loc_line(get_tx(ds_readw(CITYINDEX) * 4));
+			GUI_print_loc_line(get_tx(ds_readw(CITYINDEX)));
 
 			set_audio_track(ARCHIVE_FILE_HEALER_XMI);
 
@@ -94,14 +94,14 @@ void do_healer(void)
 
 				/* from 9.00 pm to 6.00 am the healer gets unkind */
 				if (ds_readds(DAY_TIMER) > 0x1baf8 || ds_readds(DAY_TIMER) < 0x7e90) {
-					GUI_output(get_ttx(0x790));
+					GUI_output(get_ttx(484));
 					motivation = 2;
 				}
 			}
 		}
 
 		if (v6 != 0) {
-			GUI_print_loc_line(get_tx(ds_readw(CITYINDEX) * 4));
+			GUI_print_loc_line(get_tx(ds_readw(CITYINDEX)));
 			v6 = 0;
 		}
 
@@ -111,11 +111,11 @@ void do_healer(void)
 
 			ds_writew(TEXTBOX_WIDTH, 4);
 
-			answer = GUI_radio(get_ttx(0x72c), 4,
-						get_ttx(0x71c),
-						get_ttx(0x720),
-						get_ttx(0x724),
-						get_ttx(0x728)) - 1;
+			answer = GUI_radio(get_ttx(459), 4,
+						get_ttx(455),
+						get_ttx(456),
+						get_ttx(457),
+						get_ttx(458)) - 1;
 			ds_writew(TEXTBOX_WIDTH, 3);
 
 			if (answer != -2) {
@@ -133,7 +133,7 @@ void do_healer(void)
 			/* Heal Wounds */
 
 			money = get_party_money();
-			answer = select_hero_from_group(get_ttx(0x730));
+			answer = select_hero_from_group(get_ttx(460));
 			if (answer != - 1) {
 
 				hero = get_hero(answer);
@@ -146,7 +146,7 @@ void do_healer(void)
 
 						/* Hero seems OK */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x734),
+							(char*)get_ttx(461),
 							(char*)(hero + HERO_NAME2));
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					} else {
@@ -161,7 +161,7 @@ void do_healer(void)
 
 						/* ask */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x740),
+							(char*)get_ttx(464),
 							(char*)(hero + HERO_NAME2),
 							price);
 
@@ -169,7 +169,7 @@ void do_healer(void)
 							price *= 10;
 
 							if (money < price) {
-								GUI_output(get_ttx(0x644));
+								GUI_output(get_ttx(401));
 							} else {
 								/* remove money */
 								money -= price;
@@ -187,7 +187,7 @@ void do_healer(void)
 
 								/* prepare output */
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0x74c),
+									(char*)get_ttx(467),
 									(char*)(hero + HERO_NAME2));
 
 								GUI_output(Real2Host(ds_readd(DTP2)));
@@ -200,7 +200,7 @@ void do_healer(void)
 		} else if (ds_readw(ACTION) == 0x82) {
 			/* Cure Disease */
 			money = get_party_money();
-			answer = select_hero_from_group(get_ttx(0x730));
+			answer = select_hero_from_group(get_ttx(460));
 			if (answer != -1) {
 				hero = get_hero(answer);
 
@@ -210,7 +210,7 @@ void do_healer(void)
 					if (!disease) {
 						/* Hero is not diseased */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x738),
+							(char*)get_ttx(462),
 							(char*)(hero + HERO_NAME2));
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -225,16 +225,16 @@ void do_healer(void)
 
 						/* prepare output */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x744),
+							(char*)get_ttx(465),
 							(char*)(hero + HERO_NAME2),
-							(char*)get_ttx((disease + 0x193) * 4),
+							(char*)get_ttx(disease + 0x193),
 							price);
 
 						if (GUI_bool(Real2Host(ds_readd(DTP2)))) {
 							price *= 10;
 
 							if (money < price) {
-								GUI_output(get_ttx(0x644));
+								GUI_output(get_ttx(401));
 							} else {
 								/* let pass some time */
 								timewarp(5400);
@@ -246,13 +246,13 @@ void do_healer(void)
 
 									/* prepare output */
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0x74c),
+										(char*)get_ttx(467),
 										(char*)(hero + HERO_NAME2));
 
 									GUI_output(Real2Host(ds_readd(DTP2)));
 								} else {
 									price /= 2;
-									GUI_output(get_ttx(0x750));
+									GUI_output(get_ttx(468));
 								}
 
 								/* remove money */
@@ -266,7 +266,7 @@ void do_healer(void)
 		} else if (ds_readw(ACTION) == 0x83) {
 			/* Heal Poison */
 			money = get_party_money();
-			answer = select_hero_from_group(get_ttx(0x730));
+			answer = select_hero_from_group(get_ttx(460));
 			if (answer != -1) {
 				hero = get_hero(answer);
 
@@ -276,7 +276,7 @@ void do_healer(void)
 					if (poison == 0) {
 						/* Hero is not poisoned */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x73c),
+							(char*)get_ttx(463),
 							(char*)(hero + HERO_NAME2));
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -289,7 +289,7 @@ void do_healer(void)
 
 						/* prepare output */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x748),
+							(char*)get_ttx(466),
 							price,
 							(char*)(hero + HERO_NAME2));
 
@@ -297,7 +297,7 @@ void do_healer(void)
 							price *= 10;
 
 							if (money < price) {
-								GUI_output(get_ttx(0x644));
+								GUI_output(get_ttx(401));
 							} else {
 								timewarp(5400);
 
@@ -308,13 +308,13 @@ void do_healer(void)
 
 									/* prepare output */
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0x74c),
+										(char*)get_ttx(467),
 										(char*)(hero + HERO_NAME2));
 
 									GUI_output(Real2Host(ds_readd(DTP2)));
 								} else {
 									price /= 2;
-									GUI_output(get_ttx(0x750));
+									GUI_output(get_ttx(468));
 								}
 
 								money -= price;

--- a/src/custom/schick/rewrite_m302de/seg054.cpp
+++ b/src/custom/schick/rewrite_m302de/seg054.cpp
@@ -97,12 +97,12 @@ void do_inn(void)
 			if (host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) != 0) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xb74),
+					(char*)get_ttx(733),
 					(char*)Real2Host(hero) + HERO_NAME2,
 					host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER),
-					(char*)(host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) < 2 ? get_ttx(0xb7c) : get_ttx(0xb80)));
+					(char*)(host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) < 2 ? get_ttx(735) : get_ttx(736)));
 
-				answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2, get_ttx(0xb78), get_ttx(0x864));
+				answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2, get_ttx(734), get_ttx(537));
 
 				if (answer == 1) {
 					do_alchemy(Real2Host(hero), host_readbs(Real2Host(hero) + HERO_RECIPE_ID), 1);
@@ -123,15 +123,15 @@ void do_inn(void)
 		if (host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) != 0) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xb74),
+				(char*)get_ttx(733),
 				(char*)Real2Host(hero) + HERO_NAME2,
 				host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER),
-				(char*)(host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) < 2 ? get_ttx(0xb7c) : get_ttx(0xb80)));
+				(char*)(host_readbs(Real2Host(hero) + HERO_RECIPE_TIMER) < 2 ? get_ttx(735) : get_ttx(736)));
 
 			tw_bak = ds_readws(TEXTBOX_WIDTH);
 			ds_writews(TEXTBOX_WIDTH, 4);
 
-			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2, get_ttx(0xb78), get_ttx(0x8c8));
+			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2, get_ttx(734), get_ttx(562));
 
 			ds_writews(TEXTBOX_WIDTH, tw_bak);
 
@@ -168,14 +168,14 @@ void do_inn(void)
 
 			init_ani(0);
 
-			GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+			GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 
 			ds_writews(REQUEST_REFRESH, refresh = 0);
 		}
 
 		if (refresh != 0) {
 
-			GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+			GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 
 			refresh = 0;
 		}
@@ -186,11 +186,11 @@ void do_inn(void)
 
 		if (ds_readws(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
-			answer = GUI_radio(get_ttx(0x564), ds_readws(COMBO_MODE) == 0 ? 7 : 8,
-						get_ttx(0x55c), get_ttx(0x758),
-						get_ttx(0x560), get_ttx(0x350),
-						get_ttx(0x4d8), get_ttx(0x4f0),
-						get_ttx(0x56c), get_ttx(0xcdc)) - 1;
+			answer = GUI_radio(get_ttx(345), ds_readws(COMBO_MODE) == 0 ? 7 : 8,
+						get_ttx(343), get_ttx(470),
+						get_ttx(344), get_ttx(212),
+						get_ttx(310), get_ttx(316),
+						get_ttx(347), get_ttx(823)) - 1;
 
 			if (answer != -2) {
 				ds_writews(ACTION, answer + 129);
@@ -206,7 +206,7 @@ void do_inn(void)
 			price += (price * host_readws(inn_ptr + 2)) / 100L;
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x764),
+				(char*)get_ttx(473),
 				(signed short)price);
 
 			if (GUI_bool(Real2Host(ds_readd(DTP2)))) {
@@ -219,11 +219,11 @@ void do_inn(void)
 				}
 
 				if (party_money < price) {
-					GUI_output(get_ttx(0x644));
+					GUI_output(get_ttx(401));
 				} else {
 
-					GUI_output(host_readws(inn_ptr) < 5 ? get_ttx(0x76c) :
-							(host_readws(inn_ptr) < 15 ? get_ttx(0x770) : get_ttx(0x774)));
+					GUI_output(host_readws(inn_ptr) < 5 ? get_ttx(475) :
+							(host_readws(inn_ptr) < 15 ? get_ttx(476) : get_ttx(477)));
 
 					for (i = 0, hero2 = get_hero(0); i <= 6; i++, hero2 += SIZEOF_HERO) {
 
@@ -273,24 +273,24 @@ void do_inn(void)
 			ds_writews(TEXTBOX_WIDTH, 5);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x634),
+				(char*)get_ttx(397),
 				(signed short)l8);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)) + 50,
-				(char*)get_ttx(0x638),
+				(char*)get_ttx(398),
 				(signed short)l9);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)) + 100,
-				(char*)get_ttx(0x63c),
+				(char*)get_ttx(399),
 				(signed short)l10);
 
-			ds_writebs(SLEEP_QUALITY, (signed char)GUI_radio(get_ttx(0x630), 3,
+			ds_writebs(SLEEP_QUALITY, (signed char)GUI_radio(get_ttx(396), 3,
 							Real2Host(ds_readd(DTP2)),
 							Real2Host(ds_readd(DTP2)) + 50,
 							Real2Host(ds_readd(DTP2)) + 100));
 
 			if (ds_readbs(SLEEP_QUALITY) != -1) {
-				ds_writebs(BOOKED_INN_DAYS, (signed char)GUI_input(get_ttx(0xce8), 2));
+				ds_writebs(BOOKED_INN_DAYS, (signed char)GUI_input(get_ttx(826), 2));
 			}
 
 			if (ds_readbs(BOOKED_INN_DAYS) <= 0) {
@@ -317,29 +317,29 @@ void do_inn(void)
 				}
 
 				if (party_money < price) {
-					GUI_output(get_ttx(0x644));
+					GUI_output(get_ttx(401));
 					ds_writebs(SLEEP_QUALITY, -1);
 				} else {
 					party_money -= price;
 					set_party_money(party_money);
-					GUI_output(get_ttx(0x648));
+					GUI_output(get_ttx(402));
 				}
 			}
 
 		} else if (ds_readws(ACTION) == 132) {
 
 			if (ds_readbs(SLEEP_QUALITY) != -1) {
-				GUI_use_skill2(0, get_ttx(0x62c));
+				GUI_use_skill2(0, get_ttx(395));
 				refresh = 1;
 			} else {
-				GUI_output(get_ttx(0x568));
+				GUI_output(get_ttx(346));
 			}
 
 		} else if (ds_readws(ACTION) == 133) {
 
 			if (ds_readbs(SLEEP_QUALITY) != -1) {
 
-				answer = select_hero_ok(get_ttx(0x4f4));
+				answer = select_hero_ok(get_ttx(317));
 
 				if (answer != -1) {
 
@@ -348,23 +348,23 @@ void do_inn(void)
 					if (host_readbs(Real2Host(hero) + HERO_TYPE) >= 7) {
 
 						if (magic_act[answer] != 0) {
-							GUI_output(get_ttx(0x538));
+							GUI_output(get_ttx(334));
 						} else {
 							magic_act[answer] = (signed char)use_magic(hero);
 						}
 					} else {
-						GUI_output(get_ttx(0x528));
+						GUI_output(get_ttx(330));
 					}
 				}
 			} else {
-				GUI_output(get_ttx(0x568));
+				GUI_output(get_ttx(346));
 			}
 
 		} else if (ds_readws(ACTION) == 134) {
 
 			if (ds_readbs(SLEEP_QUALITY) != -1 && ds_readbs(BOOKED_INN_DAYS) > 0) {
 
-				if (GUI_bool(get_ttx(0x4f8))) {
+				if (GUI_bool(get_ttx(318))) {
 					booked_days = ds_readbs(BOOKED_INN_DAYS);
 
 					if (host_readws(inn_ptr) < 8) {
@@ -404,13 +404,13 @@ void do_inn(void)
 					}
 				}
 			} else {
-				GUI_output(get_ttx(0x568));
+				GUI_output(get_ttx(346));
 			}
 		} else if (ds_readws(ACTION) == 135) {
 
 			if (ds_readbs(SLEEP_QUALITY) != -1) {
 
-				if (GUI_bool(get_ttx(0x640))) {
+				if (GUI_bool(get_ttx(400))) {
 					done = 1;
 					ds_writews(COMBO_MODE, 0);
 				}
@@ -425,13 +425,13 @@ void do_inn(void)
 
 			if (host_readws(tavern_ptr) >= 6 && host_readws(tavern_ptr) <= 13 &&
 				ds_readds(DAY_TIMER) < HOURS(11) && ds_readds(DAY_TIMER) > HOURS(3)) {
-				GUI_output(get_ttx(0xc84));
+				GUI_output(get_ttx(801));
 			} else if ((host_readws(tavern_ptr) < 6 || host_readws(tavern_ptr) > 13) &&
 				ds_readds(DAY_TIMER) < HOURS(16) && ds_readds(DAY_TIMER) > HOURS(3)) {
-				GUI_output(get_ttx(0x784));
+				GUI_output(get_ttx(481));
 			} else if (ds_readbs(SLEEP_QUALITY) != -1) {
 
-				if (GUI_bool(get_ttx(0x640))) {
+				if (GUI_bool(get_ttx(400))) {
 					done = 1;
 					ds_writews(COMBO_MODE, 2);
 				}

--- a/src/custom/schick/rewrite_m302de/seg055.cpp
+++ b/src/custom/schick/rewrite_m302de/seg055.cpp
@@ -87,7 +87,7 @@ void do_merchant(void)
 	if ((ds_readds(DAY_TIMER) < HOURS(8) || ds_readds(DAY_TIMER) > HOURS(19)) && ds_readbs(LOCATION) != LOCATION_MARKET)
 	{
 
-		GUI_output(get_ttx(0x788));
+		GUI_output(get_ttx(482));
 		turnaround();
 		return;
 	}
@@ -99,7 +99,7 @@ void do_merchant(void)
 			return;
 		}
 	} else if (ds_readb(MERCHANT_OFFENDED_FLAGS + ds_readws(TYPEINDEX)) != 0) {
-		GUI_output(get_ttx(0x7ec));
+		GUI_output(get_ttx(507));
 		turnaround();
 		return;
 	}
@@ -193,14 +193,14 @@ void do_merchant(void)
 
 			set_audio_track(ARCHIVE_FILE_TERMS_XMI);
 
-			GUI_print_loc_line(ds_readbs(LOCATION) == LOCATION_MARKET ? get_ttx(0xa9c) : (ds_readws(TYPEINDEX) == 93 ?  get_ttx(0xb8) : get_tx(4 * ds_readws(CITYINDEX))));
+			GUI_print_loc_line(ds_readbs(LOCATION) == LOCATION_MARKET ? get_ttx(679) : (ds_readws(TYPEINDEX) == 93 ?  get_ttx(46) : get_tx(ds_readws(CITYINDEX))));
 
 			ds_writew(REQUEST_REFRESH, refresh = 0);
 
 		}
 
 		if (refresh != 0) {
-			GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+			GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 			refresh = 0;
 		}
 
@@ -216,19 +216,19 @@ void do_merchant(void)
 
 			if (ds_readws(BANK_DEPOSIT) <= -1000 && ds_readws(DEBT_DAYS) == 0) {
 
-				GUI_output(get_ttx(0xbe4));
+				GUI_output(get_ttx(761));
 				ds_writews(DEBT_DAYS, 7);
 			}
 
 			if (ds_readws(DEBT_DAYS) == -1) {
 
-				if (GUI_bool(get_ttx(0xbe8))) {
+				if (GUI_bool(get_ttx(762))) {
 
 					party_money = get_party_money();
 
 					if (party_money < 5000) {
 
-						GUI_output(get_ttx(0xbec));
+						GUI_output(get_ttx(763));
 						ds_writews(MOUSE2_EVENT, ds_writews(ACTION, 0));
 						done = 1;
 
@@ -243,7 +243,7 @@ void do_merchant(void)
 					}
 				} else {
 
-					GUI_output(get_ttx(0xbec));
+					GUI_output(get_ttx(763));
 					ds_writews(MOUSE2_EVENT, ds_writews(ACTION, 0));
 					done = 1;
 				}
@@ -252,9 +252,9 @@ void do_merchant(void)
 
 		if (ds_readws(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
-			answer = GUI_radio(get_ttx(0x6b8), 4,
-						get_ttx(0x6bc), get_ttx(0x6c0),
-						get_ttx(0x55c), get_ttx(0x6c8)) - 1;
+			answer = GUI_radio(get_ttx(430), 4,
+						get_ttx(431), get_ttx(432),
+						get_ttx(343), get_ttx(434)) - 1;
 
 			if (answer != -2) {
 				ds_writews(ACTION, answer + 129);

--- a/src/custom/schick/rewrite_m302de/seg056.cpp
+++ b/src/custom/schick/rewrite_m302de/seg056.cpp
@@ -295,7 +295,7 @@ void buy_screen(void)
 					(char*)p_datseg + BUY_SCREEN_STR_COMMA_SPACE);
 
 				strcat((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(4 * (48 + host_readbs(get_itemsdat(item_id) + 3))));
+					(char*)get_ttx(48 + host_readbs(get_itemsdat(item_id) + 3)));
 			}
 
 			GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
@@ -341,10 +341,10 @@ void buy_screen(void)
 		if ((ds_readws(MOUSE2_EVENT) != 0 && ds_readws(ACTION) != 144) || ds_readws(ACTION) == 73) {
 
 			l3 = GUI_radio(NULL, 4,
-					get_ttx(0x6c4),
-					get_ttx(0x6cc),
-					get_ttx(0x6d0),
-					get_ttx(0x6d4)) - 1;
+					get_ttx(433),
+					get_ttx(435),
+					get_ttx(436),
+					get_ttx(437)) - 1;
 
 			if (l3 != -2) {
 				ds_writew(ACTION, l3 + 129);
@@ -393,14 +393,14 @@ void buy_screen(void)
 						if (host_readws(Real2Host(ds_readd(BUY_SHOPPING_CART)) + 4 * l16 + 2) > 1) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0xcc8),
+								(char*)get_ttx(818),
 								(char*)Real2Host(GUI_names_grammar(4, item_id, 0)));
 
 							l4 = GUI_input(Real2Host(ds_readd(DTP2)), 2);
 						}
 					} else {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x6e4),
+							(char*)get_ttx(441),
 							(char*)Real2Host(GUI_names_grammar(4, item_id, 0)));
 
 						l4 = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -417,9 +417,9 @@ void buy_screen(void)
 						(Bit32s)host_readws(Real2Host(ds_readd(BUYITEMS)) + 7 *(l7 + item) + 4) * l4;
 
 					if (l3 == 1 && price + l9 > p_money) {
-						GUI_output(get_ttx(0x644));
+						GUI_output(get_ttx(401));
 					} else if (l3 == 1 && free_slots < l17) {
-						GUI_output(get_ttx(0x6d8));
+						GUI_output(get_ttx(438));
 					} else {
 
 						if (l3 == 1) {
@@ -457,7 +457,7 @@ void buy_screen(void)
 					if (item_stackable(get_itemsdat(host_readws(Real2Host(ds_readd(BUYITEMS)) + 7 * (l7 + item))))) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x6e4),
+							(char*)get_ttx(441),
 							(char*)Real2Host(GUI_names_grammar(4, host_readws(Real2Host(ds_readd(BUYITEMS)) + 7 * (l7 + item)), 0)));
 
 						l4 = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -469,9 +469,9 @@ void buy_screen(void)
 							(Bit32s)host_readws(Real2Host(ds_readd(BUYITEMS)) + 7 * (l7 + item) + 4) * l4;
 
 						if (price + l9 > p_money) {
-							GUI_output(get_ttx(0x644));
+							GUI_output(get_ttx(401));
 						} else if (free_slots < l17) {
-							GUI_output(get_ttx(0x6d8));
+							GUI_output(get_ttx(438));
 						} else {
 							price += l9;
 
@@ -512,7 +512,7 @@ void buy_screen(void)
 
 				make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), price);
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x6dc),
+					(char*)get_ttx(439),
 					(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 
@@ -522,7 +522,7 @@ void buy_screen(void)
 				} while (percent > 50);
 
 				if (percent == 0) {
-					GUI_output(get_ttx(0x6e0));
+					GUI_output(get_ttx(440));
 					offended = 2;
 				} else if (percent >= percent_old) {
 					j = 2;
@@ -531,7 +531,7 @@ void buy_screen(void)
 				} else {
 					ds_writew(SKILLED_HERO_POS, get_skilled_hero_pos(TA_FEILSCHEN));
 
-					l3 = select_hero_ok(get_ttx(0x6e8));
+					l3 = select_hero_ok(get_ttx(442));
 
 					if (l3 == -1) {
 						break;
@@ -545,7 +545,7 @@ void buy_screen(void)
 				if (offended > 0) {
 
 					if (offended != 2) {
-						GUI_output(get_ttx(0x6f0));
+						GUI_output(get_ttx(444));
 					}
 
 					l12 = l13 = 0;
@@ -584,25 +584,25 @@ void buy_screen(void)
 						make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), price);
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xccc),
+							(char*)get_ttx(819),
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					}
 
 					if (l13 != 0) {
-						GUI_output(get_ttx(0x8d8));
+						GUI_output(get_ttx(566));
 					}
 
 					done = 1;
 				} else {
 
 					if (j == 2) {
-						GUI_output(get_ttx(0x6f4));
+						GUI_output(get_ttx(445));
 						ds_writeb(MERCHANT_OFFENDED_FLAGS + ds_readw(TYPEINDEX), 1);
 						done = 1;
 					} else {
-						GUI_output(get_ttx(0x6ec));
+						GUI_output(get_ttx(443));
 						percent_old = percent;
 					}
 

--- a/src/custom/schick/rewrite_m302de/seg057.cpp
+++ b/src/custom/schick/rewrite_m302de/seg057.cpp
@@ -141,7 +141,7 @@ void sell_screen(Bit8u *shop_ptr)
 
 			if (l10 != 0) {
 
-				hero_pos = select_hero_ok(get_ttx(0x700));
+				hero_pos = select_hero_ok(get_ttx(448));
 
 				if (hero_pos == -1 || host_readbs(get_hero(hero_pos) + HERO_KS_TAKEN) == 0) {
 					break;
@@ -310,11 +310,11 @@ void sell_screen(Bit8u *shop_ptr)
 		if (ds_readws(MOUSE2_EVENT) != 0  || ds_readws(ACTION) == 73) {
 
 			answer = GUI_radio(NULL, 5,
-					get_ttx(0x6c4),
-					get_ttx(0x6cc),
-					get_ttx(0x6d0),
-					get_ttx(0x6f8),
-					get_ttx(0x6d4)) - 1;
+					get_ttx(433),
+					get_ttx(435),
+					get_ttx(436),
+					get_ttx(446),
+					get_ttx(437)) - 1;
 
 			if (answer != -2) {
 				ds_writew(ACTION, answer + 129);
@@ -335,12 +335,12 @@ void sell_screen(Bit8u *shop_ptr)
 			item_id = host_readws(Real2Host(ds_readd(SELLITEMS)) + 7 * (l6 + item));
 
 			if (host_readws(Real2Host(ds_readd(SELLITEMS)) + 7 * (l6 + item) + 2) == 0) {
-				GUI_output(get_ttx(0x710));
+				GUI_output(get_ttx(452));
 			} else {
 
 				if (item_undropable(get_itemsdat(item_id))) {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x718),
+						(char*)get_ttx(454),
 						(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item_id, 0)));
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				} else {
@@ -353,7 +353,7 @@ void sell_screen(Bit8u *shop_ptr)
 						if (item_stackable(get_itemsdat(item_id)) && host_readws(hero1 + (HERO_ITEM_HEAD+2) + 14 * l15) > 1) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x6fc),
+								(char*)get_ttx(447),
 								(char*)Real2Host(GUI_names_grammar(4, item_id, 0)));
 
 							nice = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -386,7 +386,7 @@ void sell_screen(Bit8u *shop_ptr)
 						if (item_stackable(get_itemsdat(item_id)) && host_readws(hero1 + (HERO_ITEM_HEAD+2) + 14 * l15) > 1) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x6fc),
+								(char*)get_ttx(447),
 								(char*)Real2Host(GUI_names_grammar(4, item_id, 0)));
 
 							nice = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -435,7 +435,7 @@ void sell_screen(Bit8u *shop_ptr)
 
 				make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), price);
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x704),
+					(char*)get_ttx(449),
 					(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 
@@ -445,7 +445,7 @@ void sell_screen(Bit8u *shop_ptr)
 				} while (percent > 50);
 
 				if (percent == 0) {
-					GUI_output(get_ttx(0x6e0));
+					GUI_output(get_ttx(440));
 					l12 = 2;
 				} else if (percent >= percent_old) {
 					j = 2;
@@ -454,7 +454,7 @@ void sell_screen(Bit8u *shop_ptr)
 				} else {
 					ds_writew(SKILLED_HERO_POS, get_skilled_hero_pos(TA_FEILSCHEN));
 
-					answer = select_hero_ok_forced(get_ttx(0x6e8));
+					answer = select_hero_ok_forced(get_ttx(442));
 
 					hero2 = get_hero(answer);
 
@@ -487,12 +487,12 @@ void sell_screen(Bit8u *shop_ptr)
 					}
 
 					if (l12 != 2) {
-						GUI_output(get_ttx(0x70c));
+						GUI_output(get_ttx(451));
 
 						make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), price);
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xccc),
+							(char*)get_ttx(819),
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -510,11 +510,11 @@ void sell_screen(Bit8u *shop_ptr)
 				}
 
 				if (j == 2) {
-					GUI_output(get_ttx(0x714));
+					GUI_output(get_ttx(453));
 					ds_writeb(MERCHANT_OFFENDED_FLAGS + ds_readws(TYPEINDEX), 1);
 					done = 1;
 				} else {
-					GUI_output(get_ttx(0x708));
+					GUI_output(get_ttx(450));
 					percent_old = percent;
 				}
 

--- a/src/custom/schick/rewrite_m302de/seg058.cpp
+++ b/src/custom/schick/rewrite_m302de/seg058.cpp
@@ -160,12 +160,12 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 
 		if (ds_readds(SMITH_REPAIRITEMS + 2 + 6 * a1) > ds_readds(DAY_TIMER)) {
 			/* not ready yet */
-			GUI_output(get_ttx(0x794));
+			GUI_output(get_ttx(485));
 
 		} else if (get_item(ds_readws(SMITH_REPAIRITEMS + 6 * a1), 1, 1)) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x798),
+				(char*)get_ttx(486),
 				(char*)Real2Host(GUI_names_grammar((signed short)0x8002, ds_readws(SMITH_REPAIRITEMS + 6 * a1), 0)));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -210,7 +210,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 
 				if (l10 != 0) {
 
-					hero_pos = select_hero_ok(get_ttx(0x7bc));
+					hero_pos = select_hero_ok(get_ttx(495));
 
 					hero2 = get_hero(hero_pos);
 
@@ -346,11 +346,11 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 			if (ds_readws(MOUSE2_EVENT) != 0  || ds_readws(ACTION) == 73) {
 
 				answer = GUI_radio(NULL, 5,
-						get_ttx(0x6c4),
-						get_ttx(0x6cc),
-						get_ttx(0x6d0),
-						get_ttx(0x6f8),
-						get_ttx(0x6d4)) - 1;
+						get_ttx(433),
+						get_ttx(435),
+						get_ttx(436),
+						get_ttx(446),
+						get_ttx(437)) - 1;
 
 				if (answer != -2) {
 					ds_writew(ACTION, answer + 129);
@@ -372,7 +372,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 				p_money = get_party_money();
 
 				if (host_readws(Real2Host(ds_readd(SELLITEMS)) + 7 * (l7 + item) + 2) == 0) {
-					GUI_output(get_ttx(0x79c));
+					GUI_output(get_ttx(487));
 				} else {
 
 
@@ -387,7 +387,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 						make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), price);
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x7a0),
+							(char*)get_ttx(488),
 							(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item_id, 0)),
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
@@ -400,7 +400,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 						price -= (percent * price) / 100L;
 
 						if (percent == 0 && p_money > price) {
-							GUI_output(get_ttx(0x7a4));
+							GUI_output(get_ttx(489));
 							l12 = 2;
 						} else if (percent >= percent_old) {
 							j = 2;
@@ -408,7 +408,7 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 							break;
 						} else {
 
-							answer = select_hero_ok_forced(get_ttx(0x6e8));
+							answer = select_hero_ok_forced(get_ttx(442));
 
 							hero1 = get_hero(answer);
 
@@ -418,20 +418,20 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 						if (l12 > 0) {
 
 							if (p_money < price) {
-								GUI_output(get_ttx(0x644));
+								GUI_output(get_ttx(401));
 							} else {
 								if (l12 != 2) {
-									GUI_output(get_ttx(0x7b0));
+									GUI_output(get_ttx(492));
 								}
 
 								ds_writew(SMITH_REPAIRITEMS + 6 * a1, item_id);
 
 								if (ds_readds(DAY_TIMER) > HOURS(14)) {
 									ds_writed(SMITH_REPAIRITEMS + 2 + 6 * a1, HOURS(23));
-									GUI_output(get_ttx(0x7a8));
+									GUI_output(get_ttx(490));
 								} else {
 									ds_writed(SMITH_REPAIRITEMS + 2 + 6 * a1, ds_readd(DAY_TIMER) + HOURS(6));
-									GUI_output(get_ttx(0x7ac));
+									GUI_output(get_ttx(491));
 								}
 
 								drop_item(hero2, host_readbs(Real2Host(ds_readd(SELLITEMS)) + 6 + 7 * (l7 + item)), 1);
@@ -444,10 +444,10 @@ void repair_screen(Bit8u *smith_ptr, signed short a1)
 
 						}
 						 if (j == 2) {
-							GUI_output(get_ttx(0x7b4));
+							GUI_output(get_ttx(493));
 							done = 1;
 						} else {
-							GUI_output(get_ttx(0x7b8));
+							GUI_output(get_ttx(494));
 							percent_old = percent;
 						}
 
@@ -493,7 +493,7 @@ void do_smith(void)
 
 	if (ds_readds(DAY_TIMER) < HOURS(6) || ds_readds(DAY_TIMER) > HOURS(20)) {
 
-		GUI_output(get_ttx(0x78c));
+		GUI_output(get_ttx(483));
 		turnaround();
 		return;
 	}
@@ -521,7 +521,7 @@ void do_smith(void)
 			set_var_to_zero();
 			load_ani(5);
 			init_ani(0);
-			GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+			GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 			set_audio_track(ARCHIVE_FILE_SMITH_XMI);
 			ds_writew(REQUEST_REFRESH, 0);
 		}
@@ -532,10 +532,10 @@ void do_smith(void)
 
 			ds_writew(TEXTBOX_WIDTH, 4);
 
-			answer = GUI_radio(get_ttx(0x7c0), 3,
-						get_ttx(0x55c),
-						get_ttx(0x7c4),
-						get_ttx(0x7c8)) - 1;
+			answer = GUI_radio(get_ttx(496), 3,
+						get_ttx(343),
+						get_ttx(497),
+						get_ttx(498)) - 1;
 
 			/* TODO: why should it be 3??? Better make a backup */
 			ds_writew(TEXTBOX_WIDTH, 3);

--- a/src/custom/schick/rewrite_m302de/seg059.cpp
+++ b/src/custom/schick/rewrite_m302de/seg059.cpp
@@ -45,7 +45,7 @@ void do_tavern(void)
 	done = 0;
 	tav_ptr = p_datseg + TAVERN_DESCR_TABLE + 4 * ds_readws(TYPEINDEX);
 
-	GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+	GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 
 	ds_writew(REQUEST_REFRESH, 1);
 
@@ -53,14 +53,14 @@ void do_tavern(void)
 
 		if (ds_readds(DAY_TIMER) < HOURS(11) && ds_readds(DAY_TIMER) > HOURS(3)) {
 
-			GUI_output(get_ttx(0xc84));
+			GUI_output(get_ttx(801));
 			turnaround();
 			return;
 		}
 
 	} else if (ds_readds(DAY_TIMER) < HOURS(16) && ds_readds(DAY_TIMER) > HOURS(3)) {
 
-			GUI_output(get_ttx(0x784));
+			GUI_output(get_ttx(481));
 			turnaround();
 			return;
 	}
@@ -75,7 +75,7 @@ void do_tavern(void)
 			set_var_to_zero();
 			load_ani(27);
 			init_ani(0);
-			GUI_print_loc_line(get_tx(4 * ds_readws(CITYINDEX)));
+			GUI_print_loc_line(get_tx(ds_readws(CITYINDEX)));
 			set_audio_track(ARCHIVE_FILE_INN_XMI);
 			ds_writew(REQUEST_REFRESH, 0);
 		}
@@ -84,26 +84,26 @@ void do_tavern(void)
 
 		if (ds_readbs(TAV_CHEATED_FLAGS + ds_readws(TYPEINDEX)) != 0) {
 
-			GUI_output(get_ttx(0x760));
+			GUI_output(get_ttx(472));
 			done = 1;
 			ds_writew(MOUSE2_EVENT, ds_writew(ACTION, 0));
 		}
 
 		if (ds_readds(DAY_TIMER) < HOURS(11) && ds_readds(DAY_TIMER) > HOURS(3)) {
 
-			GUI_output(get_ttx(0x24));
+			GUI_output(get_ttx(9));
 			done = 1;
 			ds_writew(MOUSE2_EVENT, ds_writew(ACTION, 0));
 		}
 
 		if (ds_readw(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
-			answer = GUI_radio(get_ttx(0x754), ds_readw(COMBO_MODE) == 0 ? 4 : 5,
-						get_ttx(0x55c),
-						get_ttx(0x758),
-						get_ttx(0x350),
-						get_ttx(0x75c),
-						get_ttx(0xce0)) - 1;
+			answer = GUI_radio(get_ttx(469), ds_readw(COMBO_MODE) == 0 ? 4 : 5,
+						get_ttx(343),
+						get_ttx(470),
+						get_ttx(212),
+						get_ttx(471),
+						get_ttx(824)) - 1;
 
 			if (answer != -2) {
 				ds_writew(ACTION, answer + 129);
@@ -121,7 +121,7 @@ void do_tavern(void)
 
 				make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), p_money_before - p_money_after);
 
-				sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0xce4),
+				sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(825),
 					(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -142,13 +142,13 @@ void do_tavern(void)
 
 			p_money_after += host_readws(tav_ptr + 2) * p_money_after / 100;
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x764),
+				(char*)get_ttx(473),
 				(signed short)p_money_after);
 
 			if (GUI_bool(Real2Host(ds_readd(DTP2)))) {
 
-				GUI_output(host_readws(tav_ptr) < 5 ? get_ttx(0x76c) : (
-						host_readws(tav_ptr) < 15 ? get_ttx(0x770) : get_ttx(0x774)));
+				GUI_output(host_readws(tav_ptr) < 5 ? get_ttx(475) : (
+						host_readws(tav_ptr) < 15 ? get_ttx(476) : get_ttx(477)));
 
 				timewarp(HOURS(1));
 
@@ -190,7 +190,7 @@ void do_tavern(void)
 
 				if (p_money_before < p_money_after) {
 
-					GUI_output(get_ttx(0x768));
+					GUI_output(get_ttx(474));
 
 					ds_writeb(TAV_CHEATED_FLAGS + ds_readws(TYPEINDEX), 1);
 					done = 1;
@@ -210,7 +210,7 @@ void do_tavern(void)
 
 			bonus = (timeval - ds_readds(LAST_SAVE_TIME)) > 120 ? 0 : 50;
 
-			if (GUI_use_skill2(bonus, get_ttx(0x62c)) == -1) {
+			if (GUI_use_skill2(bonus, get_ttx(395)) == -1) {
 				done = 1;
 				ds_writew(COMBO_MODE, 0);
 			}
@@ -267,11 +267,11 @@ void enter_ghostship(void)
 
 	load_tx(ARCHIVE_FILE_DNGS_DTX + 1);
 
-	GUI_output(get_tx(0x48));
-	GUI_output(get_tx(0x4c));
+	GUI_output(get_tx(18));
+	GUI_output(get_tx(19));
 
 	do {
-		answer = GUI_radio(get_tx(0x50), 2, get_tx(0x54), get_tx(0x58));
+		answer = GUI_radio(get_tx(20), 2, get_tx(21), get_tx(22));
 
 	} while (answer == -1);
 

--- a/src/custom/schick/rewrite_m302de/seg060.cpp
+++ b/src/custom/schick/rewrite_m302de/seg060.cpp
@@ -83,7 +83,7 @@ void talk_tavern(void)
 		if (host_readws(state_ptr) != -1) {
 
 			txt_id = host_readws(state_ptr) & 0x7fff;
-			format = (char*)get_tx(4 * txt_id);
+			format = (char*)get_tx(txt_id);
 			hero = Real2Host(get_first_hero_available_in_group());
 
 			if (txt_id == 52 || txt_id == 72 || txt_id == 78 || txt_id == 83 || txt_id == 89) {
@@ -125,7 +125,7 @@ void talk_tavern(void)
 
 				sprintf(text_buffer, format,
 					random_interval(3, 6),
-					random_schick(2) == 1 ? get_tx(0x244) : get_tx(0x248));
+					random_schick(2) == 1 ? get_tx(145) : get_tx(146));
 
 			} else if (txt_id == 114) {
 
@@ -133,19 +133,19 @@ void talk_tavern(void)
 
 				/* print quality [-1, 2..20]  2 = best, 20 = worse */
 				sprintf(text_buffer, format,
-					food_quality >= 1 && food_quality <= 3 ? get_tx(0x220) : (
-					food_quality >= 4 && food_quality <= 6 ? get_tx(0x224) : (
-					food_quality >= 7 && food_quality <= 9 ? get_tx(0x228) : (
-					food_quality >= 10 && food_quality <= 12 ? get_tx(0x22c) : (
-					food_quality >= 13 && food_quality <= 15 ? get_tx(0x230) : (
-					food_quality >= 15 && food_quality <= 18 ? get_tx(0x234) : get_tx(0x238)))))));
+					food_quality >= 1 && food_quality <= 3 ? get_tx(136) : (
+					food_quality >= 4 && food_quality <= 6 ? get_tx(137) : (
+					food_quality >= 7 && food_quality <= 9 ? get_tx(138) : (
+					food_quality >= 10 && food_quality <= 12 ? get_tx(139) : (
+					food_quality >= 13 && food_quality <= 15 ? get_tx(140) : (
+					food_quality >= 15 && food_quality <= 18 ? get_tx(141) : get_tx(142)))))));
 
 			} else if (txt_id == 115) {
 
 				ds_writeb(TLK_TAV_INFORMERSEX, random_schick(2));
 
 				sprintf(text_buffer, format,
-					ds_readb(TLK_TAV_INFORMERSEX) == 1 ? get_tx(0x23c) : get_tx(0x240));
+					ds_readb(TLK_TAV_INFORMERSEX) == 1 ? get_tx(143) : get_tx(144));
 
 			} else if (txt_id == 119) {
 
@@ -174,7 +174,7 @@ void talk_tavern(void)
 			}
 
 			txt_id = host_readb(state_ptr + 2);
-			format = (char*)get_tx(4 * txt_id);
+			format = (char*)get_tx(txt_id);
 
 
 			if (txt_id == 1 || txt_id == 19) {
@@ -184,7 +184,7 @@ void talk_tavern(void)
 			}
 
 			txt_id = host_readb(state_ptr + 3);
-			format = (char*)get_tx(4 * txt_id);
+			format = (char*)get_tx(txt_id);
 
 			if (txt_id == 13) {
 
@@ -206,7 +206,7 @@ void talk_tavern(void)
 			}
 
 			txt_id = host_readb(state_ptr + 4);
-			strcpy(answer3_buffer, (char*)get_tx(4 * txt_id));
+			strcpy(answer3_buffer, (char*)get_tx(txt_id));
 
 			do {
 				answer = GUI_radio((Bit8u*)text_buffer, (signed char)options, answer1_buffer, answer2_buffer, answer3_buffer);

--- a/src/custom/schick/rewrite_m302de/seg061.cpp
+++ b/src/custom/schick/rewrite_m302de/seg061.cpp
@@ -81,9 +81,9 @@ void do_temple(void)
 
 			/* location string */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x3ac),
-				(char*)get_ttx(4 * (ds_readws(TEMPLE_GOD) + 21)),	/* name of the god */
-				(char*)(ds_readws(TYPEINDEX) != 58 ? get_ttx(4 * (ds_readbs(CURRENT_TOWN) + 235)): get_ttx(0x9b8)));
+				(char*)get_ttx(235),
+				(char*)get_ttx(ds_readws(TEMPLE_GOD) + 21),	/* name of the god */
+				(char*)(ds_readws(TYPEINDEX) != 58 ? get_ttx(ds_readbs(CURRENT_TOWN) + 235): get_ttx(622)));
 
 			GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 
@@ -95,16 +95,16 @@ void do_temple(void)
 		/* input window */
 		if (ds_readws(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
-			l_di = GUI_radio(get_ttx(0x384), 9,
-						get_ttx(0x388),
-						get_ttx(0x38c),
-						get_ttx(0x494),
-						get_ttx(0x390),
-						get_ttx(0x394),
-						get_ttx(0x398),
-						get_ttx(0x9b0),
-						get_ttx(0x4a0),
-						get_ttx(0x39c)) - 1;
+			l_di = GUI_radio(get_ttx(225), 9,
+						get_ttx(226),
+						get_ttx(227),
+						get_ttx(293),
+						get_ttx(228),
+						get_ttx(229),
+						get_ttx(230),
+						get_ttx(620),
+						get_ttx(296),
+						get_ttx(231)) - 1;
 
 			if (l_di != -2) {
 				ds_writew(ACTION, l_di + 129);
@@ -114,7 +114,7 @@ void do_temple(void)
 		if (ds_readws(ACTION) == 137) {
 			/* leave temple */
 			if (!ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
-				GUI_output(get_ttx(0x3a0));
+				GUI_output(get_ttx(232));
 			} else {
 				done = 1;
 			}
@@ -139,9 +139,9 @@ void do_temple(void)
 
 				/* location string */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x3ac),
-					(char*)get_ttx(4 * (ds_readws(TEMPLE_GOD) + 21)),	/* name of the god */
-					(char*)get_ttx(4 * (ds_readbs(CURRENT_TOWN) + 235)));
+					(char*)get_ttx(235),
+					(char*)get_ttx(ds_readws(TEMPLE_GOD) + 21),	/* name of the god */
+					(char*)get_ttx(ds_readbs(CURRENT_TOWN) + 235));
 				GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 
 				draw_status_line();
@@ -150,13 +150,13 @@ void do_temple(void)
 					done = 1;
 				}
 			} else {
-				GUI_output(get_ttx(0xcc4));
+				GUI_output(get_ttx(817));
 			}
 		} else if (ds_readws(ACTION) == 133) {
 			/* save game */
 			if (ds_readws(TYPEINDEX) != 58) {
 				if (!ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
-					GUI_output(get_ttx(0x3a0));
+					GUI_output(get_ttx(232));
 				} else {
 					save_game_state();
 				}
@@ -167,7 +167,7 @@ void do_temple(void)
 
 		if (ds_readws(ACTION) == 134) {
 			/* quit game */
-			if (GUI_bool(get_ttx(0x4ac))) {
+			if (GUI_bool(get_ttx(299))) {
 				done = 1;
 				ds_writews(GAME_STATE, GAME_STATE_QUIT);
 			}
@@ -176,7 +176,7 @@ void do_temple(void)
 		if (ds_readws(ACTION) == 135) {
 			/* ask for a miracle */
 			if (!ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
-				GUI_output(get_ttx(0x3a0));
+				GUI_output(get_ttx(232));
 			} else {
 				ask_miracle();
 			}
@@ -185,19 +185,19 @@ void do_temple(void)
 		if (ds_readws(ACTION) == 136) {
 			/* make a donation */
 			if (!ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
-				GUI_output(get_ttx(0x3a0));
+				GUI_output(get_ttx(232));
 			} else {
 
 				money = get_party_money();
 
 				if (!money) {
-					GUI_output(get_ttx(0x644));
+					GUI_output(get_ttx(401));
 				} else {
 
 					make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x4a4),
+						(char*)get_ttx(297),
 						(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 					input = GUI_input(Real2Host(ds_readd(DTP2)), 3);
@@ -216,7 +216,7 @@ void do_temple(void)
 						}
 
 						set_party_money(money);
-						GUI_output(get_ttx(0x4a8));
+						GUI_output(get_ttx(298));
 					}
 				}
 			}
@@ -243,13 +243,13 @@ void char_add(signed short temple_id)
 	if (ds_readbs(TOTAL_HERO_COUNTER) == 7 ||
 		(ds_readbs(TOTAL_HERO_COUNTER) == 6 && !host_readbs(get_hero(6) + HERO_TYPE)))
 	{
-		GUI_output(get_ttx(0x480));
+		GUI_output(get_ttx(288));
 	} else {
 
 		do {
 
 			if (!l_di) {
-				GUI_output(get_ttx(0x488));
+				GUI_output(get_ttx(290));
 				l_si = -1;
 			} else {
 
@@ -281,9 +281,9 @@ void char_add(signed short temple_id)
 
 					/* location string */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x3ac),
-						(char*)get_ttx(4 * (ds_readws(TEMPLE_GOD) + 21)),	/* name of the god */
-						(char*)get_ttx(4 * (ds_readbs(CURRENT_TOWN) + 235)));
+						(char*)get_ttx(235),
+						(char*)get_ttx(ds_readws(TEMPLE_GOD) + 21),	/* name of the god */
+						(char*)get_ttx(ds_readbs(CURRENT_TOWN) + 235));
 					GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 				}
 
@@ -299,12 +299,12 @@ void char_letgo(signed short temple_id)
 	Bit8u *hero;
 
 	if (!ds_readbs(TOTAL_HERO_COUNTER) || !ds_readbs(GROUP_MEMBER_COUNTS + ds_readbs(CURRENT_GROUP))) {
-		GUI_output(get_ttx(0x3a0));
+		GUI_output(get_ttx(232));
 	} else {
 
 		do {
 
-			hero_pos = select_hero_from_group(get_ttx(0x9a8));
+			hero_pos = select_hero_from_group(get_ttx(618));
 
 			if (hero_pos != -1) {
 
@@ -330,9 +330,9 @@ void char_letgo(signed short temple_id)
 
 					/* location string */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x3ac),
-						(char*)get_ttx(4 * (ds_readws(TEMPLE_GOD) + 21)),	/* name of the god */
-						(char*)get_ttx(4 * (ds_readbs(CURRENT_TOWN) + 235)));
+						(char*)get_ttx(235),
+						(char*)get_ttx(ds_readws(TEMPLE_GOD) + 21),	/* name of the god */
+						(char*)get_ttx(ds_readbs(CURRENT_TOWN) + 235));
 					GUI_print_loc_line(Real2Host(ds_readd(DTP2)));
 				}
 			}
@@ -367,7 +367,7 @@ signed short char_erase(void)
 					(char*)Real2Host(ptr) + 32 * l_si);
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)get_ttx(0x49c),
+					(char*)get_ttx(295),
 					(char*)Real2Host(ds_readd(DTP2)));
 
 				if (GUI_bool(Real2Host(ds_readd(TEXT_OUTPUT_BUF)))) {
@@ -378,7 +378,7 @@ signed short char_erase(void)
 					unlink_ret = bc_unlink((RealPt)ds_readd(TEXT_OUTPUT_BUF));
 
 					if (unlink_ret != 0) {
-						GUI_output(get_ttx(0x498));
+						GUI_output(get_ttx(294));
 						return 0;
 					}
 
@@ -443,10 +443,10 @@ void miracle_heal_hero(signed short le_in, Bit8u *str)
 		add_hero_le(get_hero(hero_pos), le_in);
 
 		/* prepare a message */
-		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x620));
+		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(392));
 
 		if (le_in > 1) {
-			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x624));
+			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(393));
 		}
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),

--- a/src/custom/schick/rewrite_m302de/seg062.cpp
+++ b/src/custom/schick/rewrite_m302de/seg062.cpp
@@ -72,7 +72,7 @@ void ask_miracle(void)
 			l_si = random_schick(god_dice.a[ds_readws(TEMPLE_GOD)]);
 
 			if (god_dice.a[ds_readws(TEMPLE_GOD)] == l_si) {
-				miracle_resurrect(get_tx2(0x8c));
+				miracle_resurrect(get_tx2(35));
 			} else {
 				switch (ds_readws(TEMPLE_GOD)) {
 				case 1: {
@@ -91,7 +91,7 @@ void ask_miracle(void)
 							/* MU+1 for 1 day */
 							if (!ds_readd(INGAME_TIMERS + 0x28)) {
 								miracle_modify(get_hero(0) + (HERO_ATTRIB + 3 * ATTRIB_MU) - get_hero(0), HOURS(24), 1);
-								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(4));
+								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(1));
 								ds_writed(INGAME_TIMERS + 0x28, HOURS(24));
 							}
 						} else if (l_si <= 7) {
@@ -107,7 +107,7 @@ void ask_miracle(void)
 										99, (signed char)i);
 
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_tx2(8),
+										(char*)get_tx2(2),
 										(char*)get_hero(i) + HERO_NAME2);
 									ds_writed(INGAME_TIMERS + 0x2c, 3 * HOURS(24));
 								}
@@ -127,7 +127,7 @@ void ask_miracle(void)
 									}
 
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0x8d4),
+										(char*)get_ttx(565),
 										(char*)hero + HERO_NAME2);
 									break;
 								} else {
@@ -139,7 +139,7 @@ void ask_miracle(void)
 										and_ptr_bs(hero + HERO_STATUS1, 0xdf);
 
 										sprintf((char*)Real2Host(ds_readd(DTP2)),
-											(char*)get_tx2(0x0c),
+											(char*)get_tx2(3),
 											(char*)hero + HERO_NAME2);
 										break;
 									}
@@ -156,14 +156,14 @@ void ask_miracle(void)
 							miracle_modify(get_hero(0) + (HERO_TA_FIGHT + 3) - get_hero(0), 3 * HOURS(24), 1);
 							miracle_modify(get_hero(0) + (HERO_AT + 3) - get_hero(0), 3 * HOURS(24), 1);
 							ds_writed(INGAME_TIMERS + 0x30, 3 * HOURS(24));
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x10));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(4));
 						}
 					} else if (l_si <= 7) {
 						ds_writed(INGAME_TIMERS, HOURS(6));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x14));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(5));
 					} else if (l_si <= 8) {
 						if (!ds_readd(INGAME_TIMERS + 0x34)) {
-							miracle_weapon(get_tx2(0x18), 0);
+							miracle_weapon(get_tx2(6), 0);
 							ds_writed(INGAME_TIMERS + 0x34, HOURS(24));
 						}
 					}
@@ -173,14 +173,14 @@ void ask_miracle(void)
 					/* EFFERD */
 					if (l_si <= 5) {
 						ds_writed(INGAME_TIMERS + 4, 3 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x1c));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(7));
 					} else if (l_si <= 8) {
 						ds_writed(INGAME_TIMERS + 8, 3 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x20));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(8));
 					} else if (l_si <= 9) {
 						if (!ds_readd(INGAME_TIMERS + 0x38)) {
 							miracle_modify(get_hero(0) + (HERO_TA_BODY + 5) - get_hero(0), 4 * HOURS(24), 2);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x24));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(9));
 							ds_writed(INGAME_TIMERS + 0x38, 4 * HOURS(24));
 						}
 					}
@@ -201,12 +201,12 @@ void ask_miracle(void)
 							}
 						}
 
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x28));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(10));
 					} else if (l_si <= 15) {
-						miracle_heal_hero(dice_roll(1, 6, 2), get_tx2(0x2c));
+						miracle_heal_hero(dice_roll(1, 6, 2), get_tx2(11));
 					} else if (l_si <= 16) {
 						ds_writed(INGAME_TIMERS + 0x10, 7 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x30));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(12));
 					}
 					break;
 				}
@@ -214,13 +214,13 @@ void ask_miracle(void)
 					/* BORON */
 					if (l_si <= 3) {
 						ds_writed(INGAME_TIMERS + 0x14, 3 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x34));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(13));
 					} else if (l_si <= 4) {
-						miracle_resurrect(get_tx2(0x38));
+						miracle_resurrect(get_tx2(14));
 					} else if (l_si <= 5) {
 						if (!ds_readd(INGAME_TIMERS + 0x3c)) {
 							miracle_modify(get_hero(0) + (HERO_ATTRIB + 3 * ATTRIB_TA) - get_hero(0), 4 * HOURS(24), -1);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x3c));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(15));
 							ds_writed(INGAME_TIMERS + 0x3c, 4 * HOURS(24));
 						}
 					}
@@ -231,7 +231,7 @@ void ask_miracle(void)
 					if (l_si <= 3) {
 						if (!ds_readd(INGAME_TIMERS + 0x40)) {
 							miracle_modify(get_hero(0) + (HERO_SP_VISION + 1) - get_hero(0), 4 * HOURS(24), 1);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x40));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(16));
 							ds_writed(INGAME_TIMERS + 0x40, 4 * HOURS(24));
 						}
 					} else if (l_si <= 6) {
@@ -249,7 +249,7 @@ void ask_miracle(void)
 								}
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0x8d4),
+									(char*)get_ttx(565),
 									(char*)hero + HERO_NAME2);
 								break;
 							} else {
@@ -261,7 +261,7 @@ void ask_miracle(void)
 									and_ptr_bs(hero + HERO_STATUS1, 0xdf);
 
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_tx2(0x44),
+										(char*)get_tx2(17),
 										(char*)hero + HERO_NAME2);
 									break;
 								}
@@ -270,7 +270,7 @@ void ask_miracle(void)
 					} else if (l_si <= 7) {
 						if (!ds_readd(INGAME_TIMERS + 0x44)) {
 							miracle_modify(get_hero(0) + HERO_MR - get_hero(0), 3 * HOURS(24), 5);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x48));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(18));
 							ds_writed(INGAME_TIMERS + 0x44, 3 * HOURS(24));
 						}
 					}
@@ -280,10 +280,10 @@ void ask_miracle(void)
 					/* FIRUN & IFIRN */
 					if (l_si <= 5) {
 						ds_writed(INGAME_TIMERS + 0x0c, 3 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x4c));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(19));
 					} else if (l_si <= 8) {
 						ds_writed(INGAME_TIMERS + 0x0c, 7 * HOURS(24));
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x4c));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(19));
 					} else if (l_si <= 9) {
 						/* +1 for 7 days */
 						if (!ds_readd(INGAME_TIMERS + 0x48)) {
@@ -299,7 +299,7 @@ void ask_miracle(void)
 								host_writebs(get_hero(i) + HERO_HUNGER, host_writebs(get_hero(i) + HERO_THIRST, 0));
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx2(0x50),
+									(char*)get_tx2(20),
 									(char*)get_hero(i) + HERO_NAME2);
 								ds_writed(INGAME_TIMERS + 0x48, 7 * HOURS(24));
 							}
@@ -310,7 +310,7 @@ void ask_miracle(void)
 				case 8: {
 					/* TSA */
 					if (l_si <= 10) {
-						miracle_heal_hero(dice_roll(2, 6, 0), get_tx2(0x54));
+						miracle_heal_hero(dice_roll(2, 6, 0), get_tx2(21));
 					} else if (l_si <= 15) {
 
 						hero = get_hero(0);
@@ -326,10 +326,10 @@ void ask_miracle(void)
 							}
 						}
 
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x58));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(22));
 
 					} else if (l_si <= 18) {
-						miracle_resurrect(get_tx2(0x5c));
+						miracle_resurrect(get_tx2(23));
 					}
 					break;
 				}
@@ -341,19 +341,19 @@ void ask_miracle(void)
 							if (!ds_readd(INGAME_TIMERS + 0x4c)) {
 								miracle_modify(get_hero(0) + (HERO_TA_CRAFT + 8) - get_hero(0), 3 * HOURS(24), 1);
 								miracle_modify(get_hero(0) + (HERO_TA_CRAFT + 7) - get_hero(0), 3 * HOURS(24), 1);
-								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x60));
+								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(24));
 								ds_writed(INGAME_TIMERS + 0x4c, 3 * HOURS(24));
 							}
 						} else if (l_si <= 8) {
 							if (!ds_readd(INGAME_TIMERS + 0x50)) {
 								miracle_modify(get_hero(0) + (HERO_TA_SOCIAL + 2) - get_hero(0), 3 * HOURS(24), 1);
-								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x64));
+								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(25));
 								ds_writed(INGAME_TIMERS + 0x50, 3 * HOURS(24));
 							}
 						} else if (l_si <= 9) {
 							if (!ds_readd(INGAME_TIMERS + 0x54)) {
 								miracle_modify(get_hero(0) + (HERO_ATTRIB + 3 * ATTRIB_FF) - get_hero(0), 3 * HOURS(24), 1);
-								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x68));
+								strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(26));
 								ds_writed(INGAME_TIMERS + 0x54, 3 * HOURS(24));
 							}
 						}
@@ -363,9 +363,9 @@ void ask_miracle(void)
 				case 10: {
 					/* PERAINE */
 					if (l_si <= 10) {
-						miracle_heal_hero(dice_roll(1, 6, 0), get_tx2(0x6c));
+						miracle_heal_hero(dice_roll(1, 6, 0), get_tx2(27));
 					} else if (l_si <= 16) {
-						miracle_heal_hero(dice_roll(2, 6, 0), get_tx2(0x6c));
+						miracle_heal_hero(dice_roll(2, 6, 0), get_tx2(27));
 					} else if (l_si <= 18) {
 
 						for (i = 0; i <= 6; i++) {
@@ -380,7 +380,7 @@ void ask_miracle(void)
 								host_writeb(hero + (HERO_ILLNESS-4) + 5 * disease, 0);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx2(0x70),
+									(char*)get_tx2(28),
 									(char*)hero + HERO_NAME2);
 								break;
 							}
@@ -417,15 +417,15 @@ void ask_miracle(void)
 							}
 						}
 
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x74));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(29));
 
 					} else if (l_si <= 6) {
 						if (!ds_readd(INGAME_TIMERS + 0x58)) {
-							miracle_weapon(get_tx2(0x78), 0);
+							miracle_weapon(get_tx2(30), 0);
 							ds_writed(INGAME_TIMERS + 0x58, HOURS(24));
 						}
 					} else if (l_si <= 7) {
-						miracle_weapon(get_tx2(0x7c), 1);
+						miracle_weapon(get_tx2(31), 1);
 					}
 					break;
 				}
@@ -435,13 +435,13 @@ void ask_miracle(void)
 						if (!ds_readd(INGAME_TIMERS + 0x5c)) {
 							miracle_modify(get_hero(0) + (HERO_TA_SOCIAL + 1) - get_hero(0), 7 * HOURS(24), 2);
 							miracle_modify(get_hero(0) + (HERO_TA_BODY + 7) - get_hero(0), 7 * HOURS(24), 2);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x80));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(32));
 							ds_writed(INGAME_TIMERS + 0x5c, 7 * HOURS(24));
 						}
 					} else if (l_si <= 13) {
 						if (!ds_readd(INGAME_TIMERS + 0x60)) {
 							miracle_modify(get_hero(0) + (HERO_ATTRIB + 3 * ATTRIB_CH) - get_hero(0), 3 * HOURS(24), 1);
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x84));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(33));
 							ds_writed(INGAME_TIMERS + 0x60, 3 * HOURS(24));
 						}
 					} else if (l_si <= 14) {
@@ -461,7 +461,7 @@ void ask_miracle(void)
 								}
 							}
 
-							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(0x88));
+							strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx2(34));
 							ds_writed(INGAME_TIMERS + 0x64, 7 * HOURS(24));
 						}
 

--- a/src/custom/schick/rewrite_m302de/seg063.cpp
+++ b/src/custom/schick/rewrite_m302de/seg063.cpp
@@ -62,8 +62,8 @@ void passages_init(void)
 
 #if !defined(__BORLANDC__)
 	D1_LOG("%16s - %16s: %d %d %d %d %d %d\n",
-		(char*)get_ttx((host_readb(p + 0) + 0xeb) * 4),
-		(char*)get_ttx((host_readb(p + 1) + 0xeb) * 4),
+		(char*)get_ttx(host_readb(p + 0) + 0xeb),
+		(char*)get_ttx(host_readb(p + 1) + 0xeb),
 		host_readb(p + 2),
 		host_readb(p + 3),
 		host_readb(p + 4),
@@ -143,9 +143,9 @@ void do_harbour(void)
 
 		if (ds_readw(MOUSE2_EVENT) != 0 || ds_readws(ACTION) == 73) {
 
-			answer = GUI_radio(get_tx(0x24), 4,
-						get_tx(0x28), get_tx(0x2c),
-						get_tx(0x30), get_tx(0x34)) - 1;
+			answer = GUI_radio(get_tx(9), 4,
+						get_tx(10), get_tx(11),
+						get_tx(12), get_tx(13)) - 1;
 
 			if (answer != -2) {
 				ds_writew(ACTION, answer + 129);
@@ -157,36 +157,36 @@ void do_harbour(void)
 			answer = prepare_passages();
 
 			if (answer == 0) {
-				GUI_output(get_tx(0x3c));
+				GUI_output(get_tx(15));
 			} else {
 
 				/* select a destination */
-				answer = GUI_radio(get_tx(0x38), (signed char)answer,
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 0 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 1 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 2 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 3 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 4 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 5 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 6 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 7 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 8 + 10)) + 235)),
-						get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 9 + 10)) + 235))) - 1;
+				answer = GUI_radio(get_tx(14), (signed char)answer,
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 0 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 1 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 2 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 3 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 4 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 5 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 6 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 7 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 8 + 10)) + 235),
+						get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 12 * 9 + 10)) + 235)) - 1;
 
 				if (answer != -2) {
 
 					psg_ptr = p_datseg + 12 * answer + SEA_TRAVEL_MENU_PASSAGES;
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x40),
+						(char*)get_tx(16),
 
-						(char*)get_tx(4 * ds_readws(SEA_TRAVEL_TX_SHIP + 2 * host_readbs(psg_ptr + 9))),
+						(char*)get_tx(ds_readws(SEA_TRAVEL_TX_SHIP + 2 * host_readbs(psg_ptr + 9))),
 						(char*)Real2Host(host_readds(psg_ptr + 0)),
 
-						(char*)(!host_readbs(psg_ptr + 8) ? get_tx(0x14) : get_tx(0x18)),
+						(char*)(!host_readbs(psg_ptr + 8) ? get_tx(5) : get_tx(6)),
 
-						(char*)get_tx(4 * ds_readws(SEA_TRAVEL_TX_CLASS + 2 * ds_readbs(SEA_TRAVEL_QUALITY_TABLE + 4 * host_readbs(psg_ptr + 9)))),
-						(char*)get_ttx(4 * (host_readb(psg_ptr + 10) + 235)),
+						(char*)get_tx(ds_readws(SEA_TRAVEL_TX_CLASS + 2 * ds_readbs(SEA_TRAVEL_QUALITY_TABLE + 4 * host_readbs(psg_ptr + 9)))),
+						(char*)get_ttx(host_readb(psg_ptr + 10) + 235),
 						get_passage_travel_hours(host_readb(Real2Host(host_readd(psg_ptr + 4)) + 2), ds_readbs(SEA_TRAVEL_QUALITY_TABLE + 3 + 4 * host_readbs(psg_ptr + 9))),
 
 						Real2Host(print_passage_price(ds_readbs(SEA_TRAVEL_QUALITY_TABLE + 2 + 4 * host_readbs(psg_ptr + 9)), Real2Host(host_readds(psg_ptr + 4)))));
@@ -204,7 +204,7 @@ void do_harbour(void)
 
 						if (ds_readws(SEA_TRAVEL_PASSAGE_PRICE) > money) {
 
-							GUI_output(get_ttx(0x644));
+							GUI_output(get_ttx(401));
 
 						} else {
 
@@ -217,7 +217,7 @@ void do_harbour(void)
 							ds_writeb(SEA_TRAVEL_PASSAGE_UNKN1, ds_readb(SEA_TRAVEL_PASSAGE_UNKN2));
 							ds_writeb(SEA_TRAVEL_PASSAGE_ID, host_readb(psg_ptr + 11));
 
-							GUI_output(host_readb(psg_ptr + 8) != 0 ? get_tx(0x48) : get_tx(0x44));
+							GUI_output(host_readb(psg_ptr + 8) != 0 ? get_tx(18) : get_tx(17));
 						}
 					}
 				}
@@ -227,25 +227,25 @@ void do_harbour(void)
 
 			if (ds_readds(DAY_TIMER) <= HOURS(6) || ds_readds(DAY_TIMER) >= HOURS(21)) {
 
-				GUI_output(get_ttx(0x8e0));
+				GUI_output(get_ttx(568));
 
 			} else {
 
 				load_in_head(11);
 
 				do {
-					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x10),
-									get_tx(0x00), 3,
-									get_tx(0x4),
-									get_tx(0x8),
-									get_tx(0x0c));
+					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(4),
+									get_tx(0), 3,
+									get_tx(1),
+									get_tx(2),
+									get_tx(3));
 				} while (answer == -1);
 
 				p_money = get_party_money();
 
 				if (p_money < 10L) {
 
-					GUI_output(get_tx(0x20));
+					GUI_output(get_tx(8));
 
 				} else if (answer == 1 || answer == 2) {
 
@@ -258,32 +258,32 @@ void do_harbour(void)
 					if (answer != 0) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)(l_si == 1 ? get_tx(0x70) : get_tx(0x58)),
+							(char*)(l_si == 1 ? get_tx(28) : get_tx(22)),
 							(char*)(answer == 1 ? p_datseg + SEA_TRAVEL_STR_T : p_datseg + SEA_TRAVEL_STR_EN),
-							(char*)(answer == 1 ? get_tx(0x5c) : get_tx(0x60)));
+							(char*)(answer == 1 ? get_tx(23) : get_tx(24)));
 
 						l_si = 0;
 
 						do {
 
 							strcat((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(4 * (ds_readb((SEA_TRAVEL_MENU_PASSAGES + 10) + 12 * l_si++) + 235)));
+								(char*)get_ttx(ds_readb((SEA_TRAVEL_MENU_PASSAGES + 10) + 12 * l_si++) + 235));
 							if (--answer) {
 
 								strcat((char*)Real2Host(ds_readd(DTP2)),
-									(char*)(answer >= 2 ? p_datseg + SEA_TRAVEL_STR_COMMA : get_tx(0x1c)));
+									(char*)(answer >= 2 ? p_datseg + SEA_TRAVEL_STR_COMMA : get_tx(7)));
 							}
 
 						} while (answer != 0);
 
 						strcat((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x64));
+							(char*)get_tx(25));
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
 					} else {
 
-						GUI_output(get_tx(0x68));
+						GUI_output(get_tx(26));
 					}
 				}
 			}
@@ -292,17 +292,17 @@ void do_harbour(void)
 
 			if (ds_readb(SEA_TRAVEL_PSGBOOKED_FLAG) != 0xaa) {
 
-				GUI_output(get_tx(0x4c));
+				GUI_output(get_tx(19));
 
 			} else if (ds_readb(SEA_TRAVEL_PSGBOOKED_TIMER) != 0) {
 
-				GUI_output(ds_readbs(SEA_TRAVEL_PSGBOOKED_TIMER) == -1 ? get_tx(0x6c) : get_tx(0x50));
+				GUI_output(ds_readbs(SEA_TRAVEL_PSGBOOKED_TIMER) == -1 ? get_tx(27) : get_tx(20));
 
 			} else {
 
 				set_var_to_zero();
 
-				GUI_output(get_tx(0x54));
+				GUI_output(get_tx(21));
 
 				ds_writeb(TRAVEL_HEROKEEPING, 1);
 

--- a/src/custom/schick/rewrite_m302de/seg065.cpp
+++ b/src/custom/schick/rewrite_m302de/seg065.cpp
@@ -54,9 +54,9 @@ void do_market(void)
 			ds_writew(REQUEST_REFRESH, 0);
 		}
 
-		answer = GUI_radio(get_ttx(0xaa0), 4,
-					get_ttx(0xa90), get_ttx(0xa94),
-					get_ttx(0xa98), get_ttx(0x994));
+		answer = GUI_radio(get_ttx(680), 4,
+					get_ttx(676), get_ttx(677),
+					get_ttx(678), get_ttx(613));
 
 		if (answer == 4 || answer == -1) {
 			done = 1;
@@ -396,9 +396,9 @@ void show_times_up(void)
 	ds_writew(BASEPOS_X, 0);
 	ds_writew(BASEPOS_Y, 55);
 
-	GUI_output(get_tx2(0xdc));
-	GUI_output(get_tx2(0xe0));
-	GUI_output(get_tx2(0xe4));
+	GUI_output(get_tx2(55));
+	GUI_output(get_tx2(56));
+	GUI_output(get_tx2(57));
 
 	ds_writew(BASEPOS_X, bak1);
 	ds_writew(BASEPOS_Y, bak2);
@@ -464,7 +464,7 @@ void show_outro(void)
 
 	delay_or_keypress(200);
 
-	GUI_output(get_tx2(0xe8));
+	GUI_output(get_tx2(58));
 
 	/* load OUTRO2.NVF */
 	handle = load_archive_file(ARCHIVE_FILE_OUTRO2_NVF);
@@ -498,7 +498,7 @@ void show_outro(void)
 
 	delay_or_keypress(200);
 
-	GUI_output(get_tx2(0xec));
+	GUI_output(get_tx2(59));
 
 	/* load OUTRO3.NVF */
 	handle = load_archive_file(ARCHIVE_FILE_OUTRO3_NVF);
@@ -532,12 +532,12 @@ void show_outro(void)
 
 	delay_or_keypress(200);
 
-	GUI_output(get_tx2(0xf0));
-	GUI_output(get_tx2(0xf4));
-	GUI_output(get_tx2(0xf8));
-	GUI_output(get_tx2(0xfc));
-	GUI_output(get_tx2(0x100));
-	GUI_output(get_tx2(0x104));
+	GUI_output(get_tx2(60));
+	GUI_output(get_tx2(61));
+	GUI_output(get_tx2(62));
+	GUI_output(get_tx2(63));
+	GUI_output(get_tx2(64));
+	GUI_output(get_tx2(65));
 
 	/* reset the timers */
 	sub_ingame_timers(DAYS(30));

--- a/src/custom/schick/rewrite_m302de/seg066.cpp
+++ b/src/custom/schick/rewrite_m302de/seg066.cpp
@@ -123,7 +123,7 @@ signed short enter_location_daspota(void)
 
 			if (host_readb(ptr + 2) != 12) {
 
-				GUI_print_loc_line(get_tx(4 * host_readw(ptr + 4)));
+				GUI_print_loc_line(get_tx(host_readw(ptr + 4)));
 
 				if (!ds_readb(DASPOTA_FIGHTFLAGS + host_readw(ptr + 4))) {
 
@@ -139,12 +139,12 @@ signed short enter_location_daspota(void)
 				set_var_to_zero();
 
 				load_ani(10);
-				GUI_print_loc_line(get_tx(4 * host_readw(ptr + 4)));
+				GUI_print_loc_line(get_tx(host_readw(ptr + 4)));
 				init_ani(0);
 
 				if (ds_readd((DASPOTA_LOCLOOT_INDEX - 4) + 4 * host_readw(ptr + 4))) {
 
-					loot_multi_chest(Real2Host((RealPt)ds_readd((DASPOTA_LOCLOOT_INDEX - 4) + 4 * host_readw(ptr + 4))), get_tx(0x54));
+					loot_multi_chest(Real2Host((RealPt)ds_readd((DASPOTA_LOCLOOT_INDEX - 4) + 4 * host_readw(ptr + 4))), get_tx(21));
 
 				} else {
 
@@ -220,17 +220,17 @@ void do_special_buildings(void)
 		} else if (type == 34) {
 			THO_botschaft();
 		} else if (type == 35) {
-			GUI_output(get_tx2(0x118));
+			GUI_output(get_tx2(70));
 		} else if (type == 36) {
-			GUI_output(get_tx2(0x11c));
+			GUI_output(get_tx2(71));
 		} else if (type == 37) {
 			THO_bank();
 		} else if (type == 38) {
-			GUI_output(get_tx2(0x148));
+			GUI_output(get_tx2(82));
 		} else if (type == 39) {
-			GUI_output(get_tx2(0x14c));
+			GUI_output(get_tx2(83));
 		} else if (type == 40) {
-			GUI_output(get_tx2(0x150));
+			GUI_output(get_tx2(84));
 		} else if (type == 41) {
 			THO_arsenal();
 		} else if (type == 42) {
@@ -874,7 +874,7 @@ signed short city_step(void)
 	if (ds_readws(REQUEST_REFRESH) != 0) {
 
 		draw_main_screen();
-		GUI_print_loc_line(get_tx(0x00));
+		GUI_print_loc_line(get_tx(0));
 
 		ds_writew(REQUEST_REFRESH, ds_writews(REDRAW_MENUICONS, 0));
 		ds_writews(CITY_REFRESH_X_TARGET, -1);
@@ -913,10 +913,10 @@ signed short city_step(void)
 			}
 		}
 
-		i = GUI_radio(get_ttx(0x8e8), (signed char)options,
-				get_ttx(0x85c), get_ttx(0x860), get_ttx(0x864),
-				get_ttx(0x868), get_ttx(0x86c), get_ttx(0x354),
-				get_ttx(0x4c8), get_ttx(0x8e4)) - 1;
+		i = GUI_radio(get_ttx(570), (signed char)options,
+				get_ttx(535), get_ttx(536), get_ttx(537),
+				get_ttx(538), get_ttx(539), get_ttx(213),
+				get_ttx(306), get_ttx(569)) - 1;
 
 		if (i != -2) {
 			ds_writew(ACTION, i + 129);

--- a/src/custom/schick/rewrite_m302de/seg067.cpp
+++ b/src/custom/schick/rewrite_m302de/seg067.cpp
@@ -79,7 +79,7 @@ void city_event_1(void)
 		 *		Or, at least some changes on the code are neccessary.
 		 */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(4 * (random_schick(4) - 1)),
+			(char*)get_tx(random_schick(4) - 1),
 			(char*)Real2Host(hero) + HERO_NAME2,
 			randval);
 
@@ -95,28 +95,28 @@ void city_event_1(void)
 	} else {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(4 * (random_schick(4) + 3)),
+			(char*)get_tx(random_schick(4) + 3),
 			(char*)Real2Host(hero) + HERO_NAME2,
 			(char*)Real2Host(GUI_get_ptr(host_readbs(Real2Host(hero) + HERO_SEX), 1)));
 
 		answer = GUI_dialogbox(hero + HERO_PORTRAIT, Real2Host(hero) + HERO_NAME2, Real2Host(ds_readd(DTP2)), 3,
-				get_tx(4 * (random_schick(4) + 7)),
-				get_tx(4 * (random_schick(4) + 11)),
-				get_tx(4 * (random_schick(4) + 15)));
+				get_tx(random_schick(4) + 7),
+				get_tx(random_schick(4) + 11),
+				get_tx(random_schick(4) + 15));
 
 		if (answer == 1) {
-			GUI_output(get_tx(4 * (random_schick(4) + 19)));
+			GUI_output(get_tx(random_schick(4) + 19));
 		} else {
 
 			randval = random_schick(5) - 1;
 
 			if (randval == 2) {
-				GUI_output(get_tx(0x68));
-				GUI_output(get_tx(0x6c));
-				GUI_output(get_tx(0x70));
+				GUI_output(get_tx(26));
+				GUI_output(get_tx(27));
+				GUI_output(get_tx(28));
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(4 * (randval + 24)),
+					(char*)get_tx(randval + 24),
 					(char*)Real2Host(hero) + HERO_NAME2);
 				GUI_output(Real2Host(ds_readd(DTP2)));
 			}
@@ -140,7 +140,7 @@ void city_event_2(void)
 		host_writeds(Real2Host(hero) + HERO_MONEY, 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(4 * (random_schick(4) + 30)),
+			(char*)get_tx(random_schick(4) + 30),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox(hero + HERO_PORTRAIT, Real2Host(hero) + HERO_NAME2, Real2Host(ds_readd(DTP2)), 0);
@@ -148,20 +148,20 @@ void city_event_2(void)
 	} else {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(4 * (random_schick(4) + 34)),
+			(char*)get_tx(random_schick(4) + 34),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		answer = GUI_dialogbox(hero + HERO_PORTRAIT, Real2Host(hero) + HERO_NAME2, Real2Host(ds_readd(DTP2)), 3,
-				get_tx(4 * (random_schick(4) + 38)),
-				get_tx(4 * (random_schick(4) + 42)),
-				get_tx(4 * (random_schick(4) + 46)));
+				get_tx(random_schick(4) + 38),
+				get_tx(random_schick(4) + 42),
+				get_tx(random_schick(4) + 46));
 
 		if (answer == 1) {
-			GUI_output(get_tx(4 * (random_schick(4) + 50)));
+			GUI_output(get_tx(random_schick(4) + 50));
 		} else {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(4 * (random_schick(4) + 54)),
+				(char*)get_tx(random_schick(4) + 54),
 				(char*)Real2Host(hero) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -183,13 +183,13 @@ void city_event_3(void)
 
 	answer = money >= 100 ? 3 : 2;
 
-	answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (random_schick(4) + 58)), answer,
-			get_tx(4 * (random_schick(4) + 62)),
-			get_tx(4 * (random_schick(4) + 66)),
-			get_tx(4 * (random_schick(4) + 70)));
+	answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(random_schick(4) + 58), answer,
+			get_tx(random_schick(4) + 62),
+			get_tx(random_schick(4) + 66),
+			get_tx(random_schick(4) + 70));
 
 	if (answer == 3) {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (random_schick(4) + 74)), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(random_schick(4) + 74), 0);
 		money -= 100;
 		set_party_money(money);
 	}
@@ -209,20 +209,20 @@ void city_event_4(void)
 
 	answer = money >= 100 ? 3 : 2;
 
-	answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (random_schick(4) + 58)), answer,
-			get_tx(4 * (random_schick(4) + 78)),
-			get_tx(4 * (random_schick(4) + 82)),
-			get_tx(4 * (random_schick(4) + 86)));
+	answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(random_schick(4) + 58), answer,
+			get_tx(random_schick(4) + 78),
+			get_tx(random_schick(4) + 82),
+			get_tx(random_schick(4) + 86));
 
 	if (answer == 3) {
 		money -= 100;
 		set_party_money(money);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (random_schick(4) + 90)), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(random_schick(4) + 90), 0);
 
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(4 * (random_schick(4) + 94)),
+			(char*)get_tx(random_schick(4) + 94),
 			(char*)Real2Host(load_current_town_gossip()));
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
@@ -247,12 +247,12 @@ void city_event_5(void)
 		hero = get_first_hero_available_in_group();
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(4 * (randval + 99)),
+			(char*)get_tx(randval + 99),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
 	} else {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (randval + 99)), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(randval + 99), 0);
 	}
 
 	ds_writews(TEXTBOX_WIDTH, tw_bak);
@@ -271,16 +271,16 @@ void city_event_6(void)
 		load_in_head(4);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(4 * (random_schick(4) + 102)),
+			(char*)get_tx(random_schick(4) + 102),
 			(char*)get_hero(get_random_hero()) + HERO_NAME2);
 
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 3,
-			get_tx(4 * (random_schick(4) + 106)),
-			get_tx(4 * (random_schick(4) + 110)),
-			get_tx(4 * (random_schick(4) + 114)));
+			get_tx(random_schick(4) + 106),
+			get_tx(random_schick(4) + 110),
+			get_tx(random_schick(4) + 114));
 
 		if (answer == 1 || answer == 2) {
-			GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(4 * (random_schick(4) + 118)), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(random_schick(4) + 118), 0);
 		} else if (answer == 3) {
 			location_bak = ds_readbs(LOCATION);
 			ds_writeb(LOCATION, LOCATION_MERCHANT);
@@ -305,7 +305,7 @@ void city_event_7(void)
 	if (!randval) {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(0x1ec),
+			(char*)get_tx(123),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox(hero + HERO_PORTRAIT, Real2Host(hero) + HERO_NAME2, Real2Host(ds_readd(DTP2)) + 0x400, 0);
@@ -315,13 +315,13 @@ void city_event_7(void)
 		load_in_head(12);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(0x1f0),
+			(char*)get_tx(124),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(0x1f4),
+			(char*)get_tx(125),
 			(char*)Real2Host(GUI_get_ptr(host_readbs(Real2Host(hero) + HERO_SEX), 3)));
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
@@ -330,21 +330,21 @@ void city_event_7(void)
 
 		load_in_head(47);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(0x1f8), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(126), 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(0x1fc),
+			(char*)get_tx(127),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(0x200),
+			(char*)get_tx(128),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, Real2Host(ds_readd(DTP2)) + 0x400, 0);
 	} else {
-		GUI_output(get_tx(0x204));
+		GUI_output(get_tx(129));
 	}
 }
 
@@ -361,21 +361,21 @@ void city_event_8(void)
 
 	if (!randval) {
 
-		GUI_output(get_tx(0x208));
+		GUI_output(get_tx(130));
 
 	} else if (randval == 1) {
 
 		load_in_head(12);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(0x20c), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(131), 0);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(0x210), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx(132), 0);
 
 	} else if (randval == 3) {
-		GUI_output(get_tx(0x214));
+		GUI_output(get_tx(133));
 	} else {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x218),
+			(char*)get_tx(134),
 			(char*)Real2Host(hero) + HERO_NAME2);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -390,14 +390,14 @@ void city_event_9(void)
 	signed short randval = random_schick(4) - 1;
 
 	if (!randval) {
-		GUI_output(get_tx(0x21c));
+		GUI_output(get_tx(135));
 	} else if (randval == 1) {
-		GUI_output(get_tx(0x220));
+		GUI_output(get_tx(136));
 	} else if (randval == 2) {
-		GUI_output(get_tx(0x224));
+		GUI_output(get_tx(137));
 	} else {
-		GUI_output(get_tx(0x228));
-		GUI_output(get_tx(0x22c));
+		GUI_output(get_tx(138));
+		GUI_output(get_tx(139));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg068.cpp
+++ b/src/custom/schick/rewrite_m302de/seg068.cpp
@@ -35,10 +35,10 @@ void THO_eisenhof(void)
 	Bit32s money;
 
 	do {
-		answer = GUI_radio(get_tx2(0xbc), 3,
-					get_tx2(0xc0),
-					get_tx2(0xc4),
-					get_tx2(0xc8));
+		answer = GUI_radio(get_tx2(47), 3,
+					get_tx2(48),
+					get_tx2(49),
+					get_tx2(50));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -48,7 +48,7 @@ void THO_eisenhof(void)
 
 	} else if (answer == 2) {
 
-		GUI_input(get_tx2(0xcc), 0);
+		GUI_input(get_tx2(51), 0);
 
 		money = get_party_money();
 		money -= 10;
@@ -57,13 +57,13 @@ void THO_eisenhof(void)
 		/* test for CH+0 */
 		if (test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0) {
 
-			GUI_input(get_tx2(0xd0), 0);
+			GUI_input(get_tx2(52), 0);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(4 * (random_schick(26) + 55)));
+					(char*)get_tx(random_schick(26) + 55));
 			GUI_input(Real2Host(ds_readd(DTP2)), 0);
 		} else {
-			GUI_input(get_tx2(0xd4), 0);
+			GUI_input(get_tx2(53), 0);
 		}
 	}
 }
@@ -77,17 +77,17 @@ void THO_imman(void)
 
 	if ((tmp == 1 || tmp == 3) && (ds_readb(DAY_OF_WEEK) == 5)) {
 		/* ask to visit the game */
-		if (GUI_bool(get_tx2(0xdc)) != 0) {
+		if (GUI_bool(get_tx2(55)) != 0) {
 
 		tmp = random_schick(4) + 0x38;
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0xe0),
+			(char*)get_tx2(56),
 			/* winner */
-			(char*)get_tx2(tmp * 4),
+			(char*)get_tx2(tmp),
 			/* looser */
-			(char*)get_tx2((random_schick(7) + 0x3c) * 4),
+			(char*)get_tx2(random_schick(7) + 0x3c),
 			/* winner */
-			(char*)get_tx2(tmp * 4),
+			(char*)get_tx2(tmp),
 			/* winners points */
 			random_interval(15, 30),
 			/* loosers points */
@@ -97,7 +97,7 @@ void THO_imman(void)
 		}
 	} else {
 		/* no imman game at the moment */
-		GUI_input(get_tx2(0xd8), 0);
+		GUI_input(get_tx2(54), 0);
 	}
 
 }
@@ -113,7 +113,7 @@ void THO_botschaft(void)
 		closed = 1;
 	}
 
-	GUI_input( (!closed) ? get_tx2(0x110): get_tx2(0x114), 0);
+	GUI_input( (!closed) ? get_tx2(68): get_tx2(69), 0);
 }
 
 void THO_bank(void)
@@ -127,7 +127,7 @@ void THO_bank(void)
 
 	if (ds_readws(BANK_DEPOSIT) <= -1000) {
 
-		GUI_input(get_tx2(0x134), 0);
+		GUI_input(get_tx2(77), 0);
 
 		if (ds_readws(DEBT_DAYS) == 0) {
 			ds_writews(DEBT_DAYS, 7);
@@ -139,31 +139,31 @@ void THO_bank(void)
 	do {
 
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)get_tx2(0x120),
+			(char*)get_tx2(72),
 			ds_readws(BANK_DEPOSIT));
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x144),
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(81),
 						Real2Host(ds_readd(TEXT_OUTPUT_BUF)), 3,
-						get_tx2(0x124), get_tx2(0x128), get_tx2(0x140));
+						get_tx2(73), get_tx2(74), get_tx2(80));
 		} while (answer == -1);
 
 
 		if (answer == 2) {
 
-			answer = GUI_input(get_tx2(0x12c), 3);
+			answer = GUI_input(get_tx2(75), 3);
 
 			if (answer <= 0) {
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x144),
-						get_tx2(0x13c), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(81),
+						get_tx2(79), 0);
 			} else {
 
 				if (ds_readws(DAYS_TO_CENS) != 0 ||
 					(ds_readws(BANK_DEPOSIT) > 0 && ds_readws(BANK_DEPOSIT) + 200 < answer) ||
 					(ds_readws(BANK_DEPOSIT) <= 0 && answer > 200))
 				{
-					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x144),
-							get_tx2(0x130), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(81),
+							get_tx2(76), 0);
 				} else {
 
 					if (ds_readws(BANK_DEPOSIT) < answer) {
@@ -180,8 +180,8 @@ void THO_bank(void)
 
 						if (ds_readws(MONTHLY_CREDIT) > 200) {
 
-							GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x144),
-									get_tx2(0x130), 0);
+							GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(81),
+									get_tx2(76), 0);
 
 							l3 = ds_readws(MONTHLY_CREDIT) - 200;
 							answer -= l3;
@@ -213,17 +213,17 @@ void THO_bank(void)
 
 			} else {
 
-				answer = GUI_input(get_tx2(0x12c), 3);
+				answer = GUI_input(get_tx2(75), 3);
 				p_money = get_party_money();
 
 				if (answer * 10 > p_money) {
-					GUI_output(get_ttx(0x644));
+					GUI_output(get_ttx(401));
 				} else {
 
 					if (answer <= 0) {
 
-						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x144),
-								get_tx2(0x13c), 0);
+						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(81),
+								get_tx2(79), 0);
 
 					} else {
 
@@ -263,7 +263,7 @@ void THO_arsenal(void)
 
 	if (ds_readds(DAY_TIMER) < HOURS(8) || ds_readds(DAY_TIMER) > HOURS(19)) {
 
-		GUI_output(get_ttx(0x788));
+		GUI_output(get_ttx(482));
 
 	} else if (ds_readb(MERCHANT_KICKED_FLAGS + ds_readws(TYPEINDEX)) != 0) {
 
@@ -278,8 +278,8 @@ void THO_arsenal(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x000), options,
-					get_tx2(0x008), get_tx2(0x004));
+					get_tx2(0), options,
+					get_tx2(2), get_tx2(1));
 
 		} while (answer == -1);
 
@@ -295,7 +295,7 @@ void THO_arsenal(void)
 			}
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-				(char*)get_tx2(0x00c),
+				(char*)get_tx2(3),
 				ds_readws(ARSENAL_MONEY));
 
 			mul_ds_ws(ARSENAL_MONEY, 100);
@@ -316,7 +316,7 @@ void THO_arsenal(void)
 
 
 		} else {
-			GUI_dialog_na(0, get_tx2(0x010));
+			GUI_dialog_na(0, get_tx2(4));
 			ds_writeb(NEED_LETTER, 1);
 		}
 
@@ -332,17 +332,17 @@ void THO_magistracy(void)
 
 	if (ds_readw(GOT_MAIN_QUEST) == 0) {
 
-		GUI_output(get_tx2(0x014));
-		GUI_output(get_tx2(0x018));
-		GUI_output(get_tx2(0x01c));
+		GUI_output(get_tx2(5));
+		GUI_output(get_tx2(6));
+		GUI_output(get_tx2(7));
 
 	} else {
 
 		do {
-			answer = GUI_radio(get_tx2(0x014), 3,
-						get_tx2(0x020),
-						get_tx2(0x024),
-						get_tx2(0x028));
+			answer = GUI_radio(get_tx2(5), 3,
+						get_tx2(8),
+						get_tx2(9),
+						get_tx2(10));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -350,29 +350,29 @@ void THO_magistracy(void)
 			if (ds_readws(GOT_LETTER_JAD) == 0) {
 
 				ds_writews(GOT_LETTER_JAD, 1);
-				GUI_output(get_tx2(0x038));
+				GUI_output(get_tx2(14));
 
 				/* get "LETTER FROM JADRA" */
 				get_item(187, 1, 1);
 
 			} else {
-				GUI_output(get_tx2(0x03c));
+				GUI_output(get_tx2(15));
 			}
 		} else if (answer == 2) {
 
-			GUI_output(get_tx2(0x030));
+			GUI_output(get_tx2(12));
 		} else {
-			GUI_output(get_tx2(0x034));
+			GUI_output(get_tx2(13));
 		}
 	}
 }
 
 void THO_mueller(void)
 {
-	if (GUI_bool(get_tx2(0x40))) {
+	if (GUI_bool(get_tx2(16))) {
 
 		GUI_output((ds_readw(VISITED_MILLER) == 0) ? /* first visit ? */
-			get_tx2(0x44) : get_tx2(0x48));
+			get_tx2(17) : get_tx2(18));
 
 		/* mark the miller as visited */
 		ds_writew(VISITED_MILLER, 1);
@@ -381,9 +381,9 @@ void THO_mueller(void)
 
 void THO_black_finger(void)
 {
-	if (GUI_radio(get_tx2(0x4c), 2, get_tx2(0x50), get_tx2(0x54)) == 1) {
+	if (GUI_radio(get_tx2(19), 2, get_tx2(20), get_tx2(21)) == 1) {
 
-		GUI_output(get_tx2(0x58));
+		GUI_output(get_tx2(22));
 	}
 }
 
@@ -407,48 +407,48 @@ void THO_ugdalf(void)
 		randval = random_schick(10) - 1;
 
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x05c), 3,
-					get_tx2(4 * (randval + 38)),
-					get_tx2(0x060),
-					get_tx2(0x064));
+					get_tx2(23), 3,
+					get_tx2(randval + 38),
+					get_tx2(24),
+					get_tx2(25));
 
 		if (answer == 1) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x6c), 0);
+					get_tx2(27), 0);
 
 		} else if (answer == 2) {
 
 			/* talk to DRAMOSCH */
 			GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x70), 0);
+					get_tx2(28), 0);
 
 			load_in_head(14);
 
-			dramosch_says(get_tx2(0x074));
+			dramosch_says(get_tx2(29));
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
 							Real2Host(host_readd(Real2Host(ds_readd(TX2_INDEX)) + 0xc0)),
 
-							get_tx2(0x078), 2,
-							get_tx2(0x07c),
-							get_tx2(0x080));
+							get_tx2(30), 2,
+							get_tx2(31),
+							get_tx2(32));
 			} while (answer == -1);
 
 			if (answer == 1) {
 				/* take the quest */
-				dramosch_says(get_tx2(0x084));
+				dramosch_says(get_tx2(33));
 				ds_writew(QUEST_UGDALF, 1);
 
 			} else {
 
-				dramosch_says(get_tx2(0x088));
+				dramosch_says(get_tx2(34));
 			}
 		}
 	} else if (ds_readw(QUEST_UGDALF) == 1 || !ds_readb(DNG14_UGDALF_DONE)) {
 
-		dramosch_says(get_tx2(0x8c));
+		dramosch_says(get_tx2(35));
 
 		/* enter the dungeon */
 		DNG_enter_dungeon(14);
@@ -471,7 +471,7 @@ void THO_ugdalf(void)
 	} else if (ds_readw(QUEST_UGDALF) == 3) {
 
 		/* talk with DRAMOSCH for 8 h */
-		dramosch_says(get_tx2(0x90));
+		dramosch_says(get_tx2(36));
 		timewarp(HOURS(8));
 
 		/* mark this quest as done */
@@ -482,10 +482,10 @@ void THO_ugdalf(void)
 		add_party_money(5000);
 	} else {
 
-		dramosch_says(get_tx2(0x94));
+		dramosch_says(get_tx2(37));
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx(4 * (random_schick(26) + 55)));
+			(char*)get_tx(random_schick(26) + 55));
 
 		dramosch_says(Real2Host(ds_readd(DTP2)) + 0x400);
 
@@ -503,13 +503,13 @@ void academy_analues(void)
 	signed short buffer1_bak;
 	signed short hero_pos;
 
-	GUI_input(get_tx2(0xf8), 0);
+	GUI_input(get_tx2(62), 0);
 
 	/* change behaviour of analues spell */
 	ds_writew(IN_ACADEMY, 99);
 
 	/* select a hero (does not need to be a magic user here) */
-	hero_pos = select_hero_ok(get_ttx(0xc68));
+	hero_pos = select_hero_ok(get_ttx(794));
 
 	if (hero_pos != -1) {
 
@@ -520,7 +520,7 @@ void academy_analues(void)
 		load_tx(ARCHIVE_FILE_SPELLTXT_LTX);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x100),
+			(char*)get_tx2(64),
 			(char*)Real2Host(spell_analues()));
 
 		if (buffer1_bak != -1 && buffer1_bak != 222) {
@@ -560,10 +560,10 @@ void THO_academy(void)
 	}
 
 	do {
-		answer = GUI_radio(get_tx2(0xc4), 3,
-					get_tx2(0xc8),
-					get_tx2(0xcc),
-					get_tx2(0xd0));
+		answer = GUI_radio(get_tx2(49), 3,
+					get_tx2(50),
+					get_tx2(51),
+					get_tx2(52));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -572,22 +572,22 @@ void THO_academy(void)
 
 		if (cursed_hero_pos == 0) {
 
-			GUI_input(get_tx2(0x10c), 0);
+			GUI_input(get_tx2(67), 0);
 
 		} else if (ds_readw(ACADEMY_DAILY_CURSE) != 0) {
 
-			GUI_input(get_tx2(0x104), 0);
+			GUI_input(get_tx2(65), 0);
 
 		} else {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0xd4),
+				(char*)get_tx2(53),
 				(char*)hero + HERO_NAME2);
 
 			do {
 				answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-							get_tx2(0x110),
-							get_tx2(0x114));
+							get_tx2(68),
+							get_tx2(69));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -597,20 +597,20 @@ void THO_academy(void)
 				if (item_id >= 0) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0xe0),
+						(char*)get_tx2(56),
 						(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item_id, 0)));
 
 					do {
 						answer = GUI_radio(Real2Host(ds_readd(DTP2)), 4,
-									get_tx2(0xe4),
-									get_tx2(0xe8),
-									get_tx2(0xec),
-									get_tx2(0xf0));
+									get_tx2(57),
+									get_tx2(58),
+									get_tx2(59),
+									get_tx2(60));
 					} while (answer == -1);
 
 					if (answer == 1 || answer == 3) {
 
-						GUI_input(get_tx2(0xf4), 0);
+						GUI_input(get_tx2(61), 0);
 
 					} else {
 
@@ -619,15 +619,15 @@ void THO_academy(void)
 
 						if (drop_item(hero, item_pos, 1)) {
 
-							GUI_input(get_tx2(0xf8), 0);
-							GUI_input(get_tx2(0xfc), 0);
+							GUI_input(get_tx2(62), 0);
+							GUI_input(get_tx2(63), 0);
 
 							ds_writew(ACADEMY_DAILY_CURSE, 1);
 
 							and_ptr_bs(get_hero(cursed_hero_pos) + HERO_STATUS1, 0xdf);
 
 						} else {
-							GUI_input(get_tx2(0x118), 0);
+							GUI_input(get_tx2(70), 0);
 						}
 					}
 
@@ -637,17 +637,17 @@ void THO_academy(void)
 					p_money -= 2000;
 					set_party_money(p_money);
 
-					GUI_input(get_tx2(0xfc), 0);
+					GUI_input(get_tx2(63), 0);
 
 					ds_writew(ACADEMY_DAILY_CURSE, 1);
 
 					and_ptr_bs(get_hero(cursed_hero_pos) + HERO_STATUS1, 0xdf);
 
 				} else {
-					GUI_input(get_ttx(0x644), 0);
+					GUI_input(get_ttx(401), 0);
 				}
 			} else {
-				GUI_input(get_tx2(0x118), 0);
+				GUI_input(get_tx2(70), 0);
 			}
 		}
 
@@ -657,14 +657,14 @@ void THO_academy(void)
 
 		if (ds_readw(ACADEMY_DAILY_IDENT) != 0) {
 
-			GUI_input(get_tx2(0x108), 0);
+			GUI_input(get_tx2(66), 0);
 
 		} else {
 
 			do {
-				answer = GUI_radio(get_tx2(0xd8), 2,
-							get_tx2(0x110),
-							get_tx2(0x114));
+				answer = GUI_radio(get_tx2(54), 2,
+							get_tx2(68),
+							get_tx2(69));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -674,20 +674,20 @@ void THO_academy(void)
 				if (item_id >= 0) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0xe0),
+						(char*)get_tx2(56),
 						(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item_id, 0)));
 
 					do {
 						answer = GUI_radio(Real2Host(ds_readd(DTP2)), 4,
-									get_tx2(0xe4),
-									get_tx2(0xe8),
-									get_tx2(0xec),
-									get_tx2(0xf0));
+									get_tx2(57),
+									get_tx2(58),
+									get_tx2(59),
+									get_tx2(60));
 					} while (answer == -1);
 
 					if (answer == 1 || answer == 3) {
 
-						GUI_input(get_tx2(0xf4), 0);
+						GUI_input(get_tx2(61), 0);
 
 					} else {
 
@@ -700,7 +700,7 @@ void THO_academy(void)
 
 						} else {
 
-							GUI_input(get_tx2(0x118), 0);
+							GUI_input(get_tx2(70), 0);
 						}
 					}
 
@@ -712,17 +712,17 @@ void THO_academy(void)
 
 					academy_analues();
 				} else {
-					GUI_input(get_ttx(0x644), 0);
+					GUI_input(get_ttx(401), 0);
 				}
 			} else {
 
-				GUI_input(get_tx2(0x118), 0);
+				GUI_input(get_tx2(70), 0);
 
 			}
 		}
 	} else {
 
-		GUI_input(get_tx2(0xdc), 0);
+		GUI_input(get_tx2(55), 0);
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg069.cpp
+++ b/src/custom/schick/rewrite_m302de/seg069.cpp
@@ -45,14 +45,14 @@ void THO_hetmann(void)
 
 		load_in_head(61);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				get_tx(0x148), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				get_tx(82), 0);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				get_tx(0x14c), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				get_tx(83), 0);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				ds_readws(MIN_MAP_PARTS) <= map_parts ? get_tx(0x150) : get_tx(0x154), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				ds_readws(MIN_MAP_PARTS) <= map_parts ? get_tx(84) : get_tx(85), 0);
 
 		answer = ds_readws(MIN_MAP_PARTS) <= map_parts ? 10 : 50;
 
@@ -60,68 +60,68 @@ void THO_hetmann(void)
 			add_ds_ds(GODS_ESTIMATION + 4 * i, answer);
 		}
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				get_tx(0x158), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				get_tx(86), 0);
 
 		ds_writeb(GOT_LETTER_HET, 1);
 		get_item(235, 1, 1);
 
 	} else if (ds_readw(HEARD_ANNOUNCE) == 0 || ds_readw(GOT_MAIN_QUEST) != 0) {
-		GUI_output(get_tx2(0x00));
+		GUI_output(get_tx2(0));
 
 	} else {
 		ds_writew(SUBVENTION, 0);
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x04), 3,
-					get_tx2(0x08),
-					get_tx2(0x0c),
-					get_tx2(0x10));
+					get_tx2(1), 3,
+					get_tx2(2),
+					get_tx2(3),
+					get_tx2(4));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x14), 0);
+					get_tx2(5), 0);
 
 		} else if (answer == 2) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x18), 0);
+					get_tx2(6), 0);
 
 			add_ds_ws(SUBVENTION, 2);
 
 		} else {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2), (RealPt)0,
-					get_tx2(0x1c), 0);
+					get_tx2(7), 0);
 
 			inc_ds_ws(SUBVENTION);
 		}
 
 		load_in_head(61);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				get_tx2(0x20), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				get_tx2(8), 0);
 
 		ds_writew(HEARD_ANNOUNCE, 3);
 
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-				get_tx2(0x24), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+				get_tx2(9), 0);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-					get_tx2(0x28), 3,
-					get_tx2(0x2c),
-					get_tx2(0x30),
-					get_tx2(0x34));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+					get_tx2(10), 3,
+					get_tx2(11),
+					get_tx2(12),
+					get_tx2(13));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-					get_tx2(0x38), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+					get_tx2(14), 0);
 
 			ds_writeb(INFORMER_FLAGS + INFORMER_ISLEIF, 1);
 			inc_ds_ws(SUBVENTION);
@@ -130,8 +130,8 @@ void THO_hetmann(void)
 
 		} else if (answer == 2) {
 
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-					get_tx2(0x3c), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+					get_tx2(15), 0);
 
 			ds_writeb(INFORMER_FLAGS + INFORMER_ISLEIF, 1);
 			ds_writew(GOT_MAIN_QUEST, 1);
@@ -144,15 +144,15 @@ void THO_hetmann(void)
 			add_ds_ws(SUBVENTION, 2);
 
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-						get_tx2(0x40), 2,
-						get_tx2(0x44),
-						get_tx2(0x48));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+						get_tx2(16), 2,
+						get_tx2(17),
+						get_tx2(18));
 			} while (answer == -1);
 
 			if (answer == 1) {
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x154),
-						get_tx2(0x4c), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(85),
+						get_tx2(19), 0);
 
 				ds_writew(GOT_MAIN_QUEST, 1);
 				ds_writew(QUESTED_MONTHS, 0);
@@ -165,29 +165,29 @@ void THO_windriders(void)
 {
 	signed short answer;
 
-	answer = GUI_radio(get_tx2(0x50), 3,
-				get_tx2(0x54),
-				get_tx2(0x58),
-				get_tx2(0x5c));
+	answer = GUI_radio(get_tx2(20), 3,
+				get_tx2(21),
+				get_tx2(22),
+				get_tx2(23));
 	if (answer != -1) {
 
 		if (answer == 1) {
 
-			GUI_output(get_tx2(0x60));
+			GUI_output(get_tx2(24));
 
 		} else if (answer == 2 || answer == 3) {
 
 			if (ds_readw(OTTA_WINDRIDERS) == 0) {
 
-				GUI_output(answer == 2 ? get_tx2(0x64): get_tx2(0x68));
+				GUI_output(answer == 2 ? get_tx2(25): get_tx2(26));
 
 			} else if (ds_readw(OTTA_WINDRIDERS) == 1) {
 
-				GUI_output(get_tx2(0x6c));
+				GUI_output(get_tx2(27));
 
 			} else {
 
-				GUI_output(get_tx2(0x70));
+				GUI_output(get_tx2(28));
 
 				ds_writew(FIG_DISCARD, 1);
 				do_fight(FIGHTS_THOR8);
@@ -207,10 +207,10 @@ void THO_tav_inn_combi(void)
 	load_ani(4);
 	init_ani(0);
 
-	answer = GUI_radio(get_ttx(0xa84), 3,
-				get_ttx(0xa88),
-				get_ttx(0xa8c),
-				get_ttx(0x56c));
+	answer = GUI_radio(get_ttx(673), 3,
+				get_ttx(674),
+				get_ttx(675),
+				get_ttx(347));
 
 	/* save the combo typeindex */
 	type_bak = ds_readw(TYPEINDEX);
@@ -284,29 +284,29 @@ void THO_stormchildren(void)
 {
 	signed short answer;
 
-	answer = GUI_radio(get_tx2(0x74), 3,
-				get_tx2(0x78),
-				get_tx2(0x7c),
-				get_tx2(0x80));
+	answer = GUI_radio(get_tx2(29), 3,
+				get_tx2(30),
+				get_tx2(31),
+				get_tx2(32));
 	if (answer != -1) {
 
 		if (answer == 1) {
 
-			GUI_output(get_tx2(0x84));
+			GUI_output(get_tx2(33));
 
 		} else if (answer == 2 || answer == 3) {
 
 			if (ds_readw(OTTA_STORMCHILDREN) == 0) {
 
-				GUI_output(answer == 2 ? get_tx2(0x88): get_tx2(0x8c));
+				GUI_output(answer == 2 ? get_tx2(34): get_tx2(35));
 
 			} else if (ds_readw(OTTA_STORMCHILDREN) == 1) {
 
-				GUI_output(get_tx2(0x90));
+				GUI_output(get_tx2(36));
 
 			} else {
 
-				GUI_output(get_tx2(0x94));
+				GUI_output(get_tx2(37));
 
 				ds_writew(FIG_DISCARD, 1);
 				do_fight(FIGHTS_THOR8);
@@ -321,29 +321,29 @@ void THO_garaldsson(void)
 {
 	signed short answer;
 
-	answer = GUI_radio(get_tx2(0x98), 3,
-				get_tx2(0x9c),
-				get_tx2(0xa0),
-				get_tx2(0xa4));
+	answer = GUI_radio(get_tx2(38), 3,
+				get_tx2(39),
+				get_tx2(40),
+				get_tx2(41));
 	if (answer != -1) {
 
 		if (answer == 1) {
 
-			GUI_output(get_tx2(0xa8));
+			GUI_output(get_tx2(42));
 
 		} else if (answer == 2 || answer == 3) {
 
 			if (ds_readw(OTTA_GARALDSSON) == 0) {
 
-				GUI_output(answer == 2 ? get_tx2(0xac): get_tx2(0xb0));
+				GUI_output(answer == 2 ? get_tx2(43): get_tx2(44));
 
 			} else if (ds_readw(OTTA_GARALDSSON) == 1) {
 
-				GUI_output(get_tx2(0xb4));
+				GUI_output(get_tx2(45));
 
 			} else {
 
-				GUI_output(get_tx2(0xb8));
+				GUI_output(get_tx2(46));
 
 				ds_writew(FIG_DISCARD, 1);
 				do_fight(FIGHTS_THOR8);

--- a/src/custom/schick/rewrite_m302de/seg070.cpp
+++ b/src/custom/schick/rewrite_m302de/seg070.cpp
@@ -38,36 +38,36 @@ void PHX_fuhrhaus(void)
 
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-				get_tx2(0x00), 3,
-				get_tx2(0x04), get_tx2(0x08), get_tx2(0x0c));
+				get_tx2(0), 3,
+				get_tx2(1), get_tx2(2), get_tx2(3));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 
-		GUI_dialog_na(0, get_tx2(0x10));
+		GUI_dialog_na(0, get_tx2(4));
 
 	} else if (answer == 2) {
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-					get_tx2(0x14), 3,
-					get_tx2(0x18), get_tx2(0x1c), get_tx2(0x20));
+					get_tx2(5), 3,
+					get_tx2(6), get_tx2(7), get_tx2(8));
 
 		} while (answer == -1);
 
-		GUI_dialog_na(0, answer == 1 ? get_tx2(0x28): (answer == 2 ? get_tx2(0x2c) : get_tx2(0x30)));
+		GUI_dialog_na(0, answer == 1 ? get_tx2(10): (answer == 2 ? get_tx2(11) : get_tx2(12)));
 
 		if (answer == 3) {
 			/* You are now able to talk to Alrik */
 			ds_writeb(ALRIK_DERONDAN, 1);
 		}
 
-		GUI_dialog_na(0, get_tx2(0x34));
+		GUI_dialog_na(0, get_tx2(13));
 
 	} else {
 
-		GUI_dialog_na(0, get_tx2(0x24));
+		GUI_dialog_na(0, get_tx2(9));
 	}
 }
 
@@ -80,16 +80,16 @@ void PHX_stadthaus(void)
 	Bit32s money;
 
 	do {
-		answer = GUI_radio(get_tx2(0x38), 3,
-					get_tx2(0x3c),
-					get_tx2(0x40),
-					get_tx2(0x44));
+		answer = GUI_radio(get_tx2(14), 3,
+					get_tx2(15),
+					get_tx2(16),
+					get_tx2(17));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 
-		GUI_output(get_tx2(0x48));
+		GUI_output(get_tx2(18));
 
 	} else {
 
@@ -104,10 +104,10 @@ void PHX_stadthaus(void)
 #ifdef M302de_ORIGINAL_BUGFIX
 
 		do {
-			answer2 = GUI_radio(get_tx2(0x4c), (signed char)answer,
-						get_tx2(0x54),
-						get_tx2(0x50),
-						get_tx2(0x58));
+			answer2 = GUI_radio(get_tx2(19), (signed char)answer,
+						get_tx2(21),
+						get_tx2(20),
+						get_tx2(22));
 		} while (answer2 == -1);
 
 		answer = answer2;
@@ -115,17 +115,17 @@ void PHX_stadthaus(void)
 #else
 		/* Original-Bug: pressing ESC calls GUI_radio() again with -1 options */
 		do {
-			answer = GUI_radio(get_tx2(0x4c), answer,
-						get_tx2(0x54),
-						get_tx2(0x50),
-						get_tx2(0x58));
+			answer = GUI_radio(get_tx2(19), answer,
+						get_tx2(21),
+						get_tx2(20),
+						get_tx2(22));
 
 		} while (answer == -1);
 #endif
 
 		if (answer == 1) {
 
-			GUI_output(get_tx2(0x5c));
+			GUI_output(get_tx2(23));
 
 		} else {
 
@@ -134,7 +134,7 @@ void PHX_stadthaus(void)
 
 			set_party_money(money);
 
-			GUI_output(get_tx2(0x60));
+			GUI_output(get_tx2(24));
 		}
 	}
 }
@@ -151,16 +151,16 @@ void PHX_spielhaus(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0x64), 3,
-					get_tx2(0x68),
-					get_tx2(0x6c),
-					get_tx2(0x70));
+		answer = GUI_radio(get_tx2(25), 3,
+					get_tx2(26),
+					get_tx2(27),
+					get_tx2(28));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 
-		GUI_output(get_tx2(0x74));
+		GUI_output(get_tx2(29));
 
 		hero = get_hero(0);
 
@@ -189,7 +189,7 @@ void PHX_spielhaus(void)
 			/* you loose: at least the half of your group have not passed the test */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x78), pos);
+				(char*)get_tx2(30), pos);
 
 			money -= pos * 100;
 
@@ -200,7 +200,7 @@ void PHX_spielhaus(void)
 
 			/* you win */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x7c), pos);
+				(char*)get_tx2(31), pos);
 
 			money += pos * 100;
 		}
@@ -211,7 +211,7 @@ void PHX_spielhaus(void)
 
 	} else if (answer == 2) {
 
-		GUI_output(get_tx2(0x80));
+		GUI_output(get_tx2(32));
 
 		/* You are now able to talk to Alrik */
 		ds_writeb(ALRIK_DERONDAN, 1);
@@ -223,14 +223,14 @@ void PHX_spielhaus(void)
 		pos = money >= 500 ? 3 : 2;
 
 		do {
-			answer = GUI_radio(get_tx2(0x84), (signed char)pos,
-						get_tx2(0x88),
-						get_tx2(0x90),
-						get_tx2(0x8c));
+			answer = GUI_radio(get_tx2(33), (signed char)pos,
+						get_tx2(34),
+						get_tx2(36),
+						get_tx2(35));
 
 		} while (answer == -1);
 
-		GUI_output(answer == 3 ? get_tx2(0x98): get_tx2(0x94));
+		GUI_output(answer == 3 ? get_tx2(38): get_tx2(37));
 
 		if (answer == 3) {
 
@@ -250,7 +250,7 @@ void PHX_spielhaus(void)
  */
 void PHX_villa_gremob(void)
 {
-	GUI_output(!ds_readb(GREMOB_INVITED)? get_tx2(0xa0) : get_tx2(0x9c));
+	GUI_output(!ds_readb(GREMOB_INVITED)? get_tx2(40) : get_tx2(39));
 
 	if (ds_readb(GREMOB_INVITED) != 0) {
 		do_fight(FIGHTS_PHEX24);
@@ -269,24 +269,24 @@ void PHX_bordell(void)
 	init_ani(0);
 
 	do {
-		answer = GUI_radio(get_tx2(0xa4), 3,
-					get_tx2(0xa8),
-					get_tx2(0xac),
-					get_tx2(0xb0));
+		answer = GUI_radio(get_tx2(41), 3,
+					get_tx2(42),
+					get_tx2(43),
+					get_tx2(44));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 
 		do {
-			answer = GUI_radio(get_tx2(0xb4), 3,
-						get_tx2(0xb8),
-						get_tx2(0xbc),
-						get_tx2(0xc0));
+			answer = GUI_radio(get_tx2(45), 3,
+						get_tx2(46),
+						get_tx2(47),
+						get_tx2(48));
 
 		} while (answer == -1);
 
-		GUI_input(answer == 3 ? get_tx2(0xcc) : get_tx2(0xd0), 0);
+		GUI_input(answer == 3 ? get_tx2(51) : get_tx2(52), 0);
 
 		if ((answer == 1) || (answer == 2)) {
 			ds_writeb(HARLOT_DATE, 1);
@@ -298,11 +298,11 @@ void PHX_bordell(void)
 
 		timewarp_until(0x93a8);
 
-		GUI_input(get_tx2(0xc4), 0);
+		GUI_input(get_tx2(49), 0);
 
 	} else if (answer == 3) {	/* this check is bogus */
 
-		GUI_input(get_tx2(0xc8), 0);
+		GUI_input(get_tx2(50), 0);
 	}
 
 	set_var_to_zero();
@@ -322,10 +322,10 @@ void PHX_apotheke(void)
 	init_ani(0);
 
 	do {
-		answer = GUI_radio(get_tx2(0xd4), 3,
-					get_tx2(0xd8),
-					get_tx2(0xdc),
-					get_tx2(0xe0));
+		answer = GUI_radio(get_tx2(53), 3,
+					get_tx2(54),
+					get_tx2(55),
+					get_tx2(56));
 
 	} while (answer == -1);
 
@@ -337,10 +337,10 @@ void PHX_apotheke(void)
 
 
 		do {
-			answer = GUI_radio(get_tx2(0xe4), (signed char)options,
-						get_tx2(0xf8),
-						get_tx2(0xf4),
-						get_tx2(0xf0));
+			answer = GUI_radio(get_tx2(57), (signed char)options,
+						get_tx2(62),
+						get_tx2(61),
+						get_tx2(60));
 
 		} while (answer == -1);
 
@@ -352,7 +352,7 @@ void PHX_apotheke(void)
 
 			get_item(61, 1, 1);
 		} else {
-			GUI_input(get_tx2(0x114), 0);
+			GUI_input(get_tx2(69), 0);
 		}
 
 	} else if (answer == 2) {
@@ -362,10 +362,10 @@ void PHX_apotheke(void)
 		answer = money >= 500 ? 3 : 2;
 
 		do {
-			answer = GUI_radio(get_tx2(0xe8), (signed char)answer,
-						get_tx2(0xfc),
-						get_tx2(0x104),
-						get_tx2(0x100));
+			answer = GUI_radio(get_tx2(58), (signed char)answer,
+						get_tx2(63),
+						get_tx2(65),
+						get_tx2(64));
 
 		} while (answer == -1);
 
@@ -376,33 +376,33 @@ void PHX_apotheke(void)
 
 			set_party_money(money);
 
-			GUI_input(get_tx2(0x11c), 0);
+			GUI_input(get_tx2(71), 0);
 		} else {
 
-			GUI_input(answer == 1 ? get_tx2(0x118) : get_tx2(0x114), 0);
+			GUI_input(answer == 1 ? get_tx2(70) : get_tx2(69), 0);
 
 		}
 	} else {
 
 		do {
-			answer = GUI_radio(get_tx2(0xec), 3,
-						get_tx2(0x108),
-						get_tx2(0x10c),
-						get_tx2(0x110));
+			answer = GUI_radio(get_tx2(59), 3,
+						get_tx2(66),
+						get_tx2(67),
+						get_tx2(68));
 
 		} while (answer == -1);
 
 		if (answer == 1) {
 
-			GUI_input(get_tx2(0x114), 0);
+			GUI_input(get_tx2(69), 0);
 
 		} else if (answer == 2) {
 
 			do {
-				answer = GUI_radio(get_tx2(0x120), 3,
-							get_tx2(0xdc),
-							get_tx2(0x124),
-							get_tx2(0x128));
+				answer = GUI_radio(get_tx2(72), 3,
+							get_tx2(55),
+							get_tx2(73),
+							get_tx2(74));
 
 			} while (answer == -1);
 
@@ -412,10 +412,10 @@ void PHX_apotheke(void)
 				answer = money >= 500 ? 3 : 2;
 
 				do {
-					answer = GUI_radio(get_tx2(0xe8), (signed char)answer,
-								get_tx2(0xfc),
-								get_tx2(0x104),
-								get_tx2(0x100));
+					answer = GUI_radio(get_tx2(58), (signed char)answer,
+								get_tx2(63),
+								get_tx2(65),
+								get_tx2(64));
 
 				} while (answer == -1);
 
@@ -425,12 +425,12 @@ void PHX_apotheke(void)
 
 					set_party_money(money);
 
-					GUI_input(get_tx2(0x11c), 0);
+					GUI_input(get_tx2(71), 0);
 				} else {
-					GUI_input(answer == 1 ? get_tx2(0x118) : get_tx2(0x114), 0);
+					GUI_input(answer == 1 ? get_tx2(70) : get_tx2(69), 0);
 				}
 			} else {
-				GUI_input(get_tx2(0x12c), 0);
+				GUI_input(get_tx2(75), 0);
 			}
 
 		} else {
@@ -440,10 +440,10 @@ void PHX_apotheke(void)
 			answer = money >= 1000 ? 3 : 2;
 
 			do {
-				answer = GUI_radio(get_tx2(0xe4), (signed char)answer,
-							get_tx2(0xf8),
-							get_tx2(0xf4),
-							get_tx2(0xf0));
+				answer = GUI_radio(get_tx2(57), (signed char)answer,
+							get_tx2(62),
+							get_tx2(61),
+							get_tx2(60));
 
 			} while (answer == -1);
 
@@ -455,7 +455,7 @@ void PHX_apotheke(void)
 
 				get_item(61, 1, 1);
 			} else {
-				GUI_input(get_tx2(0x114), 0);
+				GUI_input(get_tx2(69), 0);
 			}
 		}
 	}
@@ -475,11 +475,11 @@ void PHX_healer(void)
 
 	if (answer <= 70) {
 
-		GUI_output(get_tx2(0x130));
+		GUI_output(get_tx2(76));
 
 	} else if (answer <= 85) {
 
-		GUI_output(get_tx2(0x134));
+		GUI_output(get_tx2(77));
 
 	} else {
 
@@ -488,16 +488,16 @@ void PHX_healer(void)
 		init_ani(0);
 
 		do {
-			answer = GUI_radio(get_tx2(0x138), 3,
-						get_tx2(0x13c),
-						get_tx2(0x140),
-						get_tx2(0x144));
+			answer = GUI_radio(get_tx2(78), 3,
+						get_tx2(79),
+						get_tx2(80),
+						get_tx2(81));
 
 		} while (answer == -1);
 
 		if (answer == 1) {
 
-			GUI_output(get_tx2(0x148));
+			GUI_output(get_tx2(82));
 
 			/* enter the healer */
 			ds_writew(TYPEINDEX, 13);
@@ -507,25 +507,25 @@ void PHX_healer(void)
 
 		} else if (answer == 3) {
 
-			GUI_output(get_tx2(0x150));
+			GUI_output(get_tx2(84));
 
 		} else {
 			/* answer == 2 */
 			do {
-				answer = GUI_radio(get_tx2(0x14c), 3,
-							get_tx2(0x154),
-							get_tx2(0x158),
-							get_tx2(0x15c));
+				answer = GUI_radio(get_tx2(83), 3,
+							get_tx2(85),
+							get_tx2(86),
+							get_tx2(87));
 
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				do {
-					answer = GUI_radio(get_tx2(0x160), 3,
-								get_tx2(0x164),
-								get_tx2(0x168),
-								get_tx2(0x16c));
+					answer = GUI_radio(get_tx2(88), 3,
+								get_tx2(89),
+								get_tx2(90),
+								get_tx2(91));
 
 				} while (answer == -1);
 
@@ -535,13 +535,13 @@ void PHX_healer(void)
 
 				if (money >= 200) {
 
-					GUI_output(get_tx2(0x170));
+					GUI_output(get_tx2(92));
 
 					money -= 200;
 
 					set_party_money(money);
 				} else {
-					GUI_output(get_tx2(0x18c));
+					GUI_output(get_tx2(99));
 				}
 			} else {
 
@@ -550,10 +550,10 @@ void PHX_healer(void)
 				answer = money >= 500 ? 3 : (money >= 10 ? 2 : 1);
 
 				do {
-					answer = GUI_radio(get_tx2(0x174), (signed char)answer,
-								get_tx2(0x180),
-								get_tx2(0x178),
-								get_tx2(0x17c));
+					answer = GUI_radio(get_tx2(93), (signed char)answer,
+								get_tx2(96),
+								get_tx2(94),
+								get_tx2(95));
 
 				} while (answer == -1);
 
@@ -563,7 +563,7 @@ void PHX_healer(void)
 
 					set_party_money(money);
 
-					GUI_output(get_tx2(0x184));
+					GUI_output(get_tx2(97));
 
 				} else if (answer == 3) {
 
@@ -571,7 +571,7 @@ void PHX_healer(void)
 
 					set_party_money(money);
 
-					GUI_output(get_tx2(0x188));
+					GUI_output(get_tx2(98));
 				}
 			}
 		}

--- a/src/custom/schick/rewrite_m302de/seg071.cpp
+++ b/src/custom/schick/rewrite_m302de/seg071.cpp
@@ -45,7 +45,7 @@ void PHX_drogentempel(void)
 
 		if (ds_readb(DRUG_TIMER) && (nr_heros * 2000 <= money)) {
 
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x3c), get_tx2(0x38), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(15), get_tx2(14), 0);
 
 			money -= nr_heros * 2000;
 			set_party_money(money);
@@ -54,27 +54,27 @@ void PHX_drogentempel(void)
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x3c), get_tx2(0x00),
+						get_tx2(15), get_tx2(0),
 						3,
-						get_tx2(0x04),
-						get_tx2(0x08),
-						get_tx2(0x0c));
+						get_tx2(1),
+						get_tx2(2),
+						get_tx2(3));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x3c), get_tx2(0x10),
+							get_tx2(15), get_tx2(4),
 							3,
-							get_tx2(0x14),
-							get_tx2(0x18),
-							get_tx2(0x1c));
+							get_tx2(5),
+							get_tx2(6),
+							get_tx2(7));
 				} while (answer == -1);
 
 				if (answer == 3) {
 					GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x3c), get_tx2(0x20), 0);
+							get_tx2(15), get_tx2(8), 0);
 
 					ds_writeb(DRUG_TIMER, 10);
 				}
@@ -82,29 +82,29 @@ void PHX_drogentempel(void)
 			} else if (answer == 2) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x3c), get_tx2(0x20), 0);
+						get_tx2(15), get_tx2(8), 0);
 
 				ds_writeb(DRUG_TIMER, 10);
 			} else {
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x3c), get_tx2(0x24),
+							get_tx2(15), get_tx2(9),
 							3,
-							get_tx2(0x28),
-							get_tx2(0x2c),
-							get_tx2(0x30));
+							get_tx2(10),
+							get_tx2(11),
+							get_tx2(12));
 				} while (answer == -1);
 
 				if (answer == 3) {
 
 					GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x3c), get_tx2(0x34), 0);
+						get_tx2(15), get_tx2(13), 0);
 
 				} else {
 
 					GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x3c), get_tx2(0x20), 0);
+						get_tx2(15), get_tx2(8), 0);
 
 					ds_writeb(DRUG_TIMER, 10);
 				}
@@ -120,14 +120,14 @@ void PHX_drogentempel(void)
 		if (ds_readb(GREMOB_INVITED) != 0) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0x40), get_tx2(0x74), 0);
+					get_tx2(16), get_tx2(29), 0);
 
 			do_fight(FIGHTS_PHEX3);
 		} else {
 
 			if (ds_readb(DRUG_TIMER) && (nr_heros * 2500 <= money)) {
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x40), get_tx2(0x70), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(16), get_tx2(28), 0);
 
 				money -= nr_heros * 2500;
 				set_party_money(money);
@@ -135,28 +135,28 @@ void PHX_drogentempel(void)
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x40), get_tx2(0x44),
+							get_tx2(16), get_tx2(17),
 							2,
-							get_tx2(0x4c),
-							get_tx2(0x78));
+							get_tx2(19),
+							get_tx2(30));
 				} while (answer == -1);
 
 				if (answer == 1) {
 
 					do {
 						answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x40), get_tx2(0x48),
+							get_tx2(16), get_tx2(18),
 							3,
-							get_tx2(0x4c),
-							get_tx2(0x50),
-							get_tx2(0x54));
+							get_tx2(19),
+							get_tx2(20),
+							get_tx2(21));
 					} while (answer == -1);
 
-					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x40), get_tx2(0x68), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(16), get_tx2(26), 0);
 
 					if (nr_heros * 2000 <= money) {
 
-						if (GUI_bool(get_tx2(0x7c))) {
+						if (GUI_bool(get_tx2(31))) {
 							money -= nr_heros * 2000;
 							set_party_money(money);
 						}
@@ -164,18 +164,18 @@ void PHX_drogentempel(void)
 				} else {
 					do {
 						answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x40), get_tx2(0x58),
+							get_tx2(16), get_tx2(22),
 							3,
-							get_tx2(0x5c),
-							get_tx2(0x60),
-							get_tx2(0x64));
+							get_tx2(23),
+							get_tx2(24),
+							get_tx2(25));
 					} while (answer == -1);
 
 					if (answer == 1) {
-						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x40), get_tx2(0x6c), 0);
+						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(16), get_tx2(27), 0);
 						ds_writeb(GREMOB_INVITED, 1);
 					} else {
-						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(0x40), get_tx2(0x20), 0);
+						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx2(16), get_tx2(8), 0);
 						ds_writeb(DRUG_TIMER, 10);
 					}
 				}
@@ -205,7 +205,7 @@ void PHX_phextempel(void)
 	if (ds_readb(PTEMPLE_CLOSED) != 0) {
 
 		/* the cleric is gone */
-		GUI_output(get_tx2(0xf0));
+		GUI_output(get_tx2(60));
 
 	} else {
 
@@ -214,38 +214,38 @@ void PHX_phextempel(void)
 		load_in_head(12);
 
 		/* show introduction text */
-		GUI_output(get_tx2(0x84));
+		GUI_output(get_tx2(33));
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0x80), get_tx2(0x88),
+					get_tx2(32), get_tx2(34),
 					3,
-					get_tx2(0x8c),
-					get_tx2(0x90),
-					get_tx2(0x94));
+					get_tx2(35),
+					get_tx2(36),
+					get_tx2(37));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0x98),
+						get_tx2(32), get_tx2(38),
 						3,
-						get_tx2(0x9c),
-						get_tx2(0xa0),
-						get_tx2(0xa4));
+						get_tx2(39),
+						get_tx2(40),
+						get_tx2(41));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xc8), 0);
+						get_tx2(32), get_tx2(50), 0);
 			} else {
 
 				/* enter the temple */
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xcc), 0);
+						get_tx2(32), get_tx2(51), 0);
 
 				ds_writew(TYPEINDEX, 59);
 
@@ -266,33 +266,33 @@ void PHX_phextempel(void)
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xa8),
+						get_tx2(32), get_tx2(42),
 						3,
-						get_tx2(0xac),
-						get_tx2(0xb0),
-						get_tx2(0xb4));
+						get_tx2(43),
+						get_tx2(44),
+						get_tx2(45));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xc8), 0);
+						get_tx2(32), get_tx2(50), 0);
 
 			} else if (answer == 2) {
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-							get_tx2(0x80), get_tx2(0xd0),
+							get_tx2(32), get_tx2(52),
 							3,
-							get_tx2(0xd4),
-							get_tx2(0xd8),
-							get_tx2(0xdc));
+							get_tx2(53),
+							get_tx2(54),
+							get_tx2(55));
 				} while (answer == -1);
 
 				if (answer == 2) {
 
 					GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xe0), 0);
+						get_tx2(32), get_tx2(56), 0);
 				}
 
 			} else {
@@ -300,7 +300,7 @@ void PHX_phextempel(void)
 				/* enter the temple */
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xcc), 0);
+						get_tx2(32), get_tx2(51), 0);
 
 				ds_writew(TYPEINDEX, 59);
 
@@ -321,25 +321,25 @@ void PHX_phextempel(void)
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xb8),
+						get_tx2(32), get_tx2(46),
 						3,
-						get_tx2(0xbc),
-						get_tx2(0xc0),
-						get_tx2(0xc4));
+						get_tx2(47),
+						get_tx2(48),
+						get_tx2(49));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xe4), 0);
+						get_tx2(32), get_tx2(57), 0);
 			} else if (answer == 2) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xe8), 0);
+						get_tx2(32), get_tx2(58), 0);
 			} else if (answer == 3) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0x80), get_tx2(0xec), 0);
+						get_tx2(32), get_tx2(59), 0);
 			}
 
 			/* enter the temple */
@@ -377,39 +377,39 @@ void PHX_alrik_derondan(void)
 
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0xf8),
+				get_tx2(61), get_tx2(62),
 				3,
-				get_tx2(0xfc),
-				get_tx2(0x100),
-				get_tx2(0x104));
+				get_tx2(63),
+				get_tx2(64),
+				get_tx2(65));
 	} while (answer == -1);
 
 	if (answer == 1) {
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x108),
+					get_tx2(61), get_tx2(66),
 					3,
-					get_tx2(0x10c),
-					get_tx2(0x110),
-					get_tx2(0x114));
+					get_tx2(67),
+					get_tx2(68),
+					get_tx2(69));
 		} while (answer == -1);
 
 		if (answer == 3) {
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_tx2(0xf4), get_tx2(0x128),
+						get_tx2(61), get_tx2(74),
 						3,
-						get_tx2(0x12c),
-						get_tx2(0x130),
-						get_tx2(0x134));
+						get_tx2(75),
+						get_tx2(76),
+						get_tx2(77));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
 				GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x144), 0);
+					get_tx2(61), get_tx2(81), 0);
 
 				ds_writeb(ALRIK_DERONDAN_INSULTED, 1);
 
@@ -420,24 +420,24 @@ void PHX_alrik_derondan(void)
 			}
 		} else {
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x138), 0);
+					get_tx2(61), get_tx2(78), 0);
 		}
 
 	} else if (answer == 2) {
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x118),
+					get_tx2(61), get_tx2(70),
 					3,
-					get_tx2(0x11c),
-					get_tx2(0x120),
-					get_tx2(0x124));
+					get_tx2(71),
+					get_tx2(72),
+					get_tx2(73));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x138), 0);
+					get_tx2(61), get_tx2(78), 0);
 
 		} else if (answer == 2) {
 			l_di = 2;
@@ -447,17 +447,17 @@ void PHX_alrik_derondan(void)
 	} else {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4), get_tx2(0x128),
+					get_tx2(61), get_tx2(74),
 					3,
-					get_tx2(0x12c),
-					get_tx2(0x130),
-					get_tx2(0x134));
+					get_tx2(75),
+					get_tx2(76),
+					get_tx2(77));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0x144), 0);
+				get_tx2(61), get_tx2(81), 0);
 
 			ds_writeb(ALRIK_DERONDAN_INSULTED, 1);
 		} else if (answer == 2) {
@@ -471,20 +471,20 @@ void PHX_alrik_derondan(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4),
-					l_di == 3 ? get_tx2(0x148) : get_tx2(0x13c),
+					get_tx2(61),
+					l_di == 3 ? get_tx2(82) : get_tx2(79),
 					3,
-					get_tx2(0x150),
-					get_tx2(0x154),
-					get_tx2(0x158));
+					get_tx2(84),
+					get_tx2(85),
+					get_tx2(86));
 		} while (answer == -1);
 
 		if (answer == 1) {
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0x15c), 0);
+				get_tx2(61), get_tx2(87), 0);
 		} else if (answer == 2) {
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0x160), 0);
+				get_tx2(61), get_tx2(88), 0);
 		} else {
 
 			l_di = 1;
@@ -499,12 +499,12 @@ void PHX_alrik_derondan(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_tx2(0xf4),
-					get_tx2(0x140),
+					get_tx2(61),
+					get_tx2(80),
 					answer,
-					get_tx2(0x164),
-					get_tx2(0x16c),
-					get_tx2(0x168));
+					get_tx2(89),
+					get_tx2(91),
+					get_tx2(90));
 		} while (answer == -1);
 
 		if (answer == 3) {
@@ -513,16 +513,16 @@ void PHX_alrik_derondan(void)
 			set_party_money(money);
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0x170), 0);
+				get_tx2(61), get_tx2(92), 0);
 
 		} else if (answer == 2) {
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4), get_tx2(0x138), 0);
+				get_tx2(61), get_tx2(78), 0);
 		} else {
 
 			GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_tx2(0xf4),
-				(test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0) ? get_tx2(0x170) : get_tx2(0x138),
+				get_tx2(61),
+				(test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0) ? get_tx2(92) : get_tx2(78),
 				0);
 		}
 	}

--- a/src/custom/schick/rewrite_m302de/seg072.cpp
+++ b/src/custom/schick/rewrite_m302de/seg072.cpp
@@ -296,7 +296,7 @@ void INF_ragna_beorn_algrid(signed short informer, signed short state)
 				/* copy the picture of the NPC */
 				memcpy(Real2Host(ds_readd(DTP2)), get_hero(6) + HERO_PORTRAIT, 0x400);
 				/* remove the NPC from the group */
-				remove_npc(24, 31, 231, get_ttx(0xbd8), (Bit8u*)0);
+				remove_npc(24, 31, 231, get_ttx(758), (Bit8u*)0);
 
 				ds_writew(REQUEST_REFRESH, 1);
 

--- a/src/custom/schick/rewrite_m302de/seg073.cpp
+++ b/src/custom/schick/rewrite_m302de/seg073.cpp
@@ -461,9 +461,9 @@ RealPt get_drinkmate(void)
 
 	sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 		(char*)p_datseg + GOSSIP_STR_TRIPLE_WILDCARD, /* "%s %s%s" */
-		get_tx(name * 4),
-		get_tx(surname * 4),
-		get_tx(((ds_readb(TLK_TAV_INFORMERSEX) - 1) == 0 ? 0xcf : 0xd0) * 4));
+		get_tx(name),
+		get_tx(surname),
+		get_tx((ds_readb(TLK_TAV_INFORMERSEX) - 1) == 0 ? 207 : 208));
 
 	return (RealPt)ds_readd(TEXT_OUTPUT_BUF);
 }
@@ -480,7 +480,7 @@ signed short tavern_quest_infos(void)
 	if (ds_readws(HEARD_ANNOUNCE) == 0) {
 
 		/* print the announcement from the hetman */
-		GUI_output(get_tx(0x348));
+		GUI_output(get_tx(210));
 
 		/* remember you heard the announcement */
 		ds_writews(HEARD_ANNOUNCE, 1);
@@ -501,7 +501,7 @@ signed short tavern_quest_infos(void)
 			(ds_readws(TYPEINDEX) == 6))
 	{
 		/* print the message about a ghost ship */
-		GUI_output(get_tx(0x344));
+		GUI_output(get_tx(209));
 
 		/* remember that */
 		ds_writeb(QUEST_DEADSHIP, (unsigned char)(l_si = 1));

--- a/src/custom/schick/rewrite_m302de/seg074.cpp
+++ b/src/custom/schick/rewrite_m302de/seg074.cpp
@@ -90,13 +90,13 @@ void show_automap(void)
 			if ((ds_readw(MOUSE2_EVENT) != 0) || (ds_readw(ACTION) == 73)) {
 
 				if (ds_readb(DNG_MAP_SIZE) == 16) {
-					l_di = GUI_radio(get_ttx(0x990), 1, get_ttx(0x994)) - 1;
+					l_di = GUI_radio(get_ttx(612), 1, get_ttx(613)) - 1;
 				} else {
 					ds_writew(MENU_DEFAULT_SELECT, 2);
-					l_di = GUI_radio(get_ttx(0x990), 3,
-								 get_ttx(0x998),
-								 get_ttx(0x99c),
-								 get_ttx(0x994)) - 1;
+					l_di = GUI_radio(get_ttx(612), 3,
+								 get_ttx(614),
+								 get_ttx(615),
+								 get_ttx(613)) - 1;
 				}
 
 				if (l_di != -2) {
@@ -136,7 +136,7 @@ void show_automap(void)
 		clear_ani_pal();
 
 	} else {
-		GUI_output(get_ttx(0xc10));
+		GUI_output(get_ttx(772));
 	}
 }
 
@@ -527,12 +527,12 @@ signed short select_teleport_dest(void)
 		if ((ds_readw(MOUSE2_EVENT) != 0) || (ds_readw(ACTION) == 73)) {
 
 			if (ds_readb(DNG_MAP_SIZE) == 16) {
-				answer = GUI_radio(get_ttx(0x9a0), 1, get_ttx(0x9a4)) - 1;
+				answer = GUI_radio(get_ttx(616), 1, get_ttx(617)) - 1;
 			} else {
-				answer = GUI_radio(get_ttx(0x9a0), 3,
-							 get_ttx(0x998),
-							 get_ttx(0x99c),
-							 get_ttx(0x9a4)) - 1;
+				answer = GUI_radio(get_ttx(616), 3,
+							 get_ttx(614),
+							 get_ttx(615),
+							 get_ttx(617)) - 1;
 			}
 
 			if (answer != -2) {
@@ -617,7 +617,7 @@ signed short select_teleport_dest(void)
 			((ds_readbs(CURRENT_TOWN) != 0) && (((l_di >= 2) && (l_di <= 5)) ||
 			(l_di == 6))))
 	{
-		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x98c));
+		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(611));
 		ae_costs = -2;
 	} else {
 		host_writeb(Real2Host(ds_readd(DTP2)), 0);

--- a/src/custom/schick/rewrite_m302de/seg075.cpp
+++ b/src/custom/schick/rewrite_m302de/seg075.cpp
@@ -603,7 +603,7 @@ void DNG_timestep(signed short a1)
 			load_ani(18);
 			init_ani(1);
 
-			GUI_output(get_tx(0x5c));
+			GUI_output(get_tx(23));
 		}
 
 		ds_writeb(DUNGEON_INDEX, 0);
@@ -798,7 +798,7 @@ void DNG_stub6(void)
 			if (l_si) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xc00),
+					(char*)get_ttx(768),
 					get_hero(l_si - 1) + HERO_NAME2);
 			}
 
@@ -809,7 +809,7 @@ void DNG_stub6(void)
 				hero2 = Real2Host(get_second_hero_available_in_group());
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)get_ttx(0xc04),
+					(char*)get_ttx(769),
 					hero1 + HERO_NAME2,
 					hero2 + HERO_NAME2);
 
@@ -819,7 +819,7 @@ void DNG_stub6(void)
 				if (test_attrib(hero1, ATTRIB_GE, 2) <= 0) {
 
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0xc08),
+						(char*)get_ttx(770),
 						hero1 + HERO_NAME2,
 						hero2 + HERO_NAME2,
 						l_si = random_schick(3) + 1);
@@ -855,7 +855,7 @@ void DNG_stub6(void)
 				} while (l_di);
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)get_ttx(0xc0c),
+					(char*)get_ttx(771),
 					hero_auto + HERO_NAME2,
 					Real2Host(GUI_get_ptr(host_readbs(hero_auto + HERO_SEX), 0)),
 					Real2Host(GUI_get_ptr(host_readbs(hero_auto + HERO_SEX), 2)));

--- a/src/custom/schick/rewrite_m302de/seg076.cpp
+++ b/src/custom/schick/rewrite_m302de/seg076.cpp
@@ -136,7 +136,7 @@ void DNG_door(signed short action)
 
 					if (ds_readb(DUNGEON_INDEX) == 15 && pos == 0x1903 && ds_readb(DNG15_UNKNOWN_FLAG) != 0)
 					{
-						GUI_output(get_tx(0x48));
+						GUI_output(get_tx(18));
 
 					} else if (!(ds_readb(DUNGEON_INDEX) == 11 && pos == 0xc08 && ds_readb(DNG11_LEVER_FLAG) != 4) &&
 							!(ds_readb(DUNGEON_INDEX) == 6 && pos == 0xb01 && ds_readb(DNG06_PITDOOR_FLAG)) &&
@@ -226,7 +226,7 @@ void DNG_door(signed short action)
 						{
 							/* LOCKPICK breaks if the test was unlucky,
 								or when tried three times without moving */
-							print_msg_with_first_hero(get_ttx(0x854));
+							print_msg_with_first_hero(get_ttx(533));
 
 							or_ptr_bs(hero + 14 * lockpick_pos + (HERO_ITEM_HEAD + 4), 1);
 
@@ -235,7 +235,7 @@ void DNG_door(signed short action)
 						} else if (lockpick_result <= 0) {
 
 							/* just failed */
-							print_msg_with_first_hero(get_ttx(0x850));
+							print_msg_with_first_hero(get_ttx(532));
 
 						} else {
 							/* success => the door opens */
@@ -252,18 +252,18 @@ void DNG_door(signed short action)
 
 					} else {
 						/* all LOCKPICKS are broken */
-						print_msg_with_first_hero(get_ttx(0x84c));
+						print_msg_with_first_hero(get_ttx(531));
 					}
 				} else {
 					/* the leader has no LOCKPICKS */
-					print_msg_with_first_hero(get_ttx(0x848));
+					print_msg_with_first_hero(get_ttx(530));
 				}
 			}
 
 			if (action == 137)
 			{
 				/* use magic */
-				hero_pos = select_hero_ok(get_ttx(0x4f4));
+				hero_pos = select_hero_ok(get_ttx(317));
 
 				if (hero_pos != -1)
 				{
@@ -271,7 +271,7 @@ void DNG_door(signed short action)
 
 					if (host_readbs(hero + HERO_TYPE) < 7)
 					{
-						GUI_output(get_ttx(0x528));
+						GUI_output(get_ttx(330));
 					} else {
 						spell_result = test_spell(hero, 28, host_readbs((Bit8u*)ptr + 4));
 
@@ -279,7 +279,7 @@ void DNG_door(signed short action)
 						{
 							/* unlucky => just print a message */
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x97c),
+								(char*)get_ttx(607),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -344,7 +344,7 @@ void DNG_fallpit_test(signed short max_damage)
 	if (ds_readb(DUNGEON_LIGHT) != 0)
 	{
 		/* light is on */
-		GUI_output(get_ttx(0x814));
+		GUI_output(get_ttx(517));
 
 		/* drop one level down */
 		DNG_inc_level();
@@ -425,7 +425,7 @@ signed short DNG_step(void)
 	if (ds_readw(REQUEST_REFRESH) != 0)
 	{
 		draw_main_screen();
-		GUI_print_loc_line(get_tx(0x00));
+		GUI_print_loc_line(get_tx(0));
 		ds_writew(REQUEST_REFRESH, ds_writew(REDRAW_MENUICONS, 0));
 		ds_writew(DNG_REFRESH_X_TARGET, -1);
 	}
@@ -472,20 +472,20 @@ signed short DNG_step(void)
 			}
 		}
 
-		l_di = GUI_radio(get_ttx(0x858), (signed char)retval,
-					get_ttx(0x85c),
-					get_ttx(0x860),
-					get_ttx(0x864),
-					get_ttx(0x868),
-					get_ttx(0x86c),
-					get_ttx(0x354),
-					ds_readws(DNG_EXTRA_ACTION) == 0 ? get_ttx(0x4c8) :(
-						ds_readws(DNG_EXTRA_ACTION) == 1 ? get_ttx(0x870) :(
-						ds_readws(DNG_EXTRA_ACTION) == 3 ? get_ttx(0xc4c) :(
-						ds_readws(DNG_EXTRA_ACTION) == 5 ? get_ttx(0x878) :(
-						ds_readws(DNG_EXTRA_ACTION) == 4 ? get_ttx(0x8ac) : get_ttx(0x874))))),
-					get_ttx(0x87c),
-					get_ttx(0x880)) - 1;
+		l_di = GUI_radio(get_ttx(534), (signed char)retval,
+					get_ttx(535),
+					get_ttx(536),
+					get_ttx(537),
+					get_ttx(538),
+					get_ttx(539),
+					get_ttx(213),
+					ds_readws(DNG_EXTRA_ACTION) == 0 ? get_ttx(306) :(
+						ds_readws(DNG_EXTRA_ACTION) == 1 ? get_ttx(540) :(
+						ds_readws(DNG_EXTRA_ACTION) == 3 ? get_ttx(787) :(
+						ds_readws(DNG_EXTRA_ACTION) == 5 ? get_ttx(542) :(
+						ds_readws(DNG_EXTRA_ACTION) == 4 ? get_ttx(555) : get_ttx(541))))),
+					get_ttx(543),
+					get_ttx(544)) - 1;
 
 		if (l_di != -2)
 		{
@@ -509,7 +509,7 @@ signed short DNG_step(void)
 
 		if ((ds_readb(DUNGEON_INDEX) == 15 && pos == 0x1801) || pos == 0x1805)
 		{
-			GUI_output(get_tx(0x84));
+			GUI_output(get_tx(33));
 
 			ds_writeb(DNG15_REACHED_HANDS, 1);
 		} else {
@@ -850,13 +850,13 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 
 	do {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xc34),
+			(char*)get_ttx(781),
 			host_readb(unit_ptr));
 
 		answer = GUI_radio(Real2Host(ds_readd(DTP2)), 3,
-						get_ttx(0xc38),
-						get_ttx(0xc3c),
-						get_ttx(0xc40));
+						get_ttx(782),
+						get_ttx(783),
+						get_ttx(784));
 
 		if (answer == 1)
 		{
@@ -884,7 +884,7 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 
 						host_writeb(unit_ptr, 0);
 
-						GUI_output(get_ttx(0xc44));
+						GUI_output(get_ttx(785));
 
 						break;
 					} else {
@@ -936,7 +936,7 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 								if (host_readb(unit_ptr) <= units_needed)
 								{
 									/* empty the barrel completely */
-									GUI_output(get_ttx(0xc44));
+									GUI_output(get_ttx(785));
 									host_writeb(unit_ptr, 0);
 
 								} else {
@@ -957,7 +957,7 @@ void DNG_waterbarrel(Bit8u *unit_ptr)
 			/* print a message if no hero used the barrel */
 			if (hero_refilled_counter == 0)
 			{
-				GUI_output(get_ttx(0xc48));
+				GUI_output(get_ttx(786));
 			}
 
 			done = 1;

--- a/src/custom/schick/rewrite_m302de/seg077.cpp
+++ b/src/custom/schick/rewrite_m302de/seg077.cpp
@@ -76,7 +76,7 @@ signed short DNG01_handler(void)
 	} else if (target_pos == 0x1d05 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readbs(DNG01_SABRE_TAKEN))
 	{
 		sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-			(char*)get_ttx(0x840),
+			(char*)get_ttx(528),
 			(char*)Real2Host(GUI_names_grammar(0, 3, 0)),
 			(char*)Real2Host(GUI_2f2(2, 3, 0)));
 
@@ -89,7 +89,7 @@ signed short DNG01_handler(void)
 	} else if (target_pos == 0x3209 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readbs(DNG01_CROSSBOW_TAKEN))
 	{
 		sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-			(char*)get_ttx(0x840),
+			(char*)get_ttx(528),
 			(char*)Real2Host(GUI_names_grammar(0, 12, 0)),
 			(char*)Real2Host(GUI_2f2(2, 12, 0)));
 
@@ -102,7 +102,7 @@ signed short DNG01_handler(void)
 	} else if (target_pos == 0x4209 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readbs(DNG01_AMULET_TAKEN))
 	{
 		/* ITEM: a magic AMULET */
-		if (GUI_bool(get_tx(0x1c)) && get_item(174, 1, 1))
+		if (GUI_bool(get_tx(7)) && get_item(174, 1, 1))
 		{
 			ds_writeb(DNG01_AMULET_TAKEN, 1);
 			sub_ds_ds(GODS_ESTIMATION + 4 * 5, 100L);
@@ -127,7 +127,7 @@ signed short DNG01_handler(void)
 					sub_hero_le(hero, 2);
 
 					sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(0x30),
+						(char*)get_tx(12),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readfp(TEXT_OUTPUT_BUF)));
@@ -142,12 +142,12 @@ signed short DNG01_handler(void)
 
 		load_in_head(21);
 
-		if (GUI_dialogbox(ds_readfp(DTP2), get_ttx(0xbd0), get_tx(0x20), 2,
-				get_ttx(0x08), get_ttx(0x0c)) == 1)
+		if (GUI_dialogbox(ds_readfp(DTP2), get_ttx(756), get_tx(8), 2,
+				get_ttx(2), get_ttx(3)) == 1)
 		{
 			ds_writew(TEXTBOX_WIDTH, 3);
 
-			GUI_dialogbox(ds_readfp(DTP2), get_ttx(0xbd0), get_tx(0x24), 0);
+			GUI_dialogbox(ds_readfp(DTP2), get_ttx(756), get_tx(9), 0);
 
 			if (host_readbs(get_hero(6) + HERO_TYPE) != HERO_TYPE_NONE)
 			{
@@ -161,7 +161,7 @@ signed short DNG01_handler(void)
 		} else {
 			ds_writew(TEXTBOX_WIDTH, 3);
 
-			GUI_dialogbox(ds_readfp(DTP2), get_ttx(0xbd0), get_tx(0x28), 0);
+			GUI_dialogbox(ds_readfp(DTP2), get_ttx(756), get_tx(10), 0);
 		}
 
 		ds_writeb(DNG01_ARDORA_FREED, 1);
@@ -170,7 +170,7 @@ signed short DNG01_handler(void)
 
 	} else if (target_pos == 0x5e07 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x2c)))
+		if (GUI_bool(get_tx(11)))
 		{
 			/* check if a ROPE LADDER or a ROPE is available */
 			/* Original-Bug: Why not check for a mage with staffspell level >= 3? */
@@ -186,13 +186,13 @@ signed short DNG01_handler(void)
 					inc_ds_ws_post(Y_TARGET);
 				}
 			} else {
-				GUI_output(get_ttx(0x844));
+				GUI_output(get_ttx(529));
 			}
 		}
 
 	} else if (target_pos == 0x280b && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x60)))
+		if (GUI_bool(get_tx(24)))
 		{
 			leave_dungeon();
 			ds_writebs(CURRENT_TOWN, (signed char)ds_readws(TRV_DEST_REACHED));
@@ -201,16 +201,16 @@ signed short DNG01_handler(void)
 			ds_writeb(LOCATION, 0);
 			ds_writeb(DIRECTION, (ds_readws(ARRIVAL_DIRECTION) + 2) & 3);
 
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			if (ds_readws(DEATHTRAP) == 1 && ds_readws(DEATHTRAP_STEPS) != 0)
 			{
 				load_ani(18);
 				init_ani(1);
 				set_var_to_zero();
-				GUI_output(get_tx(0x40));
+				GUI_output(get_tx(16));
 			} else {
-				GUI_output(get_tx(0x44));
+				GUI_output(get_tx(17));
 			}
 
 			ds_writeb(SPECIAL_SCREEN, 1);
@@ -266,7 +266,7 @@ void DNG01_chest5_x1(RealPt chest)
 
 void DNG01_chest7_x1(RealPt chest)
 {
-	loot_corpse(chest, get_tx(0x10), p_datseg + DNG01_CORPSE_LOOTED);
+	loot_corpse(chest, get_tx(4), p_datseg + DNG01_CORPSE_LOOTED);
 }
 
 void DNG01_chest7_x2(RealPt chest)
@@ -275,7 +275,7 @@ void DNG01_chest7_x2(RealPt chest)
 
 	ptr_bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG01_CHEST7_CONTENT));
-	loot_chest(Real2Host(chest), get_tx(0x14), get_tx(0x18));
+	loot_chest(Real2Host(chest), get_tx(5), get_tx(6));
 	host_writed(Real2Host(chest) + 11, (Bit32u)ptr_bak);
 }
 
@@ -288,11 +288,11 @@ void DNG01_chest6_x3(RealPt chest)
  */
 #ifdef M302de_ORIGINAL_BUGFIX
 	sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-		(char*)get_tx(0x38),
+		(char*)get_tx(14),
 		(char*)Real2Host(get_first_hero_available_in_group()));
 #else
 	sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-		(char*)get_tx(0x38), 10);
+		(char*)get_tx(14), 10);
 #endif
 	print_msg_with_first_hero(Real2Host(ds_readfp(TEXT_OUTPUT_BUF)));
 
@@ -301,14 +301,14 @@ void DNG01_chest6_x3(RealPt chest)
 
 void DNG01_chest6_x2(RealPt chest)
 {
-	GUI_output(get_tx(0x0c));
+	GUI_output(get_tx(3));
 }
 
 void DNG01_chest6_x1(RealPt chest)
 {
 	if (!ds_readbs(DNG01_KEY_TAKEN))
 	{
-		GUI_input(get_tx(0x08), 10);
+		GUI_input(get_tx(2), 10);
 
 		/* compare if the user wrote MARBO */
 		if (!strcmp((char*)Real2Host(ds_readfp(TEXT_INPUT_BUF)),
@@ -335,13 +335,13 @@ void DNG01_chest6_x1(RealPt chest)
 		}
 
 	} else {
-		GUI_output(get_ttx(0x828));
+		GUI_output(get_ttx(522));
 	}
 }
 
 void DNG01_chest0_x1(RealPt chest)
 {
-	if (!ds_readb(DEADSHIP_FINAL) && GUI_bool(get_tx(0x04)))
+	if (!ds_readb(DEADSHIP_FINAL) && GUI_bool(get_tx(1)))
 	{
 		ds_writeb(DEADSHIP_FINAL, 1);
 

--- a/src/custom/schick/rewrite_m302de/seg078.cpp
+++ b/src/custom/schick/rewrite_m302de/seg078.cpp
@@ -67,26 +67,26 @@ signed short DNG02_handler(void)
 	} else if (target_pos == 0x306 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2)
 	{
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x10));
+			(char*)get_tx(4));
 
 		strcat((char*)Real2Host(ds_readd(DTP2)),
-			 (char*)((test_spell_group(42, 0) == 0) ? get_tx(0x14) : get_tx(0x18)));
+			 (char*)((test_spell_group(42, 0) == 0) ? get_tx(5) : get_tx(6)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
 	} else if (target_pos == 0x40a && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2)
 	{
-		GUI_output(get_tx(0x1c));
+		GUI_output(get_tx(7));
 
 	} else if ((target_pos == 0x70d || target_pos == 0x1605 || target_pos == 0x140e) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		if (test_skill((hero = Real2Host(get_first_hero_available_in_group())), 51, 6) > 0)
 		{
-			GUI_output(get_tx(0x20));
+			GUI_output(get_tx(8));
 
 		} else {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x24),
+				(char*)get_tx(9),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -100,7 +100,7 @@ signed short DNG02_handler(void)
 				if (test_attrib(hero, ATTRIB_KK, 4) <= 0)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x28),
+						(char*)get_tx(10),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -116,7 +116,7 @@ signed short DNG02_handler(void)
 			if (!flag)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x2c),
+					(char*)get_tx(11),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -184,7 +184,7 @@ signed short DNG02_handler(void)
 	{
 		if (ds_readb(DNG02_SPHERE_ACTIVE) != 0)
 		{
-			GUI_output(get_tx(0xa4));
+			GUI_output(get_tx(41));
 
 			hero = get_hero(0);
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -216,20 +216,20 @@ signed short DNG02_handler(void)
 
 			if (mod_slot != 0)
 			{
-				GUI_output(get_tx(0x30));
+				GUI_output(get_tx(12));
 			}
 		}
 
 	} else if (target_pos == 0x701 && !ds_readb(DNG02_RAVEN_DESTROYED) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x34)))
+		if (GUI_bool(get_tx(13)))
 		{
 			/* destroy the raven */
 			ds_writeb(DNG02_RAVEN_DESTROYED, 1);
 
 			sub_group_le(random_schick(20));
 
-			GUI_output(get_tx(0x38));
+			GUI_output(get_tx(14));
 
 			host_writebs(amap_ptr + 0x25, 0);
 		}
@@ -248,7 +248,7 @@ signed short DNG02_handler(void)
 
 		if (weight_sum >= 4000)
 		{
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			host_writeb(amap_ptr + 0x8b, 0);
 		}
@@ -292,38 +292,38 @@ signed short DNG02_handler(void)
 	{
 		ds_writeb(DIRECTION_BAK, ds_readbs(DIRECTION));
 
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 	} else if (target_pos == 0x1405 && ds_readbs(DIRECTION) == 2 &&
 			 (target_pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)))
 	{
 		ds_writeb(DIRECTION_BAK, ds_readbs(DIRECTION));
 
-		GUI_output(get_tx(0x44));
+		GUI_output(get_tx(17));
 
 	} else if (target_pos == 0x1701 && !ds_readb(DNG02_SPHERE_KNOWN))
 	{
 		load_in_head(43);
 
-		GUI_dialogbox(ds_readfp(DTP2), NULL, get_tx(0x48), 0);
+		GUI_dialogbox(ds_readfp(DTP2), NULL, get_tx(18), 0);
 
 		ds_writeb(DNG02_SPHERE_TIMER, 7);
 		ds_writeb(DNG02_SPHERE_KNOWN, 1);
 
 	} else if ((target_pos == 0x110b || target_pos == 0x1108) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x58));
+		GUI_output(get_tx(22));
 
 	} else if (target_pos == 0x1307 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x5c)))
+		if (GUI_bool(get_tx(23)))
 		{
-			GUI_output(get_tx(0x60));
+			GUI_output(get_tx(24));
 		}
 
 	} else if (target_pos == 0x1809 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG02_APPARATURE_DESTROYED))
 	{
-		GUI_output(get_tx(0x64));
+		GUI_output(get_tx(25));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -336,7 +336,7 @@ signed short DNG02_handler(void)
 				or_ptr_bs(hero + HERO_STATUS1, 0x04);
 
 				sprintf((char*)Real2Host(ds_readfp(DTP2)),
-					(char*)get_tx(0xa8),
+					(char*)get_tx(42),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
@@ -352,9 +352,9 @@ signed short DNG02_handler(void)
 	} else if (target_pos == 0x1d0b && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		do {
-			i = GUI_radio(get_tx(0x68), 2,
-					get_tx(0x6c),
-					get_tx(0x70));
+			i = GUI_radio(get_tx(26), 2,
+					get_tx(27),
+					get_tx(28));
 		} while (i == -1);
 
 		if (i == 1)
@@ -363,9 +363,9 @@ signed short DNG02_handler(void)
 			target_pos = 0xd0b;
 
 			do {
-				i = GUI_radio(get_tx(0x74), 2,
-						get_tx(0x78),
-						get_tx(0x7c));
+				i = GUI_radio(get_tx(29), 2,
+						get_tx(30),
+						get_tx(31));
 			} while (i == -1);
 
 			if (i == 2)
@@ -378,9 +378,9 @@ signed short DNG02_handler(void)
 	} else if (target_pos == 0xd0b && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		do {
-			i = GUI_radio(get_tx(0xac), 2,
-					get_tx(0x6c),
-					get_tx(0x70));
+			i = GUI_radio(get_tx(43), 2,
+					get_tx(27),
+					get_tx(28));
 		} while (i == -1);
 
 		if (i == 1)
@@ -389,9 +389,9 @@ signed short DNG02_handler(void)
 			target_pos = 0x1d0b;
 
 			do {
-				i = GUI_radio(get_tx(0x68), 2,
-						get_tx(0x6c),
-						get_tx(0x70));
+				i = GUI_radio(get_tx(26), 2,
+						get_tx(27),
+						get_tx(28));
 			} while (i == -1);
 
 			if (i == 1)
@@ -421,7 +421,7 @@ signed short DNG02_handler(void)
 
 	} else if (target_pos == 0x190e && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 1)
 	{
-		GUI_output(get_tx(0x8c));
+		GUI_output(get_tx(35));
 
 	} else if (target_pos == 0x108 &&
 			(target_pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
@@ -436,11 +436,11 @@ signed short DNG02_handler(void)
 			ds_writeb(DNG02_SECRET_DOOR1, 1);
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x94),
+				(char*)get_tx(37),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-				(char*)((i = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(0x9c) : get_tx(0x98)),
+				(char*)((i = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(39) : get_tx(38)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readfp(DTP2)),
@@ -471,11 +471,11 @@ signed short DNG02_handler(void)
 			ds_writeb(DNG02_SECRET_DOOR2, 1);
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x94),
+				(char*)get_tx(37),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-				(char*)((i = test_skill(hero, TA_SCHLOESSER, 2)) > 0 ? get_tx(0x9c) : get_tx(0x98)),
+				(char*)((i = test_skill(hero, TA_SCHLOESSER, 2)) > 0 ? get_tx(39) : get_tx(38)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readfp(DTP2)),
@@ -505,11 +505,11 @@ signed short DNG02_handler(void)
 			ds_writeb(DNG02_SECRET_DOOR3, 1);
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x94),
+				(char*)get_tx(37),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-				(char*)((i = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(0x9c) : get_tx(0x98)),
+				(char*)((i = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(39) : get_tx(38)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readfp(DTP2)),
@@ -525,7 +525,7 @@ signed short DNG02_handler(void)
 			i = random_schick(6) + 4;
 
 			sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-				(char*)get_tx(0xa0),
+				(char*)get_tx(40),
 				(char*)hero + HERO_NAME2,
 				i);
 
@@ -549,8 +549,8 @@ signed short DNG02_handler(void)
 		ds_writeb(DIRECTION, (ds_readws(ARRIVAL_DIRECTION) + 2) & 3);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xb0),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(44),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -618,9 +618,9 @@ void DNG02_chest04_func3(RealPt)
 	if (!ds_readb(DNG02_APPARATURE_DESTROYED))
 	{
 		do {
-			answer = GUI_radio(get_tx(0x04), 2,
-						get_tx(0x08),
-						get_tx(0x0c));
+			answer = GUI_radio(get_tx(1), 2,
+						get_tx(2),
+						get_tx(3));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -640,7 +640,7 @@ void DNG02_chest04_func3(RealPt)
 			}
 		}
 	} else {
-		GUI_output(get_ttx(0x828));
+		GUI_output(get_ttx(522));
 	}
 
 	ds_writew(TEXTBOX_WIDTH, tw_bak);
@@ -658,7 +658,7 @@ void DNG02_chest05_func3(RealPt chest)
 
 void DNG02_chest06_func1(RealPt chest)
 {
-	loot_corpse(chest, get_tx(0x4c), p_datseg + DNG02_CORPSE);
+	loot_corpse(chest, get_tx(19), p_datseg + DNG02_CORPSE);
 }
 
 void DNG02_chest06_func3(RealPt chest)
@@ -667,7 +667,7 @@ void DNG02_chest06_func3(RealPt chest)
 
 	ptr_bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG02_CHEST06_CONTENT));
-	loot_chest(Real2Host(chest), get_tx(0x50), get_tx(0x54));
+	loot_chest(Real2Host(chest), get_tx(20), get_tx(21));
 	host_writed(Real2Host(chest) + 11, (Bit32u)ptr_bak);
 }
 
@@ -679,13 +679,13 @@ void DNG02_chest06_func3(RealPt chest)
 void DNG02_fight_intro(signed short fight_id)
 {
 	if (fight_id == 62) {
-		GUI_output(get_tx(0x80));
+		GUI_output(get_tx(32));
 	} else if (fight_id == 66) {
-		GUI_output(get_tx(0x84));
+		GUI_output(get_tx(33));
 	} else if (fight_id == 68) {
-		GUI_output(get_tx(0x88));
+		GUI_output(get_tx(34));
 	} else if (fight_id == 72) {
-		GUI_output(get_tx(0x90));
+		GUI_output(get_tx(36));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg079.cpp
+++ b/src/custom/schick/rewrite_m302de/seg079.cpp
@@ -47,19 +47,19 @@ signed short DNG03_handler(void)
 	if ((target_pos == 0x407 || target_pos == 0x409 || target_pos == 0x608) &&
 		target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x04));
+		GUI_output(get_tx(1));
 
 		ds_writew(X_TARGET, ds_writew(Y_TARGET, 1));
 		DNG_inc_level();
 
 	} else if (target_pos == 0x304 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 0)
 	{
-		GUI_input(get_tx(0x08), 15);
+		GUI_input(get_tx(2), 15);
 
 		if (!strcmp((char*)Real2Host(ds_readfp(TEXT_INPUT_BUF)),
 				(char*)p_datseg + DNG03_STR_SPINNENNETZ))
 		{
-			GUI_output(get_tx(0x10));
+			GUI_output(get_tx(4));
 
 			ds_writew(X_TARGET, 9);
 			ds_writew(Y_TARGET, 8);
@@ -82,7 +82,7 @@ signed short DNG03_handler(void)
 
 	} else if (target_pos == 0xb06 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x10));
+		GUI_output(get_tx(4));
 
 		ds_writew(X_TARGET, 1);
 		ds_writew(Y_TARGET, 8);
@@ -111,7 +111,7 @@ signed short DNG03_handler(void)
 			(target_pos == 0x709 && ds_readbs(DIRECTION) == 2))
 		{
 			DNG_update_pos();
-			GUI_output(get_tx(0x0c));
+			GUI_output(get_tx(3));
 
 			ds_writeb(DIRECTION_BAK, ds_readbs(DIRECTION));
 		}
@@ -120,7 +120,7 @@ signed short DNG03_handler(void)
 			ds_readb(DNG03_LEVER_TRAP) != 0 &&
 			target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x14));
+		GUI_output(get_tx(5));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -131,7 +131,7 @@ signed short DNG03_handler(void)
 				test_skill(hero, TA_KLETTERN, 2) <= 0)
 			{
 				sprintf((char*)Real2Host(ds_readfp(DTP2)),
-					(char*)get_tx(0x18),
+					(char*)get_tx(6),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -145,12 +145,12 @@ signed short DNG03_handler(void)
 			ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK) &&
 			ds_readbs(DIRECTION) == 2)
 	{
-		GUI_input(get_tx(0x1c), 15);
+		GUI_input(get_tx(7), 15);
 
 		if (!strcmp((char*)Real2Host(ds_readfp(TEXT_INPUT_BUF)),
 				(char*)p_datseg + DNG03_STR_MACTANS))
 		{
-			GUI_output(get_tx(0x10));
+			GUI_output(get_tx(4));
 
 			ds_writew(X_TARGET, 3);
 			ds_writew(Y_TARGET, 4);
@@ -180,10 +180,10 @@ signed short DNG03_handler(void)
 			ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK))
 	{
 		/* LEVER: */
-		if (GUI_bool(get_tx(0x20)))
+		if (GUI_bool(get_tx(8)))
 		{
 			xor_ds_bs(DNG03_LEVER_CHEST11, 1);
-			GUI_output(get_tx(0x24));
+			GUI_output(get_tx(9));
 		}
 
 	} else if (target_pos == 0x130b &&
@@ -191,10 +191,10 @@ signed short DNG03_handler(void)
 			(target_pos != ds_readws(DNG_HANDLED_POS) ||
 			ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)))
 	{
-		if (GUI_bool(get_tx(0x20)))
+		if (GUI_bool(get_tx(8)))
 		{
 			xor_ds_bs(DNG03_LEVER_TRAP, 1);
-			GUI_output(get_tx(0x24));
+			GUI_output(get_tx(9));
 		}
 
 	} else if ((target_pos == 0x1e0d || target_pos == 0x1d04 || target_pos == 0x1b02) &&
@@ -221,7 +221,7 @@ signed short DNG03_handler(void)
 		if (j != 0 || test_attrib(hero, ATTRIB_GE, 2) <= 0)
 		{
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x34),
+				(char*)get_tx(13),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
@@ -252,7 +252,7 @@ signed short DNG03_handler(void)
 		{
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x34),
+				(char*)get_tx(13),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
@@ -309,19 +309,19 @@ signed short DNG03_handler(void)
 		i = get_first_hero_with_item(225) != -1 ? 0 : 1;
 
 		do {
-			j = GUI_radio(get_tx(0x38), 2,
-					get_tx(0x3c),
-					!i ? get_tx(0x40) : get_tx(0x74));
+			j = GUI_radio(get_tx(14), 2,
+					get_tx(15),
+					!i ? get_tx(16) : get_tx(29));
 		} while (j == -1);
 
 		if (j == 1)
 		{
-			GUI_output(get_tx(0x48));
+			GUI_output(get_tx(18));
 			ds_writeb(DNG03_SANCTUM_SMASHED, 1);
 
 		} else if (j == 2 && !i)
 		{
-			GUI_output(get_tx(0x44));
+			GUI_output(get_tx(17));
 
 			ds_writews((FIG_FLEE_POSITION + 0),
 				ds_writews((FIG_FLEE_POSITION + 2),
@@ -348,14 +348,14 @@ signed short DNG03_handler(void)
 			!ds_readb(DNG03_SPIDEREGGS_BURNED))
 	{
 		do {
-			j = GUI_radio(get_tx(0x4c), 2,
-					get_tx(0x50),
-					get_tx(0x54));
+			j = GUI_radio(get_tx(19), 2,
+					get_tx(20),
+					get_tx(21));
 		} while (j == -1);
 
 		if (j == 1)
 		{
-			GUI_output(get_tx(0x58));
+			GUI_output(get_tx(22));
 
 			add_hero_ap_all(50);
 
@@ -368,11 +368,11 @@ signed short DNG03_handler(void)
 
 	} else if (target_pos == 0x1a04 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x60));
+		GUI_output(get_tx(24));
 
 	} else if (target_pos == 0x1a08 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x10));
+		GUI_output(get_tx(4));
 		ds_writew(X_TARGET, 5);
 		ds_writew(Y_TARGET, 14);
 		DNG_dec_level();
@@ -392,7 +392,7 @@ signed short DNG03_handler(void)
 			}
 		}
 
-	} else if ((target_pos == 0x1201 && target_pos != ds_readws(DNG_HANDLED_POS) && GUI_bool(get_tx(0x5c))) ||
+	} else if ((target_pos == 0x1201 && target_pos != ds_readws(DNG_HANDLED_POS) && GUI_bool(get_tx(23))) ||
 			target_pos == 0x0008)
 	{
 		leave_dungeon();
@@ -403,8 +403,8 @@ signed short DNG03_handler(void)
 		ds_writeb(DIRECTION, (ds_readws(ARRIVAL_DIRECTION) + 2) & 3);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x78),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(30),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -473,9 +473,9 @@ void DNG03_chest05_func3(RealPt)
 {
 	signed short answer;
 	do {
-		answer = GUI_radio(get_tx(0x28), 2,
-					get_tx(0x2c),
-					get_tx(0x30));
+		answer = GUI_radio(get_tx(10), 2,
+					get_tx(11),
+					get_tx(12));
 	} while (answer == -1);
 
 	if (answer == 1)
@@ -561,7 +561,7 @@ void DNG03_chest12_func3(RealPt chest)
 
 void DNG03_chest10_func3(RealPt)
 {
-	GUI_output(get_ttx(0x828));
+	GUI_output(get_ttx(522));
 }
 
 void DNG03_chest11_func3(RealPt)
@@ -574,7 +574,7 @@ void DNG03_chest11_func3(RealPt)
 
 	if (!ds_readb(DNG03_LEVER_CHEST11))
 	{
-		GUI_output(get_tx(0x64));
+		GUI_output(get_tx(25));
 
 	} else {
 		hero = get_hero(0);
@@ -593,7 +593,7 @@ void DNG03_chest11_func3(RealPt)
 					counter++;
 
 					sprintf((char*)Real2Host(ds_readfp(DTP2)),
-						(char*)get_tx(0x6c),
+						(char*)get_tx(27),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readfp(DTP2)));
@@ -606,13 +606,13 @@ void DNG03_chest11_func3(RealPt)
 		if (counter == l_si)
 		{
 			/* end of game */
-			GUI_output(get_tx(0x68));
+			GUI_output(get_tx(26));
 
 			ds_writew(GAME_STATE, GAME_STATE_DEAD);
 		} else {
 			timewarp(HOURS(1));
 
-			GUI_output(get_tx(0x70));
+			GUI_output(get_tx(28));
 		}
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg080.cpp
+++ b/src/custom/schick/rewrite_m302de/seg080.cpp
@@ -55,9 +55,9 @@ signed short DNG04_handler(void)
 	{
 		/* do you want to grab into the gap ? */
 		do {
-			i = GUI_radio(get_tx(0x08), 2,
-						get_tx(0x0c),
-						get_tx(0x10));
+			i = GUI_radio(get_tx(2), 2,
+						get_tx(3),
+						get_tx(4));
 		} while (i == -1);
 
 		if (i == 2)
@@ -65,7 +65,7 @@ signed short DNG04_handler(void)
 			hero = Real2Host(get_first_hero_available_in_group());
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x14),
+				(char*)get_tx(5),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -81,7 +81,7 @@ signed short DNG04_handler(void)
 	} else if (pos == 0x50b && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG04_HELMET_FLAG))
 	{
 		/* do you want the SILVER HELMET? */
-		if (GUI_bool(get_tx(0x1c)))
+		if (GUI_bool(get_tx(7)))
 		{
 			/* get a SILVER HELMET */
 			if (get_item(213, 1, 1))
@@ -99,7 +99,7 @@ signed short DNG04_handler(void)
 	} else if (pos == 0x803 && pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* the ceiling may drop on your head */
-		GUI_output(get_tx(0x24));
+		GUI_output(get_tx(9));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6 ; i++, hero += SIZEOF_HERO)
@@ -110,7 +110,7 @@ signed short DNG04_handler(void)
 				test_skill(hero, TA_SCHLEICHEN, 2) <= 0)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x28),
+					(char*)get_tx(10),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -123,18 +123,18 @@ signed short DNG04_handler(void)
 
 	} else if (pos == 0x703 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 	} else if (pos == 0x505 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x30));
+		GUI_output(get_tx(12));
 
 	} else if (pos == 0xa0d && pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* dig into a heap of dirt? */
-		if (GUI_bool(get_tx(0x34)) && GUI_bool(get_tx(0x38)))
+		if (GUI_bool(get_tx(13)) && GUI_bool(get_tx(14)))
 		{
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			i = get_free_mod_slot();
 
@@ -146,7 +146,7 @@ signed short DNG04_handler(void)
 	} else if (pos == 0xe0e && pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* the ceiling may drop on your head */
-		GUI_output(get_tx(0x24));
+		GUI_output(get_tx(9));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6 ; i++, hero += SIZEOF_HERO)
@@ -157,7 +157,7 @@ signed short DNG04_handler(void)
 				test_skill(hero, TA_SCHLEICHEN, 4) <= 0)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x28),
+					(char*)get_tx(10),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -171,7 +171,7 @@ signed short DNG04_handler(void)
 	} else if (pos == 0xa06 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG04_LANTERN_FLAG))
 	{
 		/* do you want a LANTERN? */
-		if (GUI_bool(get_tx(0x40)))
+		if (GUI_bool(get_tx(16)))
 		{
 			/* get a LANTERN */
 			if (get_item(25, 1, 1))
@@ -191,7 +191,7 @@ signed short DNG04_handler(void)
 		{
 			ds_writeb(DNG04_DEEPGAP_FLAG, 1);
 
-			i = GUI_bool(get_tx(0x44));
+			i = GUI_bool(get_tx(17));
 		}
 
 		if (i)
@@ -199,7 +199,7 @@ signed short DNG04_handler(void)
 			if (test_attrib(hero, ATTRIB_GE, 0) > 0)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x48),
+					(char*)get_tx(18),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)),
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
@@ -209,7 +209,7 @@ signed short DNG04_handler(void)
 			} else {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x4c),
+					(char*)get_tx(19),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 					(char*)hero + HERO_NAME2);
@@ -242,7 +242,7 @@ signed short DNG04_handler(void)
 					sub_hero_le(hero, 2);
 
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(0x54),
+						(char*)get_tx(21),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -266,7 +266,7 @@ signed short DNG04_handler(void)
 					sub_hero_le(hero, 2);
 
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(0x64),
+						(char*)get_tx(25),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -286,8 +286,8 @@ signed short DNG04_handler(void)
 		ds_writeb(DIRECTION, (ds_readb(ARRIVAL_DIRECTION) + 2) & 0x03);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x68),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(26),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -304,17 +304,17 @@ signed short DNG04_handler(void)
 
 void DNG04_corpse0(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x04), p_datseg + DNG04_CORPSE0_FLAG);
+	loot_corpse(ptr, get_tx(1), p_datseg + DNG04_CORPSE0_FLAG);
 }
 
 void DNG04_corpse1(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x20), p_datseg + DNG04_CORPSE1_FLAG);
+	loot_corpse(ptr, get_tx(8), p_datseg + DNG04_CORPSE1_FLAG);
 }
 
 void DNG04_corpse2(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x50), p_datseg + DNG04_CORPSE2_FLAG);
+	loot_corpse(ptr, get_tx(20), p_datseg + DNG04_CORPSE2_FLAG);
 }
 
 void DNG04_corpse0_chest(RealPt chest)
@@ -324,7 +324,7 @@ void DNG04_corpse0_chest(RealPt chest)
 	bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG04_CHEST_CORPSE0));
 
-	loot_chest(Real2Host(chest), get_tx(0x58), get_tx(0x18));
+	loot_chest(Real2Host(chest), get_tx(22), get_tx(6));
 
 	host_writed(Real2Host(chest) + 11, (Bit32u)bak);
 }
@@ -336,7 +336,7 @@ void DNG04_corpse1_chest(RealPt chest)
 	bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG04_CHEST_CORPSE1));
 
-	loot_chest(Real2Host(chest), get_tx(0x5c), get_tx(0x18));
+	loot_chest(Real2Host(chest), get_tx(23), get_tx(6));
 
 	host_writed(Real2Host(chest) + 11, (Bit32u)bak);
 }
@@ -348,7 +348,7 @@ void DNG04_corpse2_chest(RealPt chest)
 	bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG04_CHEST_CORPSE2));
 
-	loot_chest(Real2Host(chest), get_tx(0x60), get_tx(0x18));
+	loot_chest(Real2Host(chest), get_tx(24), get_tx(6));
 
 	host_writed(Real2Host(chest) + 11, (Bit32u)bak);
 }
@@ -370,13 +370,13 @@ signed short DNG05_handler(void)
 
 	if (pos == 0x70e && pos != ds_readws(DNG_HANDLED_POS) && ds_readw(DNG05_TRASH_FLAG) == 0)
 	{
-		if (GUI_bool(get_tx(0x04)) && GUI_bool(get_tx(0x3c)))
+		if (GUI_bool(get_tx(1)) && GUI_bool(get_tx(15)))
 		{
 			ds_writew(DNG05_TRASH_FLAG, 1);
 
 			hero = Real2Host(get_first_hero_available_in_group());
 
-			GUI_output(get_tx(0x40));
+			GUI_output(get_tx(16));
 
 			tmp = get_free_mod_slot();
 			set_mod_slot(tmp, DAYS(1), hero + (HERO_ATTRIB + 3 * ATTRIB_CH), -5, 0);
@@ -386,9 +386,9 @@ signed short DNG05_handler(void)
 
 	} else if (pos == 0x50c && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG05_PROVIANT_FLAG))
 	{
-		if (GUI_bool(get_tx(0x08)))
+		if (GUI_bool(get_tx(2)))
 		{
-			GUI_output(get_tx(0x0c));
+			GUI_output(get_tx(3));
 
 			get_item(45, 1, 10);
 
@@ -397,9 +397,9 @@ signed short DNG05_handler(void)
 
 	} else if (pos == 0x907 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG05_BATS_FLAG))
 	{
-		if (GUI_bool(get_tx(0x10)))
+		if (GUI_bool(get_tx(4)))
 		{
-			GUI_output(get_tx(0x14));
+			GUI_output(get_tx(5));
 
 			ds_writeb(DNG05_BATS_FLAG, 1);
 		}
@@ -407,14 +407,14 @@ signed short DNG05_handler(void)
 	} else if (pos == 0x309 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG05_GOD_FLAG))
 	{
 		do {
-			tmp = GUI_radio(get_tx(0x18), 2,
-						get_tx(0x1c),
-						get_tx(0x20));
+			tmp = GUI_radio(get_tx(6), 2,
+						get_tx(7),
+						get_tx(8));
 		} while (tmp == -1);
 
 		add_ds_ds((GODS_ESTIMATION + 4 * 4), tmp == 1 ? -15 : 15);
 
-		GUI_output(get_tx(0x24));
+		GUI_output(get_tx(9));
 
 		ds_writeb(DNG05_GOD_FLAG, 1);
 
@@ -433,16 +433,16 @@ signed short DNG05_handler(void)
 
 	} else if (pos == 0xb01 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 	} else if (pos == 0x601 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x30)))
+		if (GUI_bool(get_tx(12)))
 		{
 			hero = Real2Host(get_first_hero_available_in_group());
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x34),
+				(char*)get_tx(13),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -457,7 +457,7 @@ signed short DNG05_handler(void)
 		load_ani(32);
 		init_ani(1);
 
-		GUI_output(get_tx(0x38));
+		GUI_output(get_tx(14));
 
 		set_var_to_zero();
 
@@ -476,8 +476,8 @@ signed short DNG05_handler(void)
 		ds_writeb(DIRECTION, (ds_readb(ARRIVAL_DIRECTION) + 2) & 0x03);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x44),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(17),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -500,7 +500,7 @@ signed short DNG05_handler(void)
 void DNG5_fight_intro(signed short fight_id)
 {
 	if (fight_id == 76) {
-		GUI_output(get_tx(0x28));
+		GUI_output(get_tx(10));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg081.cpp
+++ b/src/custom/schick/rewrite_m302de/seg081.cpp
@@ -51,7 +51,7 @@ signed short DNG06_handler(void)
 
 	if (target_pos == 0xe05 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG06_BOOK_FLAG))
 	{
-		if (GUI_bool(get_tx(0x04)) && get_item(224, 1, 1))
+		if (GUI_bool(get_tx(1)) && get_item(224, 1, 1))
 		{
 			ds_writeb(DNG06_BOOK_FLAG, 1);
 		}
@@ -60,13 +60,13 @@ signed short DNG06_handler(void)
 
 	if (target_pos == 0x909 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x8c));
+		GUI_output(get_tx(35));
 
 	} else if (target_pos == 0x40d && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x08)))
+		if (GUI_bool(get_tx(2)))
 		{
-			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x0c));
+			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(3));
 
 			if (!ds_readb(DNG06_MONEY_FLAG))
 			{
@@ -79,7 +79,7 @@ signed short DNG06_handler(void)
 				add_party_money(100L * i);
 
 				sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-					(char*)get_tx(0x10),
+					(char*)get_tx(4),
 					(char*)hero + HERO_NAME2,
 					i);
 
@@ -91,7 +91,7 @@ signed short DNG06_handler(void)
 
 	} else if (target_pos == 0x503 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG06_PROVIANT_FLAG))
 	{
-		if (GUI_bool(get_tx(0x14)))
+		if (GUI_bool(get_tx(5)))
 		{
 			get_item(45, 1, 40);
 			ds_writeb(DNG06_PROVIANT_FLAG, 1);
@@ -121,7 +121,7 @@ signed short DNG06_handler(void)
 			(char*)hero_first + HERO_NAME2,
 			(char*)hero_second + HERO_NAME2);
 
-		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x18));
+		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(6));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -148,9 +148,9 @@ signed short DNG06_handler(void)
 
 		if (l3 != 0)
 		{
-			if (GUI_bool(get_tx(0x1c)))
+			if (GUI_bool(get_tx(7)))
 			{
-				GUI_output(get_tx(0x20));
+				GUI_output(get_tx(8));
 
 				hero = get_hero(0);
 				for (i = l3 = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -165,11 +165,11 @@ signed short DNG06_handler(void)
 					}
 				}
 
-				if (l3 != 0 && GUI_bool(get_tx(0x24)))
+				if (l3 != 0 && GUI_bool(get_tx(9)))
 				{
 					ds_writeb(DNG06_PITDOOR_FLAG, 1);
 
-					GUI_output(get_tx(0x28));
+					GUI_output(get_tx(10));
 				}
 
 				if (!ds_readb(DNG06_PITDOOR_FLAG))
@@ -207,7 +207,7 @@ signed short DNG06_handler(void)
 		{
 			ds_writeb(DNG06_GOLDKEY_FLAG, 1);
 
-			if (GUI_bool(get_tx(0x2c)))
+			if (GUI_bool(get_tx(11)))
 			{
 				ds_writeb(DNG06_GOLDKEY_FLAG, 2);
 
@@ -233,7 +233,7 @@ signed short DNG06_handler(void)
 			hero = Real2Host(get_first_hero_available_in_group());
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)(l3 == 1 ? get_tx(0x30) : get_tx(0x34)),
+				(char*)(l3 == 1 ? get_tx(12) : get_tx(13)),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -244,10 +244,10 @@ signed short DNG06_handler(void)
 	} else if (target_pos == 0x1d05 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		do {
-			i = GUI_radio(get_tx(0x38), 3,
-					get_tx(0x3c),
-					get_tx(0x40),
-					get_tx(0x44));
+			i = GUI_radio(get_tx(14), 3,
+					get_tx(15),
+					get_tx(16),
+					get_tx(17));
 		} while (i == -1);
 
 		hero = Real2Host(get_first_hero_available_in_group());
@@ -255,7 +255,7 @@ signed short DNG06_handler(void)
 		if (i == 1 || i == 3)
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)(i == 1 ? get_tx(0x48) : get_tx(0x4c)),
+				(char*)(i == 1 ? get_tx(18) : get_tx(19)),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
@@ -276,7 +276,7 @@ signed short DNG06_handler(void)
 					test_skill(hero, TA_KOERPERBEH, host_readbs(hero + HERO_RS_BONUS1)) <= 0)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x50),
+						(char*)get_tx(20),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
@@ -291,7 +291,7 @@ signed short DNG06_handler(void)
 	} else if (target_pos == 0x1102 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* Hole in the wall: want to reach into it? want to move the lever? */
-		if (GUI_bool(get_tx(0x54)) && GUI_bool(get_tx(0x58)))
+		if (GUI_bool(get_tx(21)) && GUI_bool(get_tx(22)))
 		{
 			for (i = l3 = 0; i < 6; i++)
 			{
@@ -315,7 +315,7 @@ signed short DNG06_handler(void)
 			if (l3 != 0)
 			{
 				/* some heros are in the right position: hear gentle click */
-				GUI_output(get_tx(0x60));
+				GUI_output(get_tx(24));
 
 				ds_writeb(DNG06_LEVER_FLAG, 1);
 			} else {
@@ -323,7 +323,7 @@ signed short DNG06_handler(void)
 				hero = Real2Host(get_first_hero_available_in_group());
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x5c),
+					(char*)get_tx(23),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -335,7 +335,7 @@ signed short DNG06_handler(void)
 	} else if (target_pos == 0x1306 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* Hole in the wall: want to reach into it? want to move the lever? */
-		if (GUI_bool(get_tx(0x54)) && GUI_bool(get_tx(0x58)))
+		if (GUI_bool(get_tx(21)) && GUI_bool(get_tx(22)))
 		{
 			for (i = l3 = 0; i < 6; i++)
 			{
@@ -359,7 +359,7 @@ signed short DNG06_handler(void)
 			if (l3 != 0)
 			{
 				/* some heros are in the right position: hear gentle click */
-				GUI_output(get_tx(0x60));
+				GUI_output(get_tx(24));
 
 				ds_writeb(DNG06_LEVER_FLAG, 1);
 			} else {
@@ -367,7 +367,7 @@ signed short DNG06_handler(void)
 				hero = Real2Host(get_first_hero_available_in_group());
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x5c),
+					(char*)get_tx(23),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -382,7 +382,7 @@ signed short DNG06_handler(void)
 
 		/* large disk comes down from ceiling */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x64),
+			(char*)get_tx(25),
 			(char*)hero + HERO_NAME2);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -391,7 +391,7 @@ signed short DNG06_handler(void)
 		{
 			/* evasion succeeds */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x68),
+				(char*)get_tx(26),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -399,7 +399,7 @@ signed short DNG06_handler(void)
 		} else {
 			/* disk causes heavy damage */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x6c),
+				(char*)get_tx(27),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -409,12 +409,12 @@ signed short DNG06_handler(void)
 
 	} else if (target_pos == 0x170d && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG06_FIGHT19_FLAG))
 	{
-		if (GUI_bool(get_tx(0x70)))
+		if (GUI_bool(get_tx(28)))
 		{
 			hero = Real2Host(get_first_hero_available_in_group());
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x74),
+				(char*)get_tx(29),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
@@ -427,13 +427,13 @@ signed short DNG06_handler(void)
 	} else if (target_pos == 0x160b && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG06_DASPTREAS_FOUND))
 	{
 		/* treasure of Daspota found */
-		GUI_output(get_tx(0x90));
+		GUI_output(get_tx(36));
 
 		p_money = get_party_money();
 		p_money += 50000L;
 		set_party_money(p_money);
 
-		loot_multi_chest(p_datseg + DNG06_CHEST_DASPTREAS, get_tx(0x94));
+		loot_multi_chest(p_datseg + DNG06_CHEST_DASPTREAS, get_tx(37));
 
 		ds_writeb(DNG06_DASPTREAS_FOUND, 1);
 
@@ -460,8 +460,8 @@ signed short DNG06_handler(void)
 		ds_writeb(DIRECTION, (ds_readb(ARRIVAL_DIRECTION) + 2) & 3);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x98),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(38),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -488,8 +488,8 @@ void DNG06_fight_intro(signed short fight_id)
 	{
 		/* this is true all the time */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x78),
-			(char*)(!ds_readb(ESTORIK_KNOWN) ? get_tx(0x80) : get_tx(0x7c)));
+			(char*)get_tx(30),
+			(char*)(!ds_readb(ESTORIK_KNOWN) ? get_tx(32) : get_tx(31)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 	}
@@ -513,7 +513,7 @@ void DNG06_chest2(RealPt chest)
 	Bit8u *hero;
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x84));
+		(char*)get_tx(33));
 
 	hero = get_hero(0);
 	for (i = 0; i <=6; i++, hero += SIZEOF_HERO)
@@ -523,7 +523,7 @@ void DNG06_chest2(RealPt chest)
 			!hero_dead(hero) &&
 			test_skill(hero, TA_LESEN, 0) > 0)
 		{
-			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x88));
+			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(34));
 			break;
 		}
 	}
@@ -556,7 +556,7 @@ void DNG09_pitfall(void)
 
 		if (l3 != 0)
 		{
-			GUI_output(get_tx(0x74));
+			GUI_output(get_tx(29));
 
 		} else {
 			hero_first = Real2Host(get_first_hero_available_in_group());
@@ -568,7 +568,7 @@ void DNG09_pitfall(void)
 
 				/* print message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x78),
+					(char*)get_tx(30),
 					(char*)hero_first + HERO_NAME2,
 					(char*)hero_second + HERO_NAME2);
 
@@ -598,7 +598,7 @@ void DNG09_pitfall(void)
 
 				/* print message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x7c),
+					(char*)get_tx(31),
 					(char*)hero_first + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero_first + HERO_SEX), 0)));
 
@@ -624,7 +624,7 @@ void DNG09_pitfall(void)
 			}
 		}
 
-	} else if (GUI_bool(get_tx(0x84))) {
+	} else if (GUI_bool(get_tx(33))) {
 
 		if ((i = DNG_check_climb_tools()) != -1)
 		{
@@ -638,12 +638,12 @@ void DNG09_pitfall(void)
 				if (i)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc00),
+						(char*)get_ttx(768),
 						(char*)get_hero(i - 1) + HERO_NAME2);
 				}
 
 				strcat((char*)Real2Host(ds_readd(DTP2)),
-					(char*)(ds_readbs(DNG09_PIT_FLAG) == 2 ? get_tx(0x90) : get_tx(0x94)));
+					(char*)(ds_readbs(DNG09_PIT_FLAG) == 2 ? get_tx(36) : get_tx(37)));
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -659,10 +659,10 @@ void DNG09_pitfall(void)
 
 				ds_writeb(DNG09_PIT_FLAG, 0);
 			} else {
-				GUI_output(get_tx(0x8c));
+				GUI_output(get_tx(35));
 			}
 		} else {
-			GUI_output(get_tx(0x88));
+			GUI_output(get_tx(34));
 		}
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg082.cpp
+++ b/src/custom/schick/rewrite_m302de/seg082.cpp
@@ -52,10 +52,10 @@ signed short DNG07_handler(void)
 		if (div16(host_readb(amap_ptr + 0x2d)) != 3)
 		{
 			do {
-				i = GUI_radio(get_tx(0x20), 3,
-							get_tx(0x24),
-							get_tx(0x28),
-							get_tx(0x2c));
+				i = GUI_radio(get_tx(8), 3,
+							get_tx(9),
+							get_tx(10),
+							get_tx(11));
 			} while (i == -1);
 
 			if (i == 1)
@@ -68,7 +68,7 @@ signed short DNG07_handler(void)
 
 						if (skill_result == -99) {
 
-							print_msg_with_first_hero(get_ttx(0x854));
+							print_msg_with_first_hero(get_ttx(533));
 							or_ptr_bs(hero + HERO_ITEM_HEAD + 4 + 14 * lockpick_pos, 0x01);
 							ds_writew((FIG_FLEE_POSITION + 0),
 								ds_writew((FIG_FLEE_POSITION + 2),
@@ -79,7 +79,7 @@ signed short DNG07_handler(void)
 
 						} else if (skill_result <= 0) {
 
-							print_msg_with_first_hero(get_ttx(0x850));
+							print_msg_with_first_hero(get_ttx(532));
 							ds_writew((FIG_FLEE_POSITION + 0),
 								ds_writew((FIG_FLEE_POSITION + 2),
 								ds_writew((FIG_FLEE_POSITION + 4),
@@ -96,20 +96,20 @@ signed short DNG07_handler(void)
 						}
 
 					} else {
-						print_msg_with_first_hero(get_ttx(0x84c));
+						print_msg_with_first_hero(get_ttx(531));
 					}
 				} else {
-					print_msg_with_first_hero(get_ttx(0x848));
+					print_msg_with_first_hero(get_ttx(530));
 				}
 
 			} else if (i == 2)
 			{
 
-				hero = get_hero(select_hero_ok_forced(get_ttx(0x4f4)));
+				hero = get_hero(select_hero_ok_forced(get_ttx(317)));
 
 				if (host_readbs(hero + HERO_TYPE) < 7)
 				{
-					GUI_output(get_ttx(0x528));
+					GUI_output(get_ttx(330));
 				} else {
 					spell_result = test_spell(hero, 28, 5);
 
@@ -136,7 +136,7 @@ signed short DNG07_handler(void)
 					} else
 					{
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x97c),
+							(char*)get_ttx(607),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -156,7 +156,7 @@ signed short DNG07_handler(void)
 
 	} else if (target_pos == 0x1c03 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readb((TREASURE_MAPS + 1)) != 1)
 	{
-		GUI_output(get_tx(0x04));
+		GUI_output(get_tx(1));
 
 	} else if (target_pos == 0x1d02 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -171,9 +171,9 @@ signed short DNG07_handler(void)
 		{
 			ds_writeb(DNG07_MUELIXIER_FLAG, 1);
 
-			GUI_output(get_tx(0x08));
+			GUI_output(get_tx(2));
 
-			if (GUI_bool(get_tx(0x0c)))
+			if (GUI_bool(get_tx(3)))
 			{
 				get_item(147, 1, 1);
 
@@ -192,7 +192,7 @@ signed short DNG07_handler(void)
 				}
 			}
 		} else {
-			if (GUI_bool(get_tx(0x14)))
+			if (GUI_bool(get_tx(5)))
 			{
 				get_item(147, 1, 1);
 
@@ -204,11 +204,11 @@ signed short DNG07_handler(void)
 	{
 		ds_writeb(DNG07_FLICKER_FLAG, 1);
 
-		GUI_output(get_tx(0x10));
+		GUI_output(get_tx(4));
 
 	} else if (target_pos == 0x210b && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG07_ANTIMUELIXIER_FLAG))
 	{
-		if (GUI_bool(get_tx(0x14)))
+		if (GUI_bool(get_tx(5)))
 		{
 			get_item(226, 1, 1);
 
@@ -245,10 +245,10 @@ signed short DNG07_handler(void)
 
 	} else if (target_pos == 0x2102 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG07_POISON_FLAG))
 	{
-		if (GUI_bool(get_tx(0x18)))
+		if (GUI_bool(get_tx(6)))
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -259,7 +259,7 @@ signed short DNG07_handler(void)
 		}
 	} else if (target_pos == 0x10e && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x3c)))
+		if (GUI_bool(get_tx(15)))
 		{
 			/* ORIGINAL-BUG: forgot to set hero */
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -281,8 +281,8 @@ signed short DNG07_handler(void)
 			ds_writeb(DIRECTION, (ds_readb(ARRIVAL_DIRECTION) + 2) & 3);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x38),
-				(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+				(char*)get_tx(14),
+				(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -317,10 +317,10 @@ void DNG09_statues(signed short prob, signed short bonus)
 	if (host_readbs(amap_ptr + 16 * ds_readws(Y_TARGET) + ds_readws(X_TARGET)) == 4)
 	{
 		/* TODO: no forced decision here ? */
-		i = GUI_radio(get_tx(0x10), 3,
-				get_tx(0x14),
-				get_tx(0x18),
-				get_tx(0x1c));
+		i = GUI_radio(get_tx(4), 3,
+				get_tx(5),
+				get_tx(6),
+				get_tx(7));
 
 		if (i == 1)
 		{
@@ -341,7 +341,7 @@ void DNG09_statues(signed short prob, signed short bonus)
 					or_ptr_bs(hero + 0xab, 0x20);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x20),
+						(char*)get_tx(8),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -350,7 +350,7 @@ void DNG09_statues(signed short prob, signed short bonus)
 					sub_hero_le(hero, random_schick(6));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x24),
+						(char*)get_tx(9),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -364,7 +364,7 @@ void DNG09_statues(signed short prob, signed short bonus)
 			/* remove the statue from the map */
 			and_ptr_bs(amap_ptr + 16 * ds_readws(Y_TARGET) + ds_readws(X_TARGET), 0xfb);
 
-			GUI_output(get_tx(0x28));
+			GUI_output(get_tx(10));
 
 			/* increase estimation */
 			for (i = 0; i < 14; i++)

--- a/src/custom/schick/rewrite_m302de/seg083.cpp
+++ b/src/custom/schick/rewrite_m302de/seg083.cpp
@@ -56,7 +56,7 @@ signed short DNG08_handler(void)
 
 	if (target_pos == 0x10a && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_00))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_00, 1);
 			DNG08_search_bed();
@@ -64,7 +64,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x109 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_01))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_01, 1);
 			DNG08_search_bed();
@@ -72,7 +72,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x108 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_02))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_02, 1);
 			DNG08_search_bed();
@@ -80,7 +80,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x107 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_03))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_03, 1);
 			DNG08_search_bed();
@@ -88,7 +88,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x106 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_04))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_04, 1);
 			DNG08_search_bed();
@@ -96,7 +96,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x606 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_05))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_05, 1);
 			DNG08_search_bed();
@@ -104,7 +104,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x60a && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_06))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_06, 1);
 			DNG08_search_bed();
@@ -112,7 +112,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x707 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_07))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_07, 1);
 			DNG08_search_bed();
@@ -120,7 +120,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x701 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_08))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_08, 1);
 			DNG08_search_bed();
@@ -128,7 +128,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0xb01 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_09))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_09, 1);
 			DNG08_search_bed();
@@ -136,7 +136,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x704 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_10))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_10, 1);
 			DNG08_search_bed();
@@ -144,7 +144,7 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0xa05 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BED_11))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG08_BED_11, 1);
 			DNG08_search_bed();
@@ -156,9 +156,9 @@ signed short DNG08_handler(void)
 
 	} else 	if (target_pos == 0x306 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_TIMER1))
 	{
-		if (GUI_bool(get_tx(0x14)))
+		if (GUI_bool(get_tx(5)))
 		{
-			GUI_output(get_tx(0x18));
+			GUI_output(get_tx(6));
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
@@ -182,9 +182,9 @@ signed short DNG08_handler(void)
 
 	} else if (target_pos == 0x809 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_TIMER2))
 	{
-		if (GUI_bool(get_tx(0x14)))
+		if (GUI_bool(get_tx(5)))
 		{
-			GUI_output(get_tx(0x18));
+			GUI_output(get_tx(6));
 
 			for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 			{
@@ -208,11 +208,11 @@ signed short DNG08_handler(void)
 
 	} else if (target_pos == 0x101 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BALLISTA_DONE))
 	{
-		if (GUI_bool(get_tx(0x1c)))
+		if (GUI_bool(get_tx(7)))
 		{
 			ds_writeb(DNG08_BALLISTA_DONE, 1);
 
-			GUI_output(get_tx(0x20));
+			GUI_output(get_tx(8));
 
 			add_hero_ap_all(10);
 
@@ -224,11 +224,11 @@ signed short DNG08_handler(void)
 
 	} else if (target_pos == 0x104 && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG08_BUNDLES_DONE))
 	{
-		if (GUI_bool(get_tx(0x24)))
+		if (GUI_bool(get_tx(9)))
 		{
 			ds_writeb(DNG08_BUNDLES_DONE, 1);
 
-			GUI_output(get_tx(0x28));
+			GUI_output(get_tx(10));
 
 			add_hero_ap_all(10);
 
@@ -241,29 +241,29 @@ signed short DNG08_handler(void)
 
 	} else if (target_pos == 0xb0e && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x30));
+		GUI_output(get_tx(12));
 
 	} else if (target_pos == 0xb0b &&
 			 (target_pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
 			ds_readbs(DIRECTION) == 3)
 	{
 		do {
-			i = GUI_radio(get_tx(0x34), 3,
-					get_tx(0x38),
-					get_tx(0x3c),
-					get_tx(0x40));
+			i = GUI_radio(get_tx(13), 3,
+					get_tx(14),
+					get_tx(15),
+					get_tx(16));
 		} while (i == -1);
 
 		if (i == 2)
 		{
-			GUI_output(get_tx(0x44));
+			GUI_output(get_tx(17));
 
 		} else if (i == 3)
 		{
-			hero = get_hero(select_hero_ok_forced(get_tx(0x48)));
+			hero = get_hero(select_hero_ok_forced(get_tx(18)));
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x4c),
+				(char*)get_tx(19),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readfp(DTP2)));
@@ -308,7 +308,7 @@ signed short DNG08_handler(void)
 
 	} else if (target_pos == 0xa0c && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x50));
+		GUI_output(get_tx(20));
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
@@ -318,7 +318,7 @@ signed short DNG08_handler(void)
 				test_skill(hero, TA_KLETTERN, 2) <= 0)
 			{
 				sprintf((char*)Real2Host(ds_readfp(DTP2)),
-					(char*)get_tx(0x54),
+					(char*)get_tx(21),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 				GUI_output(Real2Host(ds_readfp(DTP2)));
@@ -338,11 +338,11 @@ signed short DNG08_handler(void)
 			ds_writeb(DNG08_SECRET_DOOR, 1);
 
 			sprintf((char*)Real2Host(ds_readfp(DTP2)),
-				(char*)get_tx(0x74),
+				(char*)get_tx(29),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-				(char*)((tmp = test_skill(hero, TA_SCHLOESSER, 2)) > 0 ? get_tx(0x78): get_tx(0x7c)),
+				(char*)((tmp = test_skill(hero, TA_SCHLOESSER, 2)) > 0 ? get_tx(30): get_tx(31)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readfp(DTP2)),
@@ -364,16 +364,16 @@ signed short DNG08_handler(void)
 	} else if (target_pos == 0x507 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		sprintf((char*)Real2Host(ds_readfp(DTP2)),
-			(char*)get_tx(0x58),
-			(char*)(test_skill(hero, TA_GOETTER_KULTE, 4) <= 0 ? get_tx(0x5c) : get_tx(0x60)));
+			(char*)get_tx(22),
+			(char*)(test_skill(hero, TA_GOETTER_KULTE, 4) <= 0 ? get_tx(23) : get_tx(24)));
 
 		GUI_output(Real2Host(ds_readfp(DTP2)));
 
 	} else if (target_pos == 0x509 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		sprintf((char*)Real2Host(ds_readfp(DTP2)),
-			(char*)get_tx(0x58),
-			(char*)(test_skill(hero, TA_GOETTER_KULTE, 6) <= 0 ? get_tx(0x5c) : get_tx(0x64)));
+			(char*)get_tx(22),
+			(char*)(test_skill(hero, TA_GOETTER_KULTE, 6) <= 0 ? get_tx(23) : get_tx(25)));
 
 		GUI_output(Real2Host(ds_readfp(DTP2)));
 
@@ -388,8 +388,8 @@ signed short DNG08_handler(void)
 		ds_writeb(DIRECTION, (ds_readws(ARRIVAL_DIRECTION) + 2) & 3);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x84),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(33),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -426,7 +426,7 @@ void DNG08_search_bed(void)
 	if (random_schick(100) <= 10)
 	{
 		sprintf((char*)Real2Host(ds_readfp(DTP2)),
-			(char*)get_tx(0x0c),
+			(char*)get_tx(3),
 			(char*)hero + HERO_NAME2,
 			(char*)Real2Host(GUI_names_grammar(2, 92, 0)));
 
@@ -441,7 +441,7 @@ void DNG08_search_bed(void)
 	if (random_schick(100) <= 10)
 	{
 		sprintf((char*)Real2Host(ds_readfp(DTP2)),
-			(char*)get_tx(0x0c),
+			(char*)get_tx(3),
 			(char*)hero + HERO_NAME2,
 			(char*)Real2Host(GUI_names_grammar(2, 14, 0)));
 
@@ -458,11 +458,11 @@ void DNG08_search_bed(void)
 		money = random_schick(6);
 
 		sprintf((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)),
-			(char*)get_tx(0x10),
+			(char*)get_tx(4),
 			money);
 
 		sprintf((char*)Real2Host(ds_readfp(DTP2)),
-			(char*)get_tx(0x0c),
+			(char*)get_tx(3),
 			(char*)hero + HERO_NAME2,
 			(char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)));
 
@@ -475,7 +475,7 @@ void DNG08_search_bed(void)
 
 	if (!counter)
 	{
-		GUI_output(get_tx(0x08));
+		GUI_output(get_tx(2));
 	}
 }
 
@@ -486,7 +486,7 @@ void DNG08_chest1_func2(RealPt)
 	hero = Real2Host(get_first_hero_available_in_group());
 
 	sprintf((char*)Real2Host(ds_readfp(DTP2)),
-		(char*)get_tx(0x2c),
+		(char*)get_tx(11),
 		(char*)hero + HERO_NAME2,
 		(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 1)));
 
@@ -502,7 +502,7 @@ void DNG08_chest0_func3(RealPt)
 	{
 		ds_writeb(DNG08_CHEST0_LOOTED, 1);
 
-		GUI_output(get_tx(0x80));
+		GUI_output(get_tx(32));
 
 		/* get 40 FOOD PACKAGES */
 		get_item(45, 1, 40);
@@ -511,7 +511,7 @@ void DNG08_chest0_func3(RealPt)
 
 void DNG08_chest1_func3(RealPt)
 {
-	loot_multi_chest(p_datseg + DNG08_CHEST1_CONTENT, get_tx(0x88));
+	loot_multi_chest(p_datseg + DNG08_CHEST1_CONTENT, get_tx(34));
 }
 
 void DNG08_chest2_func3(RealPt chest)
@@ -530,7 +530,7 @@ void DNG08_chest2_func1(RealPt chest)
 	{
 		if (test_skill(Real2Host(get_first_hero_available_in_group()), TA_SPRACHEN, 2) > 0)
 		{
-			GUI_input(get_tx(0x6c), 10);
+			GUI_input(get_tx(27), 10);
 
 			if (!strcmp((char*)Real2Host(ds_readfp(TEXT_INPUT_BUF)),
 					(char*)p_datseg + DNG08_STR_TAIRACH))
@@ -550,10 +550,10 @@ void DNG08_chest2_func1(RealPt chest)
 #endif
 			}
 		} else {
-			GUI_output(get_tx(0x68));
+			GUI_output(get_tx(26));
 		}
 	} else {
-		GUI_input(get_ttx(0x828), 0);
+		GUI_input(get_ttx(522), 0);
 	}
 }
 
@@ -568,13 +568,13 @@ void DNG08_chest3_func1(RealPt chest)
 	{
 		if (!(ds_readb(DNG08_CHEST35_LOOTED) & 1))
 		{
-			GUI_output(get_tx(0x70));
+			GUI_output(get_tx(28));
 
 			add_party_money(8530L);
 
 			or_ds_bs(DNG08_CHEST35_LOOTED, 1);
 		} else {
-			GUI_output(get_ttx(0x828));
+			GUI_output(get_ttx(522));
 		}
 	} else {
 #if defined(__BORLANDC__)
@@ -652,7 +652,7 @@ void DNG08_chest5_func3(RealPt chest)
 
 	if (!(ds_readb(DNG08_CHEST35_LOOTED) & 2))
 	{
-		GUI_output(get_tx(0x8c));
+		GUI_output(get_tx(35));
 
 		add_party_money(2890L);
 

--- a/src/custom/schick/rewrite_m302de/seg084.cpp
+++ b/src/custom/schick/rewrite_m302de/seg084.cpp
@@ -55,20 +55,20 @@ signed short DNG09_handler(void)
 
 	if (ds_readb(DNG09_PIT_FLAG) != 0 && !(ds_readds(DAY_TIMER) / 90 * 20))
 	{
-		GUI_output(get_tx(0x80));
+		GUI_output(get_tx(32));
 	}
 
 	if (target_pos == 0xb0e && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 1)
 	{
-		GUI_output(get_tx(0x04));
+		GUI_output(get_tx(1));
 
 	} else if (target_pos == 0xa08 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x08));
+		GUI_output(get_tx(2));
 
 	} else if ((target_pos == 0xe0e || target_pos == 0xe08) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x0c));
+		GUI_output(get_tx(3));
 
 	} else if ((target_pos == 0x30e || target_pos == 0x50e ||
 			target_pos == 0x10e ||	target_pos == 0x101 ||
@@ -88,7 +88,7 @@ signed short DNG09_handler(void)
 	} else if (target_pos == 0x40b && target_pos != ds_readws(DNG_HANDLED_POS) &&
 			ds_readb(DNG09_BOLTTRAP1_FLAG) != 0 && !ds_readb(DNG09_LEVER1_FLAG))
 	{
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		dec_ds_bs_post(DNG09_BOLTTRAP1_FLAG);
 
@@ -103,7 +103,7 @@ signed short DNG09_handler(void)
 				sub_hero_le(hero, dice_roll(2, 6, 4));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30),
+					(char*)get_tx(12),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -112,9 +112,9 @@ signed short DNG09_handler(void)
 
 	} else if (target_pos == 0x108 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x38)))
+		if (GUI_bool(get_tx(14)))
 		{
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			add_ds_ws(X_TARGET, 2);
 			ds_writebs(DIRECTION, 1);
@@ -126,7 +126,7 @@ signed short DNG09_handler(void)
 	{
 		dec_ds_bs_post(DNG09_BOLTTRAP2_FLAG);
 
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
@@ -139,7 +139,7 @@ signed short DNG09_handler(void)
 				sub_hero_le(hero, dice_roll(2, 6, 4));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30),
+					(char*)get_tx(12),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -151,7 +151,7 @@ signed short DNG09_handler(void)
 	{
 		dec_ds_bs_post(DNG09_BOLTTRAP3_FLAG);
 
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
@@ -164,7 +164,7 @@ signed short DNG09_handler(void)
 				sub_hero_le(hero, dice_roll(2, 6, 4));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30),
+					(char*)get_tx(12),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -173,9 +173,9 @@ signed short DNG09_handler(void)
 
 	} else if (target_pos == 0x403 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x40)))
+		if (GUI_bool(get_tx(16)))
 		{
-			GUI_output(get_tx(0x44));
+			GUI_output(get_tx(17));
 			xor_ds_bs(DNG09_LEVER1_FLAG, 1);
 		}
 
@@ -194,9 +194,9 @@ signed short DNG09_handler(void)
 
 		if (l3 != 0)
 		{
-			GUI_output(get_tx(0x48));
+			GUI_output(get_tx(18));
 		} else {
-			GUI_output(get_tx(0x4c));
+			GUI_output(get_tx(19));
 
 			dec_ds_ws_post(X_TARGET);
 			add_ds_ws(Y_TARGET, 2);
@@ -206,7 +206,7 @@ signed short DNG09_handler(void)
 	} else if (target_pos == 0x1d06 && target_pos != ds_readws(DNG_HANDLED_POS) &&
 			ds_readb(DNG09_CULTIST_FLAG) != 0 && !ds_readb(DNG09_LEVER2_FLAG))
 	{
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
@@ -219,7 +219,7 @@ signed short DNG09_handler(void)
 				sub_hero_le(hero, dice_roll(2, 6, 4));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30),
+					(char*)get_tx(12),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -228,16 +228,16 @@ signed short DNG09_handler(void)
 
 	} else if (target_pos == 0x1e09 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x40)))
+		if (GUI_bool(get_tx(16)))
 		{
-			GUI_output(get_tx(0x70));
+			GUI_output(get_tx(28));
 			xor_ds_bs(DNG09_LEVER2_FLAG, 1);
 		}
 
 	} else if (target_pos == 0x190b && target_pos != ds_readws(DNG_HANDLED_POS) &&
 			ds_readb(DNG09_BOLTTRAP4_FLAG) != 0 && ds_readb(DNG09_SECRETDOOR2) == 2)
 	{
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		/* TODO: MISSING? dec_ds_bs_post(DNG09_BOLTTRAP4_FLAG); */
 
@@ -252,7 +252,7 @@ signed short DNG09_handler(void)
 				sub_hero_le(hero, dice_roll(2, 6, 4));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x30),
+					(char*)get_tx(12),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -271,7 +271,7 @@ signed short DNG09_handler(void)
 
 	} else if (target_pos == 0x1208 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x98)))
+		if (GUI_bool(get_tx(38)))
 		{
 			dec_ds_ws_post(X_TARGET);
 			inc_ds_ws_post(Y_TARGET);
@@ -283,24 +283,24 @@ signed short DNG09_handler(void)
 			!ds_readb(DNG09_LEVER_FAST))
 	{
 		do {
-			i = GUI_radio(get_tx(0x9c), 3,
-					get_tx(0xa0),
-					get_tx(0xa4),
-					get_tx(0xa8));
+			i = GUI_radio(get_tx(39), 3,
+					get_tx(40),
+					get_tx(41),
+					get_tx(42));
 		} while (i == -1);
 
 		if (i == 2)
 		{
-			GUI_output(get_tx(0xac));
+			GUI_output(get_tx(43));
 
 		} else if (i == 3)
 		{
-			if ((i = select_hero_ok(get_tx(0xb0))) != -1)
+			if ((i = select_hero_ok(get_tx(44))) != -1)
 			{
 				hero = get_hero(i);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xb4),
+					(char*)get_tx(45),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -359,7 +359,7 @@ signed short DNG09_handler(void)
 		init_ani(0);
 		delay_or_keypress(100);
 
-		if (GUI_bool(get_tx(0xb8)))
+		if (GUI_bool(get_tx(46)))
 		{
 			ds_writeb(DNG09_ALTAR_FLAG, 1);
 
@@ -375,9 +375,9 @@ signed short DNG09_handler(void)
 
 
 			do {
-				i = GUI_radio(get_tx(0xbc), 2,
-						get_tx(0xc0),
-						get_tx(0xc4));
+				i = GUI_radio(get_tx(47), 2,
+						get_tx(48),
+						get_tx(49));
 			} while (i == -1);
 
 			if (i == 1)
@@ -385,7 +385,7 @@ signed short DNG09_handler(void)
 				get_item(248, 1, 1);
 
 			} else {
-				GUI_output(get_tx(0xc8));
+				GUI_output(get_tx(50));
 			}
 		}
 
@@ -401,11 +401,11 @@ signed short DNG09_handler(void)
 			ds_writeb(DNG09_SECRETDOOR1, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0xcc),
+				(char*)get_tx(51),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)(((l3 = test_skill(hero, TA_SCHLOESSER, 4)) > 0) ? get_tx(0xd0) : get_tx(0xd8)),
+				(char*)(((l3 = test_skill(hero, TA_SCHLOESSER, 4)) > 0) ? get_tx(52) : get_tx(54)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
@@ -438,11 +438,11 @@ signed short DNG09_handler(void)
 			ds_writeb(DNG09_SECRETDOOR2, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0xcc),
+				(char*)get_tx(51),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)(((l3 = test_skill(hero, TA_SCHLOESSER, 6)) > 0) ? get_tx(0xd0) : get_tx(0xd4)),
+				(char*)(((l3 = test_skill(hero, TA_SCHLOESSER, 6)) > 0) ? get_tx(52) : get_tx(53)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)),
@@ -472,8 +472,8 @@ signed short DNG09_handler(void)
 		ds_writeb(DIRECTION, (ds_readws(ARRIVAL_DIRECTION) + 2) & 3);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xdc),
-			(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(55),
+			(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -497,7 +497,7 @@ void DNG09_fight_intro(signed short fight_id)
 {
 	if (fight_id == 94)
 	{
-		GUI_output(get_tx(0x34));
+		GUI_output(get_tx(13));
 	}
 }
 
@@ -548,13 +548,13 @@ void DNG09_chest4_x1(RealPt chest)
 
 	if (!ds_readb(DNG09_CRYSTAL_FLAG))
 	{
-		if (GUI_bool(get_tx(0x50)))
+		if (GUI_bool(get_tx(20)))
 		{
 			do {
-				answer = GUI_radio(get_tx(0x54), 3,
-							get_tx(0x58),
-							get_tx(0x5c),
-							get_tx(0x60));
+				answer = GUI_radio(get_tx(21), 3,
+							get_tx(22),
+							get_tx(23),
+							get_tx(24));
 			} while (answer == -1);
 
 			hero = Real2Host(get_first_hero_available_in_group());
@@ -562,28 +562,28 @@ void DNG09_chest4_x1(RealPt chest)
 			if (answer == 1)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x64),
+					(char*)get_tx(25),
 					(char*)hero + HERO_NAME2);
 				GUI_output(Real2Host(ds_readd(DTP2)));
 
 				sub_hero_le(hero, dice_roll(2, 20, 0));
 			} else if (answer == 2)
 			{
-				hero = get_hero(0) + select_hero_ok_forced(get_ttx(0x4f4)) * SIZEOF_HERO;
+				hero = get_hero(0) + select_hero_ok_forced(get_ttx(317)) * SIZEOF_HERO;
 				if (test_spell(hero, 2, 0) > 0)
 				{
 					sub_ae_splash(hero, 20);
 
 					sub_ptr_ws(hero + HERO_AE_ORIG, 3);
 
-					GUI_output(get_tx(0x6c));
+					GUI_output(get_tx(27));
 
 					add_hero_ap_all(50);
 
 					ds_writeb(DNG09_CRYSTAL_FLAG, 1);
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x68),
+						(char*)get_tx(26),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -592,21 +592,21 @@ void DNG09_chest4_x1(RealPt chest)
 
 			} else if (answer == 3)
 			{
-				hero = get_hero(0) + select_hero_ok_forced(get_ttx(0x4f4)) * SIZEOF_HERO;
+				hero = get_hero(0) + select_hero_ok_forced(get_ttx(317)) * SIZEOF_HERO;
 				if (test_spell(hero, 53, 0) > 0)
 				{
 					sub_ae_splash(hero, 35);
 
 					sub_ptr_ws(hero + HERO_AE_ORIG, 3);
 
-					GUI_output(get_tx(0x6c));
+					GUI_output(get_tx(27));
 
 					add_hero_ap_all(50);
 
 					ds_writeb(DNG09_CRYSTAL_FLAG, 1);
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x68),
+						(char*)get_tx(26),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -615,7 +615,7 @@ void DNG09_chest4_x1(RealPt chest)
 			}
 		}
 	} else {
-		GUI_output(get_ttx(0x828));
+		GUI_output(get_ttx(522));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg085.cpp
+++ b/src/custom/schick/rewrite_m302de/seg085.cpp
@@ -55,10 +55,10 @@ signed short DNG10_handler(void)
 	if ((target_pos == 0x101 || target_pos == 0x302) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* TRAP: a hole in a wall; leader gets 2 LE damage */
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x08),
+				(char*)get_tx(2),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -78,14 +78,14 @@ signed short DNG10_handler(void)
 		{
 			or_ds_bs(DNG10_LEVER_FOUND, 1);
 
-			if (GUI_bool((!(ds_readb(DNG10_LEVER_FOUND) & 2) ? get_tx(0x18) : get_tx(0xa4))))
+			if (GUI_bool((!(ds_readb(DNG10_LEVER_FOUND) & 2) ? get_tx(6) : get_tx(41))))
 			{
-				if (GUI_bool(get_tx(0x1c)))
+				if (GUI_bool(get_tx(7)))
 				{
 					or_ds_bs(DNG10_LEVER_FOUND, 2);
 					xor_ds_bs(DNG10_LEVER_STATE, 1);
 
-					GUI_output(get_tx(0x20));
+					GUI_output(get_tx(8));
 				}
 			}
 		}
@@ -99,14 +99,14 @@ signed short DNG10_handler(void)
 		answer = dice_roll(3, 6, 4);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x24),
+			(char*)get_tx(9),
 			(char*)hero + HERO_NAME2);
 
 		/* check if the hero will survive */
 		if (host_readws(hero + HERO_LE) > answer)
 		{
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_tx(0x28),
+				(char*)get_tx(10),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)),
@@ -127,18 +127,18 @@ signed short DNG10_handler(void)
 			/* Original-Bug: ??? */
 			ds_writeb(DNG10_HOLE_STATE, 1);
 
-			if (ds_readb(DNG10_HOLE_STATE) == 2 || GUI_bool(get_tx(0x18)))
+			if (ds_readb(DNG10_HOLE_STATE) == 2 || GUI_bool(get_tx(6)))
 			{
 				ds_writeb(DNG10_HOLE_STATE, 2);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x2c),
+					(char*)get_tx(11),
 					(char*)hero + HERO_NAME2);
 
 				if (GUI_bool(Real2Host(ds_readd(DTP2))))
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x30),
+						(char*)get_tx(12),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -173,13 +173,13 @@ signed short DNG10_handler(void)
 			/* Original-Bug: ???*/
 			/* Damage only happens here when the leader of the group tries to disable this trap.
 			   If the trap is not found or left alone nobody gets damaged. Weird! */
-			if (GUI_bool(get_tx(0x34)) && test_skill(hero, TA_SCHLOESSER, 7) <= 0)
+			if (GUI_bool(get_tx(13)) && test_skill(hero, TA_SCHLOESSER, 7) <= 0)
 			{
 				if (ds_readb(DNG10_FLOORPLATE_LOADS) != 0)
 				{
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x38),
+						(char*)get_tx(14),
 						(char*)hero + HERO_NAME2);
 
 					dec_ds_bs_post(DNG10_FLOORPLATE_LOADS);
@@ -187,7 +187,7 @@ signed short DNG10_handler(void)
 					sub_hero_le(hero, dice_roll(3, 6, 0));
 				} else {
 					strcpy((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x3c));
+						(char*)get_tx(15));
 				}
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -197,20 +197,20 @@ signed short DNG10_handler(void)
 	} else if (target_pos == 0x10c && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: you see three holes in the wall */
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 	} else if (target_pos == 0x30e && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: collection bowl */
-		if (GUI_bool(get_tx(0x44)))
+		if (GUI_bool(get_tx(17)))
 		{
-			answer = GUI_input(get_tx(0x48), 6) * 10;
+			answer = GUI_input(get_tx(18), 6) * 10;
 
 			if (get_party_money() < answer)
 			{
-				GUI_output(get_ttx(0x644));
+				GUI_output(get_ttx(401));
 			} else {
-				GUI_output( (answer >= 1000) ? get_tx(0x50) : get_tx(0x4c));
+				GUI_output( (answer >= 1000) ? get_tx(20) : get_tx(19));
 
 				set_party_money( get_party_money() - answer);
 			}
@@ -219,12 +219,12 @@ signed short DNG10_handler(void)
 	} else if (target_pos == 0x60c && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2)
 	{
 		/* INFO: an empty room */
-		GUI_output(get_tx(0x54));
+		GUI_output(get_tx(21));
 
 	} else if (target_pos == 0xa0d && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG10_HESHTOT))
 	{
 		/* FIGHT: scared heshtot */
-		if (GUI_bool(get_tx(0x58)))
+		if (GUI_bool(get_tx(22)))
 		{
 			ds_writew((FIG_FLEE_POSITION + 0), ds_writew((FIG_FLEE_POSITION + 2), ds_writew((0xd325 + 4), ds_writew((0xd325 + 6), 0xa0d))));
 			ds_writew(DNG_HANDLED_POS, 0);
@@ -234,7 +234,7 @@ signed short DNG10_handler(void)
 				ds_writeb(DNG10_HESHTOT, 1);
 			}
 		} else {
-			GUI_output(get_tx(0x5c));
+			GUI_output(get_tx(23));
 			sub_group_le(random_schick(6));
 
 			ds_writew(X_TARGET, 1);
@@ -250,7 +250,7 @@ signed short DNG10_handler(void)
 		/* TRAP: column of fire, probability 10%, damage 1W6 for each hero in the party */
 		if (random_schick(100) <= 10)
 		{
-			GUI_output(get_tx(0x60));
+			GUI_output(get_tx(24));
 
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
@@ -266,12 +266,12 @@ signed short DNG10_handler(void)
 	} else if (target_pos == 0x1e02 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* LEVER: enables/disables fight 111, leader get 2 LE damage */
-		if (GUI_bool(get_tx(0x64)))
+		if (GUI_bool(get_tx(25)))
 		{
 			xor_ds_bs(DNG10_MUMMY_LEVER, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x68),
+				(char*)get_tx(26),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -290,7 +290,7 @@ signed short DNG10_handler(void)
 	} else if (target_pos == 0x110c && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2)
 	{
 		/* INFO: glowing walls */
-		GUI_output(get_tx(0x6c));
+		GUI_output(get_tx(27));
 
 	} else if (target_pos == 0x190c && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DNG10_DRAGON_QUEST) != 0)
 	{
@@ -308,9 +308,9 @@ signed short DNG10_handler(void)
 			load_in_head(58);
 
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70),
-						get_tx(0x74), 2,
-						get_tx(0x78), get_tx(0x7c));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28),
+						get_tx(29), 2,
+						get_tx(30), get_tx(31));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -318,13 +318,13 @@ signed short DNG10_handler(void)
 				/* try to fight the dragon */
 				ds_writeb(DNG10_DRAGON_QUEST, 1);
 
-				if (GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70),
-						get_tx(0x80), 2,
-						get_ttx(0x08), get_ttx(0x0c)) == 1)
+				if (GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28),
+						get_tx(32), 2,
+						get_ttx(2), get_ttx(3)) == 1)
 				{
-					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x84), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(33), 0);
 				} else {
-					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x88), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(34), 0);
 
 					sub_group_le(5000);
 				}
@@ -347,7 +347,7 @@ signed short DNG10_handler(void)
 				{
 					ds_writeb(DNG10_HOARD_PLUNDERED, 1);
 
-					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x8c), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(35), 0);
 
 					/* 2x HEALING POTION, MAGIC POTION, THROWING DAGGER and ...*/
 					get_item(145, 1, 2);
@@ -362,12 +362,12 @@ signed short DNG10_handler(void)
 				} else {
 					ds_writeb(DNG10_DRAGON_QUEST, 1);
 
-					if (GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x80), 2,
-								get_ttx(0x08), get_ttx(0x0c)) == 1)
+					if (GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(32), 2,
+								get_ttx(2), get_ttx(3)) == 1)
 					{
-						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x84), 0);
+						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(33), 0);
 					} else {
-						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x88), 0);
+						GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(34), 0);
 						sub_group_le(5000);
 					}
 				}
@@ -385,8 +385,8 @@ signed short DNG10_handler(void)
 				result = get_item_pos(hero, 201);
 				drop_item(hero, result, 1);
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x90), 0);
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x94), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(36), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(37), 0);
 
 				/* 2x HEALING POTION, MAGIC POTION, THROWING DAGGER, CRYSTAL BALL and ...*/
 				get_item(145, 1, 2);
@@ -404,14 +404,14 @@ signed short DNG10_handler(void)
 
 				ds_writeb(DNG10_DRAGON_QUEST, 2);
 			} else {
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x70), get_tx(0x98), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(28), get_tx(38), 0);
 			}
 		}
 
 	} else if (target_pos == 0x2005 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: some fools you are */
-		GUI_output(get_tx(0x9c));
+		GUI_output(get_tx(39));
 
 	} else if (target_pos == 0x03 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -424,8 +424,8 @@ signed short DNG10_handler(void)
 		ds_writeb(DIRECTION, (ds_readbs(ARRIVAL_DIRECTION) + 2) & 0x03);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xa0),
-			(char*)get_ttx(4 * (ds_readw(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(40),
+			(char*)get_ttx(ds_readw(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -442,14 +442,14 @@ signed short DNG10_handler(void)
 
 void DNG10_chest0_x1(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x0c), p_datseg + DNG10_CORPSE_LOOTED);
+	loot_corpse(ptr, get_tx(3), p_datseg + DNG10_CORPSE_LOOTED);
 }
 
 void DNG10_chest0_x2(RealPt chest)
 {
 	RealPt ptr_bak = (RealPt)host_readd(Real2Host(chest) + 11);
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, DNG10_CHEST0_CONTENT));
-	loot_chest(Real2Host(chest), get_tx(0x10), get_tx(0x14));
+	loot_chest(Real2Host(chest), get_tx(4), get_tx(5));
 	host_writed(Real2Host(chest) + 11, (Bit32u)ptr_bak);
 }
 

--- a/src/custom/schick/rewrite_m302de/seg086.cpp
+++ b/src/custom/schick/rewrite_m302de/seg086.cpp
@@ -50,7 +50,7 @@ signed short DNG11_handler(void)
 
 	if (target_pos == 0x60c && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DNG11_SOUP_SUPPLY) != 0)
 	{
-		if (GUI_radio(get_tx(0x04), 2, get_tx(0x08), get_tx(0x0c)) == 1)
+		if (GUI_radio(get_tx(1), 2, get_tx(2), get_tx(3)) == 1)
 		{
 			add_group_le(1);
 
@@ -73,13 +73,13 @@ signed short DNG11_handler(void)
 
 	} else if (target_pos == 0x609 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		answer = GUI_radio(get_tx(0x10), 6,
-					get_tx(0x14),
-					get_tx(0x18),
-					get_tx(0x1c),
-					get_tx(0x20),
-					get_tx(0x24),
-					get_tx(0x28));
+		answer = GUI_radio(get_tx(4), 6,
+					get_tx(5),
+					get_tx(6),
+					get_tx(7),
+					get_tx(8),
+					get_tx(9),
+					get_tx(10));
 
 		ds_writeb(DNG11_LEVER_FLAG, 0);
 
@@ -87,28 +87,28 @@ signed short DNG11_handler(void)
 		{
 			ds_writeb(DNG11_LEVER_FLAG, (signed char)answer);
 
-			GUI_output(get_tx(0x2c));
+			GUI_output(get_tx(11));
 		}
 
 	} else if (target_pos == 0x909)
 	{
 		if (target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG11_EFFERD_HINT))
 		{
-			GUI_output(get_tx(0x30));
+			GUI_output(get_tx(12));
 
 		} else if (ds_readb(DNG11_EFFERD_SACRIFICE) != 0 && !ds_readb(DNG11_EFFERD_HINT))
 		{
 			ds_writeb(DNG11_EFFERD_HINT, 1);
 			ds_writeb(DNG11_UNKNOWN2_FLAG, ds_writeb(DNG11_EFFERD_SACRIFICE, 0));
 
-			GUI_output(get_tx(0x34));
+			GUI_output(get_tx(13));
 		}
 
 	} else if (target_pos == 0xc0a && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DNG11_FIRETRAP1_FLAG) != 0)
 	{
 		if (ds_readb(DNG11_EFFERD_HINT) != 0 || ds_readb(DNG11_UNKNOWN1_FLAG) != 0)
 		{
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			dec_ds_bs_post(DNG11_FIRETRAP1_FLAG);
 
@@ -128,7 +128,7 @@ signed short DNG11_handler(void)
 	{
 		if (ds_readb(DNG11_UNKNOWN2_FLAG) != 0)
 		{
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 
 			dec_ds_bs_post(DNG11_FIRETRAP2_FLAG);
 
@@ -146,26 +146,26 @@ signed short DNG11_handler(void)
 
 	} else if (target_pos == 0xb03 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 1)
 	{
-		GUI_output(get_tx(0x44));
+		GUI_output(get_tx(17));
 
 	} else if (((target_pos == 0xc03 && ds_readbs(DIRECTION) == 1) ||
 			(target_pos == 0xb02 && ds_readbs(DIRECTION) == 0)) &&
 			target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-			GUI_output(get_tx(0x40));
+			GUI_output(get_tx(16));
 
 	} else if ((target_pos == 0x600 || target_pos == 0x700 || target_pos == 0x800 || target_pos == 0x900) &&
 			target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_radio(get_tx(0x48), 2, get_tx(0x4c), get_tx(0x50)) == 1)
+		if (GUI_radio(get_tx(18), 2, get_tx(19), get_tx(20)) == 1)
 		{
-			GUI_output(get_tx(0x54));
-			GUI_output(get_tx(0x58));
+			GUI_output(get_tx(21));
+			GUI_output(get_tx(22));
 
 			load_ani(18);
 			init_ani(0);
 
-			GUI_output(get_tx(0x5c));
+			GUI_output(get_tx(23));
 
 			hero = get_hero(0);
 			for (answer = 0; answer <= 6; answer++, hero += SIZEOF_HERO)
@@ -194,11 +194,11 @@ signed short DNG11_handler(void)
 			ds_writeb(DNG11_SECRETDOOR1_FLAG, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x68),
+				(char*)get_tx(26),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((ds_readb(DNG11_LEVER_FLAG) == 2 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 5)) > 0 ? get_tx(0x6c) : get_tx(0x70)),
+				(char*)((ds_readb(DNG11_LEVER_FLAG) == 2 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 5)) > 0 ? get_tx(27) : get_tx(28)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -227,11 +227,11 @@ signed short DNG11_handler(void)
 			ds_writeb(DNG11_SECRETDOOR2_FLAG, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x68),
+				(char*)get_tx(26),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((ds_readb(DNG11_LEVER_FLAG) == 1 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 3)) > 0 ? get_tx(0x6c) : get_tx(0x70)),
+				(char*)((ds_readb(DNG11_LEVER_FLAG) == 1 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 3)) > 0 ? get_tx(27) : get_tx(28)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -260,11 +260,11 @@ signed short DNG11_handler(void)
 			ds_writeb(DNG11_SECRETDOOR3_FLAG, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x68),
+				(char*)get_tx(26),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((ds_readb(DNG11_LEVER_FLAG) == 5 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 5)) > 0 ? get_tx(0x6c) : get_tx(0x70)),
+				(char*)((ds_readb(DNG11_LEVER_FLAG) == 5 || ds_readb(DNG11_LEVER_FLAG) == 3) && (test_result = test_skill(hero, TA_SCHLOESSER, 5)) > 0 ? get_tx(27) : get_tx(28)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -294,8 +294,8 @@ signed short DNG11_handler(void)
 		ds_writeb(DIRECTION, (ds_readbs(ARRIVAL_DIRECTION) + 2) & 0x03);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x74),
-			(char*)get_ttx(4 * (ds_readw(TRV_DESTINATION) + 0xeb)));
+			(char*)get_tx(29),
+			(char*)get_ttx(ds_readw(TRV_DESTINATION) + 0xeb));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -315,14 +315,14 @@ void DNG11_chest1(void)
 	if (!ds_readb(DNG11_PROVIANT1_FLAG))
 	{
 		/* a chest with 50 food rations */
-		GUI_output(get_tx(0x60));
+		GUI_output(get_tx(24));
 
 		ds_writeb(DNG11_PROVIANT1_FLAG, 1);
 
 	} else {
 
 		/* an empty chest */
-		GUI_output(get_ttx(0x828));
+		GUI_output(get_ttx(522));
 	}
 }
 
@@ -331,14 +331,14 @@ void DNG11_chest2(void)
 	if (!ds_readb(DNG11_PROVIANT2_FLAG))
 	{
 		/* a chest with 21 food rations */
-		GUI_output(get_tx(0x64));
+		GUI_output(get_tx(25));
 
 		ds_writeb(DNG11_PROVIANT2_FLAG, 1);
 
 	} else {
 
 		/* an empty chest */
-		GUI_output(get_ttx(0x828));
+		GUI_output(get_ttx(522));
 	}
 }
 
@@ -470,7 +470,7 @@ void DNG11_chest14(RealPt chest)
 void DNG11_fight_intro(signed short fight_id)
 {
 	if (fight_id == 127) {
-		GUI_output(get_tx(0x38));
+		GUI_output(get_tx(14));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg087.cpp
+++ b/src/custom/schick/rewrite_m302de/seg087.cpp
@@ -65,7 +65,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x204 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_MONEY_FLAG)) {
 
-		if (GUI_bool(get_tx(0x04))) {
+		if (GUI_bool(get_tx(1))) {
 
 			/* mark as visited */
 			ds_writeb(DNG14_MONEY_FLAG, 1);
@@ -78,14 +78,14 @@ signed short DNG14_handler(void)
 			/* set gods estimation for PHEX to -100 */
 			ds_writed(GODS_ESTIMATION + 4 * 9, -100);
 
-			GUI_output(get_tx(0x08));
+			GUI_output(get_tx(2));
 		}
 
 	} else if (pos == 0x503 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_ALARM_FLAG)) {
 
 		if (test_skill(hero, TA_SINNESSCHAERFE, 6) <= 0) {
 
-			GUI_output(get_tx(0x0c));
+			GUI_output(get_tx(3));
 
 			ds_writeb(DNG14_ALARM_FLAG, 1);
 		}
@@ -98,11 +98,11 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x706 && pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DIRECTION) == 0) {
 
-		loot_multi_chest(p_datseg + DNG14_CHEST_PANTRY, get_tx(0x10));
+		loot_multi_chest(p_datseg + DNG14_CHEST_PANTRY, get_tx(4));
 
 	} else if (pos == 0x60b && pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DIRECTION) == 1) {
 
-		loot_multi_chest(p_datseg + DNG14_CHEST_GEAR, get_tx(0x14));
+		loot_multi_chest(p_datseg + DNG14_CHEST_GEAR, get_tx(5));
 
 	} else if ((pos == 0x90d || pos == 0x909) && pos != ds_readws(DNG_HANDLED_POS) && random_schick(100) <= 20) {
 
@@ -120,13 +120,13 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0xb0e && pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DIRECTION) == 1) {
 
-		GUI_output(get_tx(0x18));
+		GUI_output(get_tx(6));
 
 	} else if (pos == 0xd07 && pos != ds_readws(DNG_HANDLED_POS) && ds_readb(DNG14_POISONTRAP) != 0) {
 
-		GUI_output(get_tx(0x28));
+		GUI_output(get_tx(10));
 
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 
 		ds_writeb(DNG14_POISONTRAP, 2);
 
@@ -144,7 +144,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0xa03 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x30));
+		GUI_output(get_tx(12));
 
 	} else if (pos == 0x40b &&
 			(pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
@@ -156,11 +156,11 @@ signed short DNG14_handler(void)
 			ds_writeb(DNG14_SECRETDOOR1, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, -6)) > 0 ? get_tx(0x20): get_tx(0x24)),
+				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, -6)) > 0 ? get_tx(8): get_tx(9)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -187,11 +187,11 @@ signed short DNG14_handler(void)
 			ds_writeb(DNG14_SECRETDOOR2, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 6)) > 0 ? get_tx(0x20): get_tx(0x24)),
+				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 6)) > 0 ? get_tx(8): get_tx(9)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -234,9 +234,9 @@ signed short DNG14_handler(void)
 
 		/* a Ladder */
 
-		if (GUI_bool(get_tx(0x34))) {
+		if (GUI_bool(get_tx(13))) {
 
-			GUI_output(get_tx(0x38));
+			GUI_output(get_tx(14));
 
 			inc_ds_ws(Y_TARGET);
 			ds_writebs(DIRECTION, 2);
@@ -258,7 +258,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x1809 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x3c));
+		GUI_output(get_tx(15));
 
 	} else if (pos == 0x1a06 && pos != ds_readws(DNG_HANDLED_POS) && random_schick(100) <= 50) {
 
@@ -270,30 +270,30 @@ signed short DNG14_handler(void)
 
 	} else if ((pos == 0x1802 || pos == 0x1805) && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 3) {
 
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 	} else if (pos == 0x1c02 && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 1) {
 
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 	} else if (pos == 0x1c06 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 		if (!ds_readb(DNG14_BOOTY_FLAG)) {
 
-			loot_multi_chest(p_datseg + DNG14_CHEST_BARREL, get_tx(0x44));
+			loot_multi_chest(p_datseg + DNG14_CHEST_BARREL, get_tx(17));
 
 			ds_writeb(DNG14_BOOTY_FLAG, 1);
 		}
 
 	} else if (pos == 0x1c0a && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x48));
+		GUI_output(get_tx(18));
 
 	} else if (pos == 0x1d0a && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_UGDALF_DONE)) {
 
-		GUI_output(get_tx(0x4c));
+		GUI_output(get_tx(19));
 
 		ds_writeb(DNG14_UGDALF_DONE, 1);
 
@@ -310,11 +310,11 @@ signed short DNG14_handler(void)
 			ds_writeb(DNG14_SECRETDOOR3, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, -6)) > 0 ? get_tx(0x20) : get_tx(0x24)),
+				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, -6)) > 0 ? get_tx(8) : get_tx(9)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -342,11 +342,11 @@ signed short DNG14_handler(void)
 			ds_writeb(DNG14_SECRETDOOR4, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 7)) > 0 ? get_tx(0x20) : get_tx(0x24)),
+				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 7)) > 0 ? get_tx(8) : get_tx(9)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -365,12 +365,12 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x2306 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x50));
+		GUI_output(get_tx(20));
 
 
 	} else if (pos == 0x240d && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		if (GUI_bool(get_tx(0x54))) {
+		if (GUI_bool(get_tx(21))) {
 
 			l_di = group_count_item(121);
 			l_di += group_count_item(32);
@@ -390,10 +390,10 @@ signed short DNG14_handler(void)
 			}
 
 			do {
-				hero_pos = GUI_radio(get_tx(0x58), (l_di >= 5 ? 3 : 2),
-							get_tx(0x5c),
-							get_tx(0x60),
-							get_tx(0x64));
+				hero_pos = GUI_radio(get_tx(22), (l_di >= 5 ? 3 : 2),
+							get_tx(23),
+							get_tx(24),
+							get_tx(25));
 			} while (hero_pos == -1);
 
 			if (hero_pos == 3) {
@@ -407,7 +407,7 @@ signed short DNG14_handler(void)
 						test_skill(hero, TA_KLETTERN, 0) <= 0)
 					{
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x68),
+							(char*)get_tx(26),
 							(char*)hero + HERO_NAME2,
 							(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
 
@@ -433,7 +433,7 @@ signed short DNG14_handler(void)
 						test_skill(hero, TA_KLETTERN, 4) <= 0)
 					{
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x6c),
+							(char*)get_tx(27),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -451,7 +451,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x220e && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_TORCHES_FLAG)) {
 
-		if (GUI_bool(get_tx(0x70))) {
+		if (GUI_bool(get_tx(28))) {
 
 			ds_writeb(DNG14_TORCHES_FLAG, 1);
 
@@ -462,7 +462,7 @@ signed short DNG14_handler(void)
 
 		ds_writeb(DNG14_SPOOKY_FLAG, 1);
 
-		GUI_output(get_tx(0x74));
+		GUI_output(get_tx(29));
 
 		hero = get_hero(0);
 		for (hero_pos = 0; hero_pos <= 6; hero_pos++, hero += SIZEOF_HERO) {
@@ -480,7 +480,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x2102 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_SPEAR_FLAG)) {
 
-		if (GUI_bool(get_tx(0x78))) {
+		if (GUI_bool(get_tx(30))) {
 
 			ds_writeb(DNG14_SPEAR_FLAG, 1);
 
@@ -490,11 +490,11 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x2907 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		if (GUI_bool(get_tx(0x7c))) {
+		if (GUI_bool(get_tx(31))) {
 
 			timewarp(HOURS(12));
 
-			GUI_output(get_tx(0x80));
+			GUI_output(get_tx(32));
 		}
 
 		ds_writews(X_TARGET, ds_readws(X_TARGET_BAK));
@@ -502,22 +502,22 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x2707 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_dialog_na(60, get_tx(0x84));
+		GUI_dialog_na(60, get_tx(33));
 
 	} else if (pos == 0x2d07 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_dialog_na(60, get_tx(0x88));
+		GUI_dialog_na(60, get_tx(34));
 
 	} else if (pos == 0x2e05 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x90));
+		GUI_output(get_tx(36));
 
 		/* each hero gets 2W6 damage */
 		sub_group_le(dice_roll(2, 6, 0));
 
 	} else if (pos == 0x2e03 && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 0) {
 
-		GUI_output(get_tx(0x94));
+		GUI_output(get_tx(37));
 
 	} else if (pos == 0x2e05 &&
 			(pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
@@ -528,11 +528,11 @@ signed short DNG14_handler(void)
 			ds_writeb(DNG14_SECRETDOOR5, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c),
+				(char*)get_tx(7),
 				(char*)hero + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(0x20) : get_tx(0x24)),
+				(char*)((l_di = test_skill(hero, TA_SCHLOESSER, 4)) > 0 ? get_tx(8) : get_tx(9)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			strcat((char*)Real2Host(ds_readd(DTP2)), (char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -553,24 +553,24 @@ signed short DNG14_handler(void)
 
 	if (pos == 0x340c && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0x8c));
+		GUI_output(get_tx(35));
 
 	} else if (((pos == 0x3a0a && ds_readbs(DIRECTION) == 1) || (pos == TEVENT138_FLAG && ds_readbs(DIRECTION) == 3)) &&
 			pos != ds_readws(DNG_HANDLED_POS))
 	{
-		if (GUI_bool(get_tx(0x98))) {
+		if (GUI_bool(get_tx(38))) {
 
 			if (get_first_hero_with_item(121) != - 1 || get_first_hero_with_item(32) != -1)
 			{
 
-				if ((hero_pos = select_hero_ok(get_tx(0x9c))) != -1) {
+				if ((hero_pos = select_hero_ok(get_tx(39))) != -1) {
 
 					hero = get_hero(hero_pos);
 
 					if (test_skill(hero, TA_SCHWIMMEN, 8) <= 0) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0xa0),
+							(char*)get_tx(40),
 							(char*)hero + HERO_NAME2,
 							(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -584,7 +584,7 @@ signed short DNG14_handler(void)
 						if (hero_dead(hero)) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx(0xfc),
+								(char*)get_tx(63),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -593,7 +593,7 @@ signed short DNG14_handler(void)
 						}
 					} else {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0xa4),
+							(char*)get_tx(41),
 							(char*)hero + HERO_NAME2,
 							(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -610,19 +610,19 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x0360b && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_dialog_na(55, get_tx(0xb0));
+		GUI_dialog_na(55, get_tx(44));
 
 	} else if ((pos == 0x3401 || pos == 0x3c07 || pos == 0x3103 || pos == 0x3607) && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0xb4));
+		GUI_output(get_tx(45));
 
 	} else if (pos == 0x340d && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		GUI_output(get_tx(0xbc));
+		GUI_output(get_tx(47));
 
 	} else if (pos == 0x3303 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_HATCHET_FLAG)) {
 
-		if (GUI_bool(get_tx(0xb8))) {
+		if (GUI_bool(get_tx(46))) {
 
 			ds_writeb(DNG14_HATCHET_FLAG, 1);
 
@@ -631,12 +631,12 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x3b0d && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 1) {
 
-		GUI_output(get_tx(0xc0));
+		GUI_output(get_tx(48));
 
 	} else if (pos == 0x3c0c && pos != ds_readws(DNG_HANDLED_POS)) {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xc4),
+			(char*)get_tx(49),
 			(char*)hero + HERO_NAME2,
 			(char*)hero + HERO_NAME2);
 
@@ -647,7 +647,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x3703 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_RING_FLAG)) {
 
-		if (GUI_bool(get_tx(0xc8))) {
+		if (GUI_bool(get_tx(50))) {
 
 			ds_writeb(DNG14_RING_FLAG, 1);
 
@@ -656,15 +656,15 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x3b01 && pos != ds_readws(DNG_HANDLED_POS)) {
 
-		if (GUI_bool(get_tx(0xcc))) {
+		if (GUI_bool(get_tx(51))) {
 
-			GUI_output(get_tx(0xd0));
+			GUI_output(get_tx(52));
 
 			if (!ds_readb(DNG14_CELLAREXIT_FLAG)) {
 
-				GUI_output(get_tx(0xd4));
-				GUI_output(get_tx(0xd8));
-				GUI_output(get_tx(0xdc));
+				GUI_output(get_tx(53));
+				GUI_output(get_tx(54));
+				GUI_output(get_tx(55));
 
 				drink_while_drinking(100);
 
@@ -680,7 +680,7 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x450d && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG14_ORKNASE_FLAG)) {
 
-		if (GUI_bool(get_tx(0xe4))) {
+		if (GUI_bool(get_tx(57))) {
 
 			ds_writeb(DNG14_ORKNASE_FLAG, 1);
 
@@ -689,16 +689,16 @@ signed short DNG14_handler(void)
 
 	} else if (pos == 0x4c09 && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2) {
 
-		GUI_output(get_tx(0xe8));
+		GUI_output(get_tx(58));
 
 	} else if (pos == 0x4509 && pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 0) {
 
-		if (!GUI_bool(get_tx(0xec))) {
+		if (!GUI_bool(get_tx(59))) {
 
 			ds_writew(X_TARGET, ds_readws(X_TARGET_BAK));
 			ds_writew(Y_TARGET, ds_readws(Y_TARGET_BAK));
 
-			GUI_output(get_tx(0xf0));
+			GUI_output(get_tx(60));
 		}
 
 	} else if (pos == 0x000e && pos != ds_readws(DNG_HANDLED_POS)) {

--- a/src/custom/schick/rewrite_m302de/seg088.cpp
+++ b/src/custom/schick/rewrite_m302de/seg088.cpp
@@ -41,7 +41,7 @@ void DNG14_dive(signed short diver_pos, signed char mod, signed short dest_x)
 			if (test_skill(hero, TA_SCHWIMMEN, mod) <= 0) {
 				/* swimming failed */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xa8),
+					(char*)get_tx(42),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
@@ -54,7 +54,7 @@ void DNG14_dive(signed short diver_pos, signed char mod, signed short dest_x)
 				/* swimming succeeded */
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xac),
+					(char*)get_tx(43),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -75,7 +75,7 @@ void DNG14_dive(signed short diver_pos, signed char mod, signed short dest_x)
 void DNG14_fight_intro(signed short fight_id)
 {
 	if ((fight_id == 172) || (fight_id == 174)) {
-		GUI_output(get_tx(0xe0));
+		GUI_output(get_tx(56));
 	}
 }
 
@@ -101,7 +101,7 @@ void DNG14_chest_x2(RealPt chest)
 
 void DNG14_chest_x3(RealPt chest)
 {
-	loot_multi_chest(p_datseg + DNG14_CHEST_X3, get_tx(0xf8));
+	loot_multi_chest(p_datseg + DNG14_CHEST_X3, get_tx(62));
 }
 
 void DNG14_chest_x4(RealPt chest)
@@ -139,7 +139,7 @@ void DNG14_chest_x6(RealPt chest)
 
 		ds_writeb(DNG14_FULLMAP_FLAG, 0);
 
-		GUI_output(get_tx(0x100));
+		GUI_output(get_tx(64));
 
 		for (x = 0; x < 16; x++) {
 			for (y = 0; y < 16; y++) {
@@ -174,7 +174,7 @@ void DNG14_chest_x9(void)
 	Bit8u *hero;
 
 	hero = Real2Host(get_first_hero_available_in_group());
-	print_msg_with_first_hero(get_tx(0xf4));
+	print_msg_with_first_hero(get_tx(61));
 	sub_hero_le(hero, dice_roll(2, 6, 0));
 }
 
@@ -212,15 +212,15 @@ void DNG15_riddle(void)
 	if (!l_di || !ds_readb(DNG15_REACHED_HANDS)) {
 
 		/* INFO: you hear a soft cracking noise */
-		GUI_output(get_tx(0x70));
+		GUI_output(get_tx(28));
 
 	} else {
 
 		/* ask which lever should be pulled */
 		do {
-			i = GUI_radio(get_tx(0x74), 2,
-					get_tx(0x78),
-					get_tx(0x7c));
+			i = GUI_radio(get_tx(29), 2,
+					get_tx(30),
+					get_tx(31));
 		} while (i == -1);
 
 		if (i == 2) {
@@ -236,19 +236,19 @@ void DNG15_riddle(void)
 			if (ds_readb(DNG15_LEVER_SOUTH) != 0 && ds_readb(DNG15_LEVER_NORTH) != 0)
 			{
 				/* riddle solved: remove the door from the map */
-				GUI_output(get_tx(0x80));
+				GUI_output(get_tx(32));
 
 				host_writeb(ptr + 0x39, 0x20);
 
 				add_hero_ap_all(10);
 			} else {
 				/* INFO: you hear a soft cracking noise */
-				GUI_output(get_tx(0x70));
+				GUI_output(get_tx(28));
 			}
 		} else {
 			/* pull on the this side */
 			/* INFO: you hear a soft cracking noise */
-			GUI_output(get_tx(0x70));
+			GUI_output(get_tx(28));
 		}
 	}
 

--- a/src/custom/schick/rewrite_m302de/seg089.cpp
+++ b/src/custom/schick/rewrite_m302de/seg089.cpp
@@ -60,12 +60,12 @@ signed short DNG15_handler(void)
 		((target_pos == 0xc0a || target_pos == 0x80a) && dir == 0)) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: a large hall */
-		GUI_output(get_tx(0x04));
+		GUI_output(get_tx(1));
 
 	} else if (((target_pos == 0x304 && dir == 0) || (target_pos == 0x403 && dir == 3)) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: entering the tower */
-		GUI_output(get_tx(0x08));
+		GUI_output(get_tx(2));
 
 	} else if ((target_pos == 0x101 || target_pos == 0x201 || target_pos == 0x301 || target_pos == 0x401 ||
 			target_pos == 0x102 || target_pos == 0x202 || target_pos == 0x302 || target_pos == 0x402 ||
@@ -85,7 +85,7 @@ signed short DNG15_handler(void)
 				tmp = random_schick(3);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)(tmp == 3 ? get_tx(0x0c) : (tmp == 2 ? get_tx(0x10) : get_tx(0x14))),
+					(char*)(tmp == 3 ? get_tx(3) : (tmp == 2 ? get_tx(4) : get_tx(5))),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -99,25 +99,25 @@ signed short DNG15_handler(void)
 			target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* debris, with wounds and no hidden ladder */
-		DNG15_wounds_and_ladders(get_tx(0x24), 1, 0);
+		DNG15_wounds_and_ladders(get_tx(9), 1, 0);
 
 	} else if ((target_pos == 0xb00 || target_pos == 0xc00 || target_pos == 0xd00 ||
 			target_pos == 0xf00 || target_pos == 0xf01 || target_pos == 0xe00) &&
 			target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* debris, no wounds and no hidden ladder */
-		DNG15_wounds_and_ladders(get_tx(0x38), 0, 0);
+		DNG15_wounds_and_ladders(get_tx(14), 0, 0);
 
 	} else if (target_pos == 0xe02 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* debris, with wounds and hidden ladder */
-		DNG15_wounds_and_ladders(get_tx(0x3c), 1, 1);
+		DNG15_wounds_and_ladders(get_tx(15), 1, 1);
 
 	} else if ((target_pos == 0xb01 || target_pos == 0xc01 || target_pos == 0xd01 ||
 			target_pos == 0xe01) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* debris, with wounds and no hidden ladder */
-		DNG15_wounds_and_ladders(get_tx(0x40), 1, 0);
+		DNG15_wounds_and_ladders(get_tx(16), 1, 0);
 
 	} else if (target_pos == 0x901 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -130,7 +130,7 @@ signed short DNG15_handler(void)
 	} else if (target_pos == 0x1e02 && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* LADDER: upwards */
-		if (GUI_bool(get_tx(0x44)))
+		if (GUI_bool(get_tx(17)))
 		{
 			DNG_dec_level();
 			ds_writeb(DIRECTION, 3);
@@ -144,10 +144,10 @@ signed short DNG15_handler(void)
 		tmp = dir;
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x5c),
-			(char*)(tmp == 0 ? get_tx(0x58) :
-				(tmp == 2 ? get_tx(0x54) :
-				(tmp == 3 ? get_tx(0x50) : get_tx(0x4c)))));
+			(char*)get_tx(23),
+			(char*)(tmp == 0 ? get_tx(22) :
+				(tmp == 2 ? get_tx(21) :
+				(tmp == 3 ? get_tx(20) : get_tx(19)))));
 
 		for (i = tmp = 0; i < 6; i++)
 		{
@@ -160,7 +160,7 @@ signed short DNG15_handler(void)
 		}
 
 		strcat((char*)Real2Host(ds_readd(DTP2)),
-			(char*)(tmp == 0 ? get_tx(0x60) : get_tx(0x64)));
+			(char*)(tmp == 0 ? get_tx(24) : get_tx(25)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -173,10 +173,10 @@ signed short DNG15_handler(void)
 		tmp = dir;
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x5c),
-			(char*)(tmp == 0 ? get_tx(0x54) :
-				(tmp == 2 ? get_tx(0x58) :
-				(tmp == 3 ? get_tx(0x4c) : get_tx(0x50)))));
+			(char*)get_tx(23),
+			(char*)(tmp == 0 ? get_tx(21) :
+				(tmp == 2 ? get_tx(22) :
+				(tmp == 3 ? get_tx(19) : get_tx(20)))));
 
 		for (i = tmp = 0; i < 6; i++)
 		{
@@ -189,7 +189,7 @@ signed short DNG15_handler(void)
 		}
 
 		strcat((char*)Real2Host(ds_readd(DTP2)),
-			(char*)(tmp == 0 ? get_tx(0x60) : get_tx(0x64)));
+			(char*)(tmp == 0 ? get_tx(24) : get_tx(25)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -211,12 +211,12 @@ signed short DNG15_handler(void)
 		if (tmp == 0)
 		{
 			/* go through the mirror */
-			GUI_output(get_tx(0x68));
+			GUI_output(get_tx(26));
 			ds_writew(Y_TARGET, 5);
 			DNG_update_pos();
 		} else {
 			/* stay here */
-			GUI_output(get_tx(0x6c));
+			GUI_output(get_tx(27));
 			ds_writew(Y_TARGET, ds_readw(Y_TARGET_BAK));
 		}
 
@@ -237,23 +237,23 @@ signed short DNG15_handler(void)
 		if (tmp == 0)
 		{
 			/* go through the mirror */
-			GUI_output(get_tx(0x68));
+			GUI_output(get_tx(26));
 			ds_writew(Y_TARGET, 1);
 			DNG_update_pos();
 		} else {
 			/* stay here */
-			GUI_output(get_tx(0x6c));
+			GUI_output(get_tx(27));
 			ds_writew(Y_TARGET, ds_readw(Y_TARGET_BAK));
 		}
 
 	} else if (target_pos == 0x110e && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
-		loot_multi_chest(p_datseg + DNG15_CHEST_EQUIPS, get_tx(0x98));
+		loot_multi_chest(p_datseg + DNG15_CHEST_EQUIPS, get_tx(38));
 
 	} else if (target_pos == 0x110b && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: wooden beams */
-		GUI_output(get_tx(0x9c));
+		GUI_output(get_tx(39));
 
 	} else if (target_pos == 0x130a && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -262,9 +262,9 @@ signed short DNG15_handler(void)
 	} else if (target_pos == 0x240a && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG15_TOOK_HOE))
 	{
 		/* ITEM: a HOE */
-		if (GUI_bool(get_tx(0xc8)))
+		if (GUI_bool(get_tx(50)))
 		{
-			GUI_output(get_tx(0xcc));
+			GUI_output(get_tx(51));
 
 			if (get_item(93, 1, 1) != -1)
 			{
@@ -275,7 +275,7 @@ signed short DNG15_handler(void)
 	} else if ((target_pos == 0x2109 || target_pos == 0x230d) && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
 		/* INFO: end of the corridor */
-		GUI_output(get_tx(0xd0));
+		GUI_output(get_tx(52));
 
 	} else if (target_pos == 0x230c && target_pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -457,7 +457,7 @@ signed short DNG15_handler(void)
 		/* EXIT: may be blocked if cursed money has been taken */
 		if (ds_readb(DNG15_TOOK_CURSED_MONEY) != 0)
 		{
-			GUI_output(get_tx(0x18));
+			GUI_output(get_tx(6));
 
 			ds_writew(X_TARGET, ds_readws(X_TARGET_BAK));
 			ds_writew(Y_TARGET, ds_readws(Y_TARGET_BAK));
@@ -471,8 +471,8 @@ signed short DNG15_handler(void)
 			ds_writeb(DIRECTION, (ds_readbs(ARRIVAL_DIRECTION) + 2) & 0x03);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0xdc),
-				(char*)get_ttx(4 * (ds_readw(TRV_DESTINATION) + 0xeb)));
+				(char*)get_tx(55),
+				(char*)get_ttx(ds_readw(TRV_DESTINATION) + 0xeb));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -512,8 +512,8 @@ void DNG15_small_wounds(void)
 			randval = random_schick(3);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)(randval == 3 ? get_tx(0x0c) :
-						(randval == 2 ? get_tx(0x1c) : get_tx(0x20))),
+				(char*)(randval == 3 ? get_tx(3) :
+						(randval == 2 ? get_tx(7) : get_tx(8))),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -532,15 +532,15 @@ void DNG15_small_wounds(void)
  */
 void DNG15_debris(signed short ladder)
 {
-	if (GUI_bool(get_tx(0x28)))
+	if (GUI_bool(get_tx(10)))
 	{
 		if (ladder == 0)
 		{
-			GUI_output(get_tx(0x2c));
+			GUI_output(get_tx(11));
 		} else {
-			GUI_output(get_tx(0x30));
+			GUI_output(get_tx(12));
 
-			if (GUI_bool(get_tx(0x34)))
+			if (GUI_bool(get_tx(13)))
 			{
 				ds_writeb(DIRECTION, 3);
 				dec_ds_ws(X_TARGET);
@@ -552,23 +552,23 @@ void DNG15_debris(signed short ladder)
 
 void DNG15_empty_chest(RealPt chest)
 {
-	GUI_output(get_ttx(0x828));
+	GUI_output(get_ttx(522));
 }
 
 void DNG15_rotten_clothes_chest(RealPt chest)
 {
-	GUI_output(get_tx(0x88));
+	GUI_output(get_tx(34));
 }
 
 void DNG15_smelling_chest(RealPt chest)
 {
 	Bit8u *hero;
-	if (GUI_bool(get_tx(0x8c)))
+	if (GUI_bool(get_tx(35)))
 	{
 		hero = get_hero(get_random_hero());
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x90),
+			(char*)get_tx(36),
 			(char*)hero + HERO_NAME2);
 		GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -582,7 +582,7 @@ void DNG15_figures_chest(RealPt chest)
 
 	tw_bak = ds_readws(TEXTBOX_WIDTH);
 	ds_writew(TEXTBOX_WIDTH, 7);
-	GUI_output(get_tx(0x94));
+	GUI_output(get_tx(37));
 	ds_writew(TEXTBOX_WIDTH, tw_bak);
 }
 
@@ -594,7 +594,7 @@ void DNG15_cursed_money_chest(RealPt chest)
 	tw_bak = ds_readws(TEXTBOX_WIDTH);
 	ds_writew(TEXTBOX_WIDTH, 7);
 
-	if (GUI_bool(get_tx(0xd8)))
+	if (GUI_bool(get_tx(54)))
 	{
 		/* You are cursed ... */
 		ds_writeb(DNG15_TOOK_CURSED_MONEY, 1);
@@ -623,7 +623,7 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 		case 1:
 		{
 			/* rotting beams */
-			GUI_output(get_tx(0xa0));
+			GUI_output(get_tx(40));
 
 			/* count failed GE-3 test */
 			for (i = cnt = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -642,16 +642,16 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 				/* if more that one hero failed, the ceiling craks */
 				inc_ptr_bs(ptr);
 
-				GUI_output(get_tx(0xa4));
+				GUI_output(get_tx(41));
 			}
 			break;
 		}
 		case 2:
 		{
 			/* the beams crash imediately */
-			GUI_output(get_tx(0xa8));
+			GUI_output(get_tx(42));
 			inc_ptr_bs(ptr);
-			GUI_output(get_tx(0xac));
+			GUI_output(get_tx(43));
 
 			/* each hero gets 1W6 damage on a failed GE test */
 			for (i = cnt = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -662,7 +662,7 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 					test_attrib(hero, ATTRIB_GE, 0) <= 0)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0xb0),
+						(char*)get_tx(44),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -682,11 +682,11 @@ void DNG15_collapsing_ceiling(Bit8u* ptr)
 			if (random_schick(100) >= 65)
 			{
 				/* the way is already cleared */
-				GUI_output(get_tx(0xc0));
+				GUI_output(get_tx(48));
 			} else {
 				dec_ptr_bs(ptr);
 
-				if (GUI_bool(get_tx(0xc4)))
+				if (GUI_bool(get_tx(49)))
 				{
 					DNG15_clear_way(ptr);
 				}
@@ -719,7 +719,7 @@ void DNG15_clear_way(Bit8u* ptr)
 	/* With aprobability of 60% the ceiling crashes down. */
 	if (random_schick(100) <= 60)
 	{
-		GUI_output(get_tx(0xb8));
+		GUI_output(get_tx(46));
 
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 		{
@@ -729,7 +729,7 @@ void DNG15_clear_way(Bit8u* ptr)
 				test_attrib(hero, ATTRIB_GE, 0) <= 0)
 			{
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xb0),
+					(char*)get_tx(44),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -743,7 +743,7 @@ void DNG15_clear_way(Bit8u* ptr)
 		ds_writew(Y_TARGET, ds_readws(Y_TARGET_BAK));
 	} else {
 		inc_ptr_bs(ptr);
-		GUI_output(get_tx(0xbc));
+		GUI_output(get_tx(47));
 	}
 }
 
@@ -751,7 +751,7 @@ void DNG15_cursed_money(Bit8u* ptr)
 {
 	Bit32s p_money;
 
-	if (GUI_bool(get_tx(0xd4)))
+	if (GUI_bool(get_tx(53)))
 	{
 		host_writebs(ptr, ds_writeb(DNG15_TOOK_CURSED_MONEY, 1));
 

--- a/src/custom/schick/rewrite_m302de/seg090.cpp
+++ b/src/custom/schick/rewrite_m302de/seg090.cpp
@@ -63,7 +63,7 @@ signed short DNG12_handler(void)
 #endif
 		if (test_skill(hero, 0x33, 6) > 0) {
 
-			GUI_output(get_tx(0x54));
+			GUI_output(get_tx(21));
 
 			and_ptr_bs(ptr + 0x87, 0xf);
 			/* turn off water trap */
@@ -72,7 +72,7 @@ signed short DNG12_handler(void)
 
 		} else {
 			/* door not detected */
-			if (GUI_bool(get_tx(0x40))) GUI_output(get_tx(0x44));
+			if (GUI_bool(get_tx(16))) GUI_output(get_tx(17));
 		}
 	} else {
 
@@ -93,8 +93,8 @@ signed short DNG12_handler(void)
 				ds_writews(DNG12_WATERTRAP_BAK, (signed short)(ds_readds(DNG12_WATERTRAP_TIMER) / MINUTES(5)));
 
 				/* warning according to water level */
-				GUI_output(ds_readds(DNG12_WATERTRAP_TIMER) == MINUTES(0) ? get_tx(0x50) :
-						(ds_readds(DNG12_WATERTRAP_TIMER) <= MINUTES(10) ? get_tx(0x4c) : get_tx(0x48)));
+				GUI_output(ds_readds(DNG12_WATERTRAP_TIMER) == MINUTES(0) ? get_tx(20) :
+						(ds_readds(DNG12_WATERTRAP_TIMER) <= MINUTES(10) ? get_tx(19) : get_tx(18)));
 
 				if (ds_readds(DNG12_WATERTRAP_TIMER) == MINUTES(0)) {
 					/* time is up, drown party */
@@ -115,7 +115,7 @@ signed short DNG12_handler(void)
 
 						/* prepare a message with the name of the NPC */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx(0x58),
+								(char*)get_tx(22),
 								(char*)get_hero(6) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -168,13 +168,13 @@ signed short DNG12_handler(void)
 	} else if (target_pos == 0x0804 && target_pos != ds_readws(DNG_HANDLED_POS)) {
 
 		/* upper Ingerimm idol */
-		GUI_output(get_tx(0x0c));
+		GUI_output(get_tx(3));
 
-		if (GUI_bool(get_tx(0x10))) {
+		if (GUI_bool(get_tx(4))) {
 
 			do {
-				i = GUI_radio(get_tx(0x14), 3,
-						get_tx(0x18), get_tx(0x1c), get_tx(0x20));
+				i = GUI_radio(get_tx(5), 3,
+						get_tx(6), get_tx(7), get_tx(8));
 			} while (i == -1);
 
 			if (i == 1) {
@@ -182,14 +182,14 @@ signed short DNG12_handler(void)
 #if !defined(__BORLANDC__)
 				D1_INFO("nichts passiert\n");
 #endif
-				GUI_output(get_tx(0x24));
+				GUI_output(get_tx(9));
 			} else if (i == 2) {
 				/* press arm */
 #if !defined(__BORLANDC__)
 				D1_INFO("Einsturz des Tunnels verhindern (buggy)\n");
 #endif
 
-				GUI_output(get_tx(0x24));
+				GUI_output(get_tx(9));
 
 				if (ds_readbs(DNG12_TUNNEL1) > 0) ds_writeb(DNG12_TUNNEL1, -1);
 				if (ds_readbs(DNG12_TUNNEL2) > 0) ds_writeb(DNG12_TUNNEL2, -1);
@@ -198,7 +198,7 @@ signed short DNG12_handler(void)
 			} else if (i == 3) {
 				/* sacrifice gold */
 
-				GUI_output(get_tx(0x28));
+				GUI_output(get_tx(10));
 
 				money = get_party_money();
 
@@ -213,17 +213,17 @@ signed short DNG12_handler(void)
 		}
 	} else if (target_pos == 0x0503 && target_pos != ds_readws(DNG_HANDLED_POS)) {
 		/* trap door */
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 		DNG_fallpit(6);
 	} else if (target_pos == 0x0406 && target_pos != ds_readws(DNG_HANDLED_POS)) {
 		/* trap door */
-		GUI_output(get_tx(0x2c));
+		GUI_output(get_tx(11));
 		ds_writews(X_TARGET, 1);
 		ds_writews(Y_TARGET, 3);
 		DNG_inc_level();
 	} else if (target_pos == 0x060d && target_pos != ds_readws(DNG_HANDLED_POS)) {
 		/* bolt trap */
-		print_msg_with_first_hero(get_tx(0x34));
+		print_msg_with_first_hero(get_tx(13));
 		sub_hero_le(hero, random_schick(6));
 	} else if (target_pos == 0x120e && target_pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG12_INGERIMM_HINT))
 	{
@@ -231,7 +231,7 @@ signed short DNG12_handler(void)
 #if !defined(__BORLANDC__)
 		D1_INFO("Untere Ingerimstatue\n");
 #endif
-		GUI_output(get_tx(0x38));
+		GUI_output(get_tx(14));
 
 	} else if (target_pos == 0x120e) {
 #if !defined(__BORLANDC__)
@@ -242,7 +242,7 @@ signed short DNG12_handler(void)
 			/* hint to secret door */
 			ds_writeb(DNG12_INGERIMM_HINT, 1);
 			ds_writeb(DNG12_INGERIMM_SACRIFICE, 0);
-			GUI_output(get_tx(0x3c));
+			GUI_output(get_tx(15));
 		}
 	} else if (target_pos == 0x130a && target_pos != ds_readws(DNG_HANDLED_POS)) {
 #if !defined(__BORLANDC__)
@@ -263,14 +263,14 @@ signed short DNG12_handler(void)
 	} else if (target_pos == 0x1108 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 3) {
 		/* water source */
 
-		if (GUI_bool(get_tx(0x40))) {
-			GUI_output(get_tx(0x44));
+		if (GUI_bool(get_tx(16))) {
+			GUI_output(get_tx(17));
 		}
 	} else if (target_pos == 0x1302 && target_pos != ds_readws(DNG_HANDLED_POS) && ds_readbs(DIRECTION) == 2) {
 #if !defined(__BORLANDC__)
 		D1_INFO("Rueckwaerts gehen\n");
 #endif
-		GUI_output(get_tx(0x5c));
+		GUI_output(get_tx(23));
 		ds_writew(X_TARGET, 1);
 		ds_writew(Y_TARGET, 3);
 		ds_writeb(DIRECTION, 3);
@@ -279,7 +279,7 @@ signed short DNG12_handler(void)
 #if !defined(__BORLANDC__)
 		D1_INFO("Rueckwaerts gehen\n");
 #endif
-		GUI_output(get_tx(0x5c));
+		GUI_output(get_tx(23));
 		ds_writew(X_TARGET, 5);
 		ds_writew(Y_TARGET, 3);
 		ds_writeb(DIRECTION, 1);
@@ -288,7 +288,7 @@ signed short DNG12_handler(void)
 #if !defined(__BORLANDC__)
 		D1_INFO("Rueckwaerts gehen\n");
 #endif
-		GUI_output(get_tx(0x5c));
+		GUI_output(get_tx(23));
 		ds_writew(X_TARGET, 3);
 		ds_writew(Y_TARGET, 1);
 		ds_writeb(DIRECTION, 0);
@@ -298,7 +298,7 @@ signed short DNG12_handler(void)
 		D1_INFO("Illusionswand und Grube\n");
 #endif
 
-		if (GUI_bool(get_tx(0x60)))
+		if (GUI_bool(get_tx(24)))
 		{
 			if (ds_readb(DNG12_OBSTACLE_ACTIVE) != 0)
 			{
@@ -308,7 +308,7 @@ signed short DNG12_handler(void)
 				{
 					/* the hero must at least fall three times into pit */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x64),
+						(char*)get_tx(25),
 						(char*)hero + HERO_NAME2,
 						Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 						Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
@@ -322,7 +322,7 @@ signed short DNG12_handler(void)
 							reworked, when BLADE.DAT should also be supported.
 					*/
 #ifdef M302de_ORIGINAL_BUGFIX
-					if (strlen((char*)get_tx(0x64)) == 219)
+					if (strlen((char*)get_tx(25)) == 219)
 					{
 						/* generate a new format string */
 						const unsigned char add_line[110] = {	0x40, 0x3c,'I','C','H',' ',
@@ -345,7 +345,7 @@ signed short DNG12_handler(void)
 								'\0'
 								};
 
-					strcpy((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)), (char*)get_tx(0x64));
+					strcpy((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)), (char*)get_tx(25));
 					strcat((char*)Real2Host(ds_readfp(TEXT_OUTPUT_BUF)), (const char*)add_line);
 
 					sprintf((char*)Real2Host(ds_readfp(DTP2)),
@@ -359,7 +359,7 @@ signed short DNG12_handler(void)
 					}
 #else
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x7c),
+						(char*)get_tx(31),
 						(char*)hero + HERO_NAME2,
 						Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 						Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)),
@@ -409,7 +409,7 @@ signed short DNG12_handler(void)
 					}
 #else
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x80),
+						(char*)get_tx(32),
 						(char*)hero + HERO_NAME2);
 #endif
 				}
@@ -421,7 +421,7 @@ signed short DNG12_handler(void)
 				ds_writew(Y_TARGET, ds_readw(Y_TARGET_BAK));
 			} else {
 				/* pass */
-				GUI_output(get_tx(0x68));
+				GUI_output(get_tx(26));
 			}
 		} else {
 			ds_writew(X_TARGET, ds_readw(X_TARGET_BAK));
@@ -432,17 +432,17 @@ signed short DNG12_handler(void)
 
 		if (test_skill(hero, 0x33, 2) > 0) {
 
-			if (GUI_bool(get_tx(0x70))) {
+			if (GUI_bool(get_tx(28))) {
 				if (test_skill(hero, 0x30, 0) <= 0) {
 					/* defusing trap failed */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x74),
+						(char*)get_tx(29),
 						(char*)hero + HERO_NAME2);
 					sub_hero_le(hero , dice_roll(3, 6, 0));
 				} else {
 					/* trap defused */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x78),
+						(char*)get_tx(30),
 						(char*)hero + HERO_NAME2,
 						(char*)hero + HERO_NAME2);
 
@@ -454,7 +454,7 @@ signed short DNG12_handler(void)
 			}
 		} else {
 			/* sprung trap */
-			GUI_output(get_tx(0x6c));
+			GUI_output(get_tx(27));
 			sub_group_le(dice_roll(3, 6, 0));
 		}
 	} else if (target_pos == 0x0d0f && target_pos != ds_readws(DNG_HANDLED_POS)) {
@@ -474,11 +474,11 @@ signed short DNG12_handler(void)
 void DNG_clear_corridor(Bit8u *ptr)
 {
 	/* ask if the corridor should be cleared */
-	if (GUI_bool(get_tx(0x4))) {
+	if (GUI_bool(get_tx(1))) {
 
 		/* clear the corridor */
 
-		GUI_output(get_tx(0x8));
+		GUI_output(get_tx(2));
 
 		timewarp(DAYS(1));
 
@@ -510,7 +510,7 @@ void DNG_oberorken_chest(RealPt chest)
 void DNG12_fight_intro(signed short fight_id)
 {
 	if (fight_id == 141) {
-		GUI_output(get_tx(0x30));
+		GUI_output(get_tx(12));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg091.cpp
+++ b/src/custom/schick/rewrite_m302de/seg091.cpp
@@ -48,7 +48,7 @@ signed short DNG13_handler(void)
 		hero = get_hero(get_random_hero());
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x48),
+			(char*)get_tx(18),
 			(char*)hero + HERO_NAME2);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -58,7 +58,7 @@ signed short DNG13_handler(void)
 
 	if (pos == 0x90d && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG13_LANTERN_FLAG))
 	{
-		if (GUI_bool(get_tx(0x04)))
+		if (GUI_bool(get_tx(1)))
 		{
 			ds_writeb(DNG13_LANTERN_FLAG, 1);
 
@@ -68,41 +68,41 @@ signed short DNG13_handler(void)
 	} else if ((pos == 0x10c || pos == 0xe06 || pos == 0xe0d || pos == 0x301) &&
 			pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x08));
+		GUI_output(get_tx(2));
 
 	} else if (pos == 0x20d && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_dialog_na(60, get_tx(0x0c));
+		GUI_dialog_na(60, get_tx(3));
 
 	} else if (pos == 0x30c && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		DNG13_unblock_passage(get_tx(0x10), p_datseg + DNG13_PASSAGE1_FLAG);
+		DNG13_unblock_passage(get_tx(4), p_datseg + DNG13_PASSAGE1_FLAG);
 
 	} else if (pos == 0x409 &&
 			 (pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
 			ds_readbs(DIRECTION) == WEST)
 	{
-		GUI_output(get_tx(0x18));
+		GUI_output(get_tx(6));
 		ds_writeb(DIRECTION_BAK, ds_readbs(DIRECTION));
 
 	} else if (pos == 0xa02 &&
 			 (pos != ds_readws(DNG_HANDLED_POS) || ds_readbs(DIRECTION) != ds_readbs(DIRECTION_BAK)) &&
 			ds_readbs(DIRECTION) == EAST)
 	{
-		GUI_output(get_tx(0x18));
+		GUI_output(get_tx(6));
 		ds_writeb(DIRECTION_BAK, ds_readbs(DIRECTION));
 
 	} else if (pos == 0x509 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		DNG13_unblock_passage(get_tx(0x1c), p_datseg + DNG13_PASSAGE2_FLAG);
+		DNG13_unblock_passage(get_tx(7), p_datseg + DNG13_PASSAGE2_FLAG);
 
 	} else if (pos == 0x209 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		loot_multi_chest(p_datseg + DNG13_CHEST_EQUIPS, get_tx(0x20));
+		loot_multi_chest(p_datseg + DNG13_CHEST_EQUIPS, get_tx(8));
 
 	} else if (pos == 0xa06 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		DNG13_unblock_passage(get_tx(0x1c), p_datseg + DNG13_PASSAGE3_FLAG);
+		DNG13_unblock_passage(get_tx(7), p_datseg + DNG13_PASSAGE3_FLAG);
 
 	} else if (pos == 0xb05 && pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -110,15 +110,15 @@ signed short DNG13_handler(void)
 
 	} else if (pos == 0xa0a && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x30));
+		GUI_output(get_tx(12));
 
 	} else if (pos == 0xe09 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		DNG13_unblock_passage(get_tx(0x1c), p_datseg + DNG13_PASSAGE4_FLAG);
+		DNG13_unblock_passage(get_tx(7), p_datseg + DNG13_PASSAGE4_FLAG);
 
 	} else if (pos == 0x703 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		DNG13_unblock_passage(get_tx(0x1c), p_datseg + DNG13_PASSAGE5_FLAG);
+		DNG13_unblock_passage(get_tx(7), p_datseg + DNG13_PASSAGE5_FLAG);
 
 	} else if (pos == 0x401 && pos != ds_readws(DNG_HANDLED_POS))
 	{
@@ -126,13 +126,13 @@ signed short DNG13_handler(void)
 
 	} else if (pos == 0x505 && pos != ds_readws(DNG_HANDLED_POS))
 	{
-		GUI_output(get_tx(0x3c));
+		GUI_output(get_tx(15));
 
-		GUI_output(get_tx(0x40));
+		GUI_output(get_tx(16));
 
 	} else if (pos == 0x407 && pos != ds_readws(DNG_HANDLED_POS) && !ds_readb(DNG13_MONEY_FLAG))
 	{
-		GUI_output(get_tx(0x44));
+		GUI_output(get_tx(17));
 
 		ds_writeb(DNG13_MONEY_FLAG, 1);
 
@@ -201,7 +201,7 @@ void DNG13_unblock_passage(Bit8u* text, Bit8u* flag)
 			/* if all items are available, it takes 2 hours instead of 6 */
 			timewarp(!has_items ? HOURS(6) : HOURS(2));
 
-			GUI_output(get_tx(0x14));
+			GUI_output(get_tx(5));
 
 			/* mark this passage as free */
 			host_writeb(flag, 1);
@@ -216,7 +216,7 @@ void DNG13_unblock_passage(Bit8u* text, Bit8u* flag)
 
 void DNG13_corpse0(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x24), p_datseg + DNG13_CORPSE0_FLAG);
+	loot_corpse(ptr, get_tx(9), p_datseg + DNG13_CORPSE0_FLAG);
 }
 
 void DNG13_chest0(RealPt chest)
@@ -226,14 +226,14 @@ void DNG13_chest0(RealPt chest)
 	bak = (RealPt)host_readd(Real2Host(chest) + 0xb);
 	host_writed(Real2Host(chest) + 0xb, (Bit32u)RealMake(datseg, DNG13_CHEST0_CONTENT));
 
-	loot_chest(Real2Host(chest), get_tx(0x28), get_tx(0x2c));
+	loot_chest(Real2Host(chest), get_tx(10), get_tx(11));
 
 	host_writed(Real2Host(chest) + 0xb, (Bit32u)bak);
 }
 
 void DNG13_corpse1(RealPt ptr)
 {
-	loot_corpse(ptr, get_tx(0x38), p_datseg + DNG13_CORPSE1_FLAG);
+	loot_corpse(ptr, get_tx(14), p_datseg + DNG13_CORPSE1_FLAG);
 }
 
 void DNG13_chest1(RealPt chest)
@@ -243,7 +243,7 @@ void DNG13_chest1(RealPt chest)
 	bak = (RealPt)host_readd(Real2Host(chest) + 0xb);
 	host_writed(Real2Host(chest) + 0xb, (Bit32u)RealMake(datseg, DNG13_CHEST1_CONTENT));
 
-	loot_chest(Real2Host(chest), get_tx(0x28), get_tx(0x2c));
+	loot_chest(Real2Host(chest), get_tx(10), get_tx(11));
 
 	host_writed(Real2Host(chest) + 0xb, (Bit32u)bak);
 }
@@ -257,7 +257,7 @@ void DNG13_fight_intro(signed short fight_id)
 {
 	if (fight_id == FIGHTS_DPRE10_1)
 	{
-		GUI_output(get_tx(0x34));
+		GUI_output(get_tx(13));
 	}
 }
 
@@ -285,11 +285,11 @@ void DNG13_collapsing_ceiling(void)
 	if (fails > 1)
 	{
 		/* at least two heros failed in the skill test */
-		GUI_output(get_tx(0x4c));
+		GUI_output(get_tx(19));
 
 		sub_group_le(dice_roll(1, 6, 4));
 
-		GUI_output(get_tx(0x50));
+		GUI_output(get_tx(20));
 
 		/* check if the group has ALL of these items:
 			SHOVEL, HOE, CROWBAR, FRANCESCA
@@ -335,11 +335,11 @@ void DNG13_collapsing_ceiling_easy(void)
 	if (fails > 1)
 	{
 		/* at least two heros failed in the skill test */
-		GUI_output(get_tx(0x4c));
+		GUI_output(get_tx(19));
 
 		sub_group_le(dice_roll(1, 6, 5));
 
-		GUI_output(get_tx(0x50));
+		GUI_output(get_tx(20));
 
 		/* check if the group has ALL of these items:
 			SHOVEL, HOE, CROWBAR, FRANCESCA

--- a/src/custom/schick/rewrite_m302de/seg092.cpp
+++ b/src/custom/schick/rewrite_m302de/seg092.cpp
@@ -34,7 +34,7 @@ namespace M302de {
 void chest_protected_normal(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x818));
+	print_msg_with_first_hero(get_ttx(518));
 
 	/* the first hero gets wounded with 1W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), random_schick(6));
@@ -43,13 +43,13 @@ void chest_protected_normal(void)
 void chest_closed(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x81c));
+	print_msg_with_first_hero(get_ttx(519));
 }
 
 void chest_protected_heavy(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x820));
+	print_msg_with_first_hero(get_ttx(520));
 
 	/* the first hero gets wounded with 2W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(2, 6, 0));
@@ -58,7 +58,7 @@ void chest_protected_heavy(void)
 void chest_poisoned1(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x820));
+	print_msg_with_first_hero(get_ttx(520));
 
 	/* the first hero gets wounded with 2W6 */
 	sub_hero_le(Real2Host((RealPt)(ds_writed(MAIN_ACTING_HERO, (Bit32u)get_first_hero_available_in_group()))), dice_roll(2, 6, 0));
@@ -70,7 +70,7 @@ void chest_poisoned1(void)
 void chest_poisoned2(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x820));
+	print_msg_with_first_hero(get_ttx(520));
 
 	/* the first hero gets wounded with 2W6 */
 	sub_hero_le(Real2Host((RealPt)(ds_writed(MAIN_ACTING_HERO, (Bit32u)get_first_hero_available_in_group()))), dice_roll(2, 6, 0));
@@ -82,7 +82,7 @@ void chest_poisoned2(void)
 void chest_poisoned3(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x820));
+	print_msg_with_first_hero(get_ttx(520));
 
 	/* the first hero gets wounded with 1W6 */
 	sub_hero_le(Real2Host((RealPt)(ds_writed(MAIN_ACTING_HERO, (Bit32u)get_first_hero_available_in_group()))), dice_roll(1, 6, 0));
@@ -94,7 +94,7 @@ void chest_poisoned3(void)
 void chest_protected_brutal(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x820));
+	print_msg_with_first_hero(get_ttx(520));
 
 	/* the first hero gets wounded with 4W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(4, 6, 0));
@@ -103,7 +103,7 @@ void chest_protected_brutal(void)
 void chest_stoned(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0xc20));
+	print_msg_with_first_hero(get_ttx(776));
 
 	/* save pointer of the first hero */
 	ds_writed(MAIN_ACTING_HERO, (Bit32u)get_first_hero_available_in_group());
@@ -115,7 +115,7 @@ void chest_stoned(void)
 void chest_ignifax_normal(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0xc24));
+	print_msg_with_first_hero(get_ttx(777));
 
 	/* the first hero gets wounded with 2W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(2, 6, 0));
@@ -124,7 +124,7 @@ void chest_ignifax_normal(void)
 void chest_ignifax_brutal(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0xc24));
+	print_msg_with_first_hero(get_ttx(777));
 
 	/* the first hero gets wounded with 4W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(4, 6, 0));
@@ -133,7 +133,7 @@ void chest_ignifax_brutal(void)
 void chest_ignifax_heavy(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0xc24));
+	print_msg_with_first_hero(get_ttx(777));
 
 	/* the first hero gets wounded with 3W6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(3, 6, 0));
@@ -142,7 +142,7 @@ void chest_ignifax_heavy(void)
 void chest_crossbow_bolts(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0xc50));
+	print_msg_with_first_hero(get_ttx(788));
 
 	/* the first hero gets wounded with 2W6+6 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(2, 6, 6));
@@ -167,14 +167,14 @@ void chest_cursed(void)
 		}
 
 		/* print a message */
-		print_msg_with_first_hero(get_ttx(0x8cc));
+		print_msg_with_first_hero(get_ttx(563));
 	}
 }
 
 void chest_fulminictus(void)
 {
 	/* a protected chest */
-	print_msg_with_first_hero(get_ttx(0x8d0));
+	print_msg_with_first_hero(get_ttx(564));
 
 	/* the first hero gets wounded with 4W6+5 */
 	sub_hero_le(Real2Host(get_first_hero_available_in_group()), dice_roll(4, 6, 5));
@@ -212,12 +212,12 @@ void loot_simple_chest(Bit8u *chest)
 
 		if (item_nr == 0) {
 			/* this chest is empty */
-			GUI_output(get_ttx(0x828));
+			GUI_output(get_ttx(522));
 			break;
 		} else {
 
 			/* show radio menu with item names */
-			item_nr = GUI_radio(get_ttx(0x824), (signed char)item_nr,
+			item_nr = GUI_radio(get_ttx(521), (signed char)item_nr,
 						names[0], names[1], names[2], names[3],
 						names[4], names[5], names[6], names[7],
 						names[8], names[9], names[10], names[11],
@@ -455,7 +455,7 @@ void seg092_06b4(signed short a1)
 			/* There is money in the chest */
 			make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), host_readw(Real2Host(chest_ptr) + 17));
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc64),
+				(char*)get_ttx(793),
 				(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 			GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -486,7 +486,7 @@ void use_lockpicks_on_chest(RealPt chest_ptr)
 			if (l_di == -99) {
 				/* unlucky, your lockpicks break... */
 
-				print_msg_with_first_hero(get_ttx(0x854));
+				print_msg_with_first_hero(get_ttx(533));
 				or_ptr_bs(hero + (HERO_ITEM_HEAD+4) + 14 * l_si, 1);
 
 				/* ... and you trigger the trap */
@@ -544,10 +544,10 @@ void use_lockpicks_on_chest(RealPt chest_ptr)
 			}
 
 		} else {
-			print_msg_with_first_hero(get_ttx(0x84c));
+			print_msg_with_first_hero(get_ttx(531));
 		}
 	} else {
-		print_msg_with_first_hero(get_ttx(0x848));
+		print_msg_with_first_hero(get_ttx(530));
 	}
 }
 
@@ -629,7 +629,7 @@ void loot_multi_chest(Bit8u *chest, Bit8u *msg)
 				len = strlen(temp_str);
 
 				do {
-					i = (item_cnt = chest[item_no + 1]) > 1 ? GUI_input(get_ttx(0x944), len) : item_cnt;
+					i = (item_cnt = chest[item_no + 1]) > 1 ? GUI_input(get_ttx(593), len) : item_cnt;
 
 				} while (i < 0);
 

--- a/src/custom/schick/rewrite_m302de/seg093.cpp
+++ b/src/custom/schick/rewrite_m302de/seg093.cpp
@@ -105,20 +105,20 @@ signed short do_travel_mode(void)
 					i = 0;
 					while ((l_di = host_readb(Real2Host(host_readd(dir_sign_ptr + 2)) + i)) != 255)
 					{
-						destinations_tab[i] = get_ttx(4 * (0xeb + ds_writebs(TRV_MENU_TOWNS + i,
+						destinations_tab[i] = get_ttx(235 + ds_writebs(TRV_MENU_TOWNS + i,
 						    (answer = ds_readb((ROUTES_TAB - 9) + 9 * l_di)) != ds_readbs(CURRENT_TOWN) ?
-						    (signed char) answer : ds_readbs((ROUTES_TAB - 9 + 1) + 9 * l_di))));
+						    (signed char) answer : ds_readbs((ROUTES_TAB - 9 + 1) + 9 * l_di)));
 
 						i++;
 					}
 
 					ds_writeb(TRV_MENU_TOWNS + i, ds_readbs(CURRENT_TOWN));
-					destinations_tab[i] = get_ttx(0x994);
+					destinations_tab[i] = get_ttx(613);
 					i++;
 
 					sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0x884),
-						(char*)get_ttx(4 * (0xeb + ds_readbs(CURRENT_TOWN))));
+						(char*)get_ttx(545),
+						(char*)get_ttx(235 + ds_readbs(CURRENT_TOWN)));
 
 					tw_bak = ds_readws(TEXTBOX_WIDTH);
 					ds_writew(TEXTBOX_WIDTH, 4);
@@ -150,7 +150,7 @@ signed short do_travel_mode(void)
 					if (!get_current_season() &&
 						(route_id == 31 || route_id == 41 || route_id == 47 || route_id == 48 || route_id == 49))
 					{
-						GUI_input(get_tx(0x114), 0);
+						GUI_input(get_tx(69), 0);
 						break;
 					}
 
@@ -224,7 +224,7 @@ signed short do_travel_mode(void)
 
 						set_and_spin_lock();
 
-						GUI_input(get_tx(4 * l4), 0);
+						GUI_input(get_tx(l4), 0);
 
 						ds_writew(BASEPOS_X, l6);
 						ds_writew(BASEPOS_Y, l7);

--- a/src/custom/schick/rewrite_m302de/seg094.cpp
+++ b/src/custom/schick/rewrite_m302de/seg094.cpp
@@ -247,14 +247,14 @@ void TM_func1(signed short route_no, signed short backwards)
 		{
 			if (!ds_readb(FORCEDMARCH_TIMER))
 			{
-				answer = GUI_radio(get_ttx(0xcbc), 3,
-							get_tx(0x128),
-							get_ttx(0xcc0),
-							get_ttx(0x994));
+				answer = GUI_radio(get_ttx(815), 3,
+							get_tx(74),
+							get_ttx(816),
+							get_ttx(613));
 			} else {
-				answer = GUI_radio(get_ttx(0xcbc), 2,
-							get_ttx(0xcc0),
-							get_ttx(0x994));
+				answer = GUI_radio(get_ttx(815), 2,
+							get_ttx(816),
+							get_ttx(613));
 			}
 
 			if (answer == 1 && !ds_readb(FORCEDMARCH_TIMER))
@@ -362,7 +362,7 @@ void TM_func1(signed short route_no, signed short backwards)
 				load_map();
 			}
 
-			GUI_input(get_tx(0x118), 0);
+			GUI_input(get_tx(70), 0);
 
 			ds_writeb(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -437,7 +437,7 @@ void TM_func1(signed short route_no, signed short backwards)
 			if (ds_readws(REQUEST_REFRESH) == 2 && route_no != 59)
 			{
 			    /* Return or continue? */
-				if (GUI_radio(get_tx(0x11c), 2, get_tx(0x120), get_tx(0x124)) == 2)
+				if (GUI_radio(get_tx(71), 2, get_tx(72), get_tx(73)) == 2)
 				{
 					ds_writew(TRV_RETURN, ds_readws(TRV_RETURN) == 0 ? 1 : -1);
 
@@ -516,21 +516,21 @@ signed short TM_unused1(RealPt dir_sign_ptr, signed short old_route_no)
 					{
 						if (route_no2 != route_no1)
 						{
-							destinations_tab[town_i++] = get_ttx(4 * (0xeb + ds_writebs(TRV_MENU_TOWNS + town_i,
+							destinations_tab[town_i++] = get_ttx(235 + ds_writebs(TRV_MENU_TOWNS + town_i,
                                 ((answer = ds_readb((ROUTES_TAB - 9) + 9 * route_id)) != ds_readbs(CURRENT_TOWN) ?
                                     (unsigned char)answer : ds_readb((ROUTES_TAB - 9 + 1) + 9 * route_id))
-                            )));
+                            ));
 						}
 						route_no2++;
 					}
 
 					ds_writeb(TRV_MENU_TOWNS + town_i, (signed char)town);
-					destinations_tab[town_i] = get_ttx(0x88c);
+					destinations_tab[town_i] = get_ttx(547);
 					town_i++;
 					ds_writefp(TM_UNUSED1_PTR, dir_sign_ptr);
 
 					set_textbox_positions(town);
-					answer = GUI_radio(get_ttx(0x888), (signed char)town_i,
+					answer = GUI_radio(get_ttx(546), (signed char)town_i,
 								destinations_tab[0],
 								destinations_tab[1],
 								destinations_tab[2],

--- a/src/custom/schick/rewrite_m302de/seg095.cpp
+++ b/src/custom/schick/rewrite_m302de/seg095.cpp
@@ -116,7 +116,7 @@ void npc_farewell(void)
 		case NPC_NARIELL: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x14, 0x1f, 0xe2,
-					get_ttx(0xbc4), get_tx(0x24));
+					get_ttx(753), get_tx(9));
 			break;
 		}
 		case NPC_HARIKA: {
@@ -128,7 +128,7 @@ void npc_farewell(void)
 					ds_readb(CURRENT_TOWN) == 0x11) {
 
 					remove_npc(0x16, 0x1f, 0xe3,
-						get_ttx(0xbc8), get_tx(0x4c));
+						get_ttx(754), get_tx(19));
 
 					hero_i = get_hero(0);
 					for (i = 0; i < 6; i++, hero_i += SIZEOF_HERO) {
@@ -148,25 +148,25 @@ void npc_farewell(void)
 		case NPC_CURIAN: {
 			if (ds_readws(NPC_MONTHS) >= 6)
 				remove_npc(0x19, 0x40, 0xe4,
-					get_ttx(0xbcc), get_tx(0x74));
+					get_ttx(755), get_tx(29));
 			break;
 		}
 		case NPC_ARDORA: {
 			if (ds_readws(NPC_MONTHS) >= 1)
 				remove_npc(0x15, 0x1f, 0xe5,
-					get_ttx(0xbd0), get_tx(0xac));
+					get_ttx(756), get_tx(43));
 			break;
 		}
 		case NPC_GARSVIK: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x17, 0x1f, 0xe6,
-					get_ttx(0xbd4), get_tx(0xd4));
+					get_ttx(757), get_tx(53));
 			break;
 		}
 		case NPC_ERWO: {
 			if (ds_readws(NPC_MONTHS) >= 2)
 				remove_npc(0x18, 0x1f, 0xe7,
-					get_ttx(0xbd8), get_tx(0xfc));
+					get_ttx(758), get_tx(63));
 			break;
 		}
 	}
@@ -189,23 +189,23 @@ void npc_nariell(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbc4), get_tx(0x00),
+				get_ttx(753), get_tx(0),
 				3,
-				get_tx(0x04), get_tx(0x08),
-				get_tx(0x0c));
+				get_tx(1), get_tx(2),
+				get_tx(3));
 	} while (answer == -1);
 
 	/* process the answer */
 	if (answer == 1) {
 		GUI_dialogbox((RealPt)ds_readd(DTP2),
-			get_ttx(0xbc4), get_tx(0x10), 0);
+			get_ttx(753), get_tx(4), 0);
 	} else {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbc4),
-					(answer == 2) ? get_tx(0x14): get_tx(0x18),
-					2, get_tx(0x1c),
-					get_tx(0x20));
+					get_ttx(753),
+					(answer == 2) ? get_tx(5): get_tx(6),
+					2, get_tx(7),
+					get_tx(8));
 		} while (answer == -1);
 
 		/* add nariell */
@@ -231,15 +231,15 @@ void npc_harika(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbc8), get_tx(0x28),
+				get_ttx(754), get_tx(10),
 				3,
-				get_tx(0x2c), get_tx(0x30),
-				get_tx(0x34));
+				get_tx(11), get_tx(12),
+				get_tx(13));
 	} while (answer == -1);
 
 	if (answer == 1) {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbc8),
-			get_tx(0x38), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(754),
+			get_tx(14), 0);
 	} else if (answer == 2) {
 		money = get_party_money();
 
@@ -247,9 +247,9 @@ void npc_harika(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbc8), get_tx(0x3c),
+					get_ttx(754), get_tx(15),
 					answer,
-					get_tx(0x44), get_tx(0x48));
+					get_tx(17), get_tx(18));
 		} while (answer == -1);
 
 		/* hire her for 20D */
@@ -268,9 +268,9 @@ void npc_harika(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbc8), get_tx(0x40),
+					get_ttx(754), get_tx(16),
 					answer,
-					get_tx(0x44), get_tx(0x48));
+					get_tx(17), get_tx(18));
 		} while (answer == -1);
 
 		/* hire her for 15D */
@@ -300,22 +300,22 @@ void npc_curian(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbcc), get_tx(0x50),
+				get_ttx(755), get_tx(20),
 				3,
-				get_tx(0x54), get_tx(0x58),
-				get_tx(0x5c));
+				get_tx(21), get_tx(22),
+				get_tx(23));
 	} while (answer == -1);
 
 	if (answer == 1) {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbcc),
-			get_tx(0x60), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(755),
+			get_tx(24), 0);
 	} else {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbcc),
-					(answer == 2) ? get_tx(0x64): get_tx(0x68),
+					get_ttx(755),
+					(answer == 2) ? get_tx(25): get_tx(26),
 					2,
-					get_tx(0x6c), get_tx(0x70));
+					get_tx(27), get_tx(28));
 		} while (answer == -1);
 
 		/* add NPC */
@@ -341,55 +341,55 @@ void npc_ardora(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbd0), get_tx(0x78),
+				get_ttx(756), get_tx(30),
 				3,
-				get_tx(0x7c), get_tx(0x80),
-				get_tx(0x84));
+				get_tx(31), get_tx(32),
+				get_tx(33));
 	} while (answer == -1);
 
 	if (answer == 1) {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbd0), get_tx(0x88),
+					get_ttx(756), get_tx(34),
 					2,
-					get_tx(0x8c), get_tx(0x90));
+					get_tx(35), get_tx(36));
 		} while (answer == -1);
 
 		if (answer == 2) {
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd0),
-				get_tx(0x94), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(756),
+				get_tx(37), 0);
 		} else {
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-						get_ttx(0xbd0), get_tx(0x9c),
+						get_ttx(756), get_tx(39),
 						2,
-						get_tx(0xa0), get_tx(0xa4));
+						get_tx(40), get_tx(41));
 			} while (answer == -1);
 
 			if (answer == 1) {
 				add_npc(0xe5);
 			} else {
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd0),
-					get_tx(0xa8), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(756),
+					get_tx(42), 0);
 			}
 		}
 	} else {
 		if (answer == 2) {
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd0),
-				get_tx(0x98), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(756),
+				get_tx(38), 0);
 		}
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd0),
-					get_tx(0x9c), 2,
-					get_tx(0xa0), get_tx(0xa4));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(756),
+					get_tx(39), 2,
+					get_tx(40), get_tx(41));
 		} while (answer == -1);
 
 		if (answer == 1) {
 			add_npc(0xe5);
 		} else {
-			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd0),
-				get_tx(0xa8), 0);
+			GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(756),
+				get_tx(42), 0);
 		}
 	}
 
@@ -410,22 +410,22 @@ void npc_garsvik(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbd4), get_tx(0xb0),
+				get_ttx(757), get_tx(44),
 				3,
-				get_tx(0xb4), get_tx(0xb8),
-				get_tx(0xbc));
+				get_tx(45), get_tx(46),
+				get_tx(47));
 	} while (answer == -1);
 
 	if (answer == 1) {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd4),
-			get_tx(0xc0), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(757),
+			get_tx(48), 0);
 	} else {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbd4),
-					(answer == 2) ? get_tx(0xc4): get_tx(0xc8),
+					get_ttx(757),
+					(answer == 2) ? get_tx(49): get_tx(50),
 					2,
-					get_tx(0xcc), get_tx(0xd0));
+					get_tx(51), get_tx(52));
 		} while (answer == -1);
 
 		/* add NPC */
@@ -451,22 +451,22 @@ void npc_erwo(void)
 	/* show dialog window */
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-				get_ttx(0xbd8), get_tx(0xd8),
+				get_ttx(758), get_tx(54),
 				3,
-				get_tx(0xdc), get_tx(0xe0),
-				get_tx(0xe4));
+				get_tx(55), get_tx(56),
+				get_tx(57));
 	} while (answer == -1);
 
 	if (answer == 1) {
-		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(0xbd8),
-			get_tx(0xe8), 0);
+		GUI_dialogbox((RealPt)ds_readd(DTP2), get_ttx(758),
+			get_tx(58), 0);
 	} else {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
-					get_ttx(0xbd8),
-					(answer == 2) ? get_tx(0xec): get_tx(0xf0),
+					get_ttx(758),
+					(answer == 2) ? get_tx(59): get_tx(60),
 					2,
-					get_tx(0xf4), get_tx(0xf8));
+					get_tx(61), get_tx(62));
 		} while (answer == -1);
 
 		/* add NPC */

--- a/src/custom/schick/rewrite_m302de/seg097.cpp
+++ b/src/custom/schick/rewrite_m302de/seg097.cpp
@@ -430,7 +430,7 @@ signed short GUI_bool(Bit8u *text)
 
 	ds_writew(GUI_BOOL_FLAG, 1);
 
-	ret_radio = GUI_radio(text, 2, get_ttx(0x08), get_ttx(0x0c));
+	ret_radio = GUI_radio(text, 2, get_ttx(2), get_ttx(3));
 	ds_writew(GUI_BOOL_FLAG, 0);
 
 	return (ret_radio == 1) ? 1 : 0;

--- a/src/custom/schick/rewrite_m302de/seg098.cpp
+++ b/src/custom/schick/rewrite_m302de/seg098.cpp
@@ -364,7 +364,7 @@ signed short use_magic(RealPt hero)
 
 	retval = 0;
 
-	answer = GUI_radio(get_ttx(0x524), 3, get_ttx(0x4dc), get_ttx(0x4e0), get_ttx(0x354));
+	answer = GUI_radio(get_ttx(329), 3, get_ttx(311), get_ttx(312), get_ttx(213));
 
 	if (answer != -1) {
 
@@ -377,7 +377,7 @@ signed short use_magic(RealPt hero)
 
 
 				if ((thonny_pos = get_item_pos(Real2Host(hero), 131)) == -1) {
-					GUI_output(get_ttx(0xc58));
+					GUI_output(get_ttx(790));
 					return 0;
 				}
 			} else {
@@ -386,7 +386,7 @@ signed short use_magic(RealPt hero)
 			}
 
 			/* Aks how many LE should be used */
-			le = GUI_input(get_ttx(0x534), 2);
+			le = GUI_input(get_ttx(333), 2);
 
 			if (le != -1) {
 				retval = 2;
@@ -416,7 +416,7 @@ signed short use_magic(RealPt hero)
 				} else {
 					/* Failed, print only a message */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc6c),
+						(char*)get_ttx(795),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -429,12 +429,12 @@ signed short use_magic(RealPt hero)
 
 			if (host_readbs(Real2Host(hero) + HERO_TYPE) != HERO_TYPE_MAGE) {
 				/* only for mages */
-				GUI_output(get_ttx(0x64c));
+				GUI_output(get_ttx(403));
 				return 0;
 			}
 
 			if (host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL) == 7) {
-				GUI_output(get_ttx(0x53c));
+				GUI_output(get_ttx(335));
 			} else {
 
 				if (ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)) <= host_readws(Real2Host(hero) + HERO_AE)) {
@@ -453,7 +453,7 @@ signed short use_magic(RealPt hero)
 
 						/* print a message */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x54c),
+							(char*)get_ttx(339),
 							host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL) + 1);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -472,7 +472,7 @@ signed short use_magic(RealPt hero)
 						timewarp(0x6978);
 					} else {
 						/* Failed */
-						GUI_output(get_ttx(0x548));
+						GUI_output(get_ttx(338));
 
 						/* only half of the AE costs */
 						sub_ae_splash(Real2Host(hero), ds_readbs((STAFFSPELL_DESCRIPTIONS + 4) + 6 * host_readbs(Real2Host(hero) + HERO_STAFFSPELL_LVL)) / 2);
@@ -482,7 +482,7 @@ signed short use_magic(RealPt hero)
 					}
 				} else {
 					/* not enough AE */
-					GUI_output(get_ttx(0x544));
+					GUI_output(get_ttx(337));
 				}
 			}
 
@@ -551,34 +551,34 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 
 	/* only for magic users */
 	if (host_readbs(hero + HERO_TYPE) < 7) {
-		GUI_output(get_ttx(0x528));
+		GUI_output(get_ttx(330));
 		return -2;
 	}
 
 	if (show_vals == 1) {
 
-		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x334));
+		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(205));
 
 		if (host_readbs(hero + HERO_SP_RISE) > 1) {
-			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x624));
+			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(393));
 		}
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x330),
-			(host_readbs(hero + HERO_SP_RISE) > 1) ? get_ttx(0x4c4) : get_ttx(0x4c0),
+			(char*)get_ttx(204),
+			(host_readbs(hero + HERO_SP_RISE) > 1) ? get_ttx(305) : get_ttx(304),
 			host_readbs(hero + HERO_SP_RISE),
 			Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 		answer1 = GUI_radio(Real2Host(ds_readd(DTP2)), 12,
-					get_ttx(0x300), get_ttx(0x304),
-					get_ttx(0x308), get_ttx(0x30c),
-					get_ttx(0x310), get_ttx(0x314),
-					get_ttx(0x318), get_ttx(0x31c),
-					get_ttx(0x190), get_ttx(0x324),
-					get_ttx(0x328), get_ttx(0x32c)) - 1;
+					get_ttx(192), get_ttx(193),
+					get_ttx(194), get_ttx(195),
+					get_ttx(196), get_ttx(197),
+					get_ttx(198), get_ttx(199),
+					get_ttx(100), get_ttx(201),
+					get_ttx(202), get_ttx(203)) - 1;
 	} else {
 
-		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x360));
+		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(216));
 
 		for (l_di = 0; l_di < 12; l_di++) {
 
@@ -589,7 +589,7 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 
 			sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 				(ones.a[l_di] != 0) ? str.a : col_str.a,
-				get_ttx(4 * (l_di + 192)));
+				get_ttx(l_di + 192));
 		}
 
 		answer1 = GUI_radio(Real2Host(ds_readd(DTP2)), 12,
@@ -613,7 +613,7 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 			/* this cant use any spells of this class */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x8bc),
+				(char*)get_ttx(559),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -633,7 +633,7 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 
 					sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 						(char*)str_val.a,
-						(char*)get_ttx(4 * (first_spell + l_di + 106)),
+						(char*)get_ttx(first_spell + l_di + 106),
 						host_readbs(hero + HERO_SPELLS + first_spell + l_di));
 				} else if (
 					(((ds_readw(IN_FIGHT) != 0) && (ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * (first_spell + l_di)) == 1)) ||
@@ -644,26 +644,26 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 					if (show_vals == 2) {
 						sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 							(char*)str_val.a,
-							(char*)get_ttx(4 * (first_spell + l_di + 106)),
+							(char*)get_ttx(first_spell + l_di + 106),
 							host_readbs(hero + HERO_SPELLS + first_spell + l_di));
 					} else {
 						sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 							(char*)str.a,
-							(char*)get_ttx(4 * (first_spell + l_di + 106)));
+							(char*)get_ttx(first_spell + l_di + 106));
 					}
 				} else if (show_vals == 2) {
 					sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 						(char*)col_str_val.a,
-						(char*)get_ttx(4 * (first_spell + l_di + 106)),
+						(char*)get_ttx(first_spell + l_di + 106),
 						host_readbs(hero + HERO_SPELLS + first_spell + l_di));
 				} else {
 					sprintf((char*)Real2Host(ds_readd(RADIO_NAME_LIST + 4 * l_di)),
 						(char*)col_str.a,
-						(char*)get_ttx(4 * (first_spell + l_di + 106)));
+						(char*)get_ttx(first_spell + l_di + 106));
 				}
 			}
 
-			retval = GUI_radio(get_ttx(0x364), ds_readbs((SPELLS_INDEX + 1) + 2 * answer1),
+			retval = GUI_radio(get_ttx(217), ds_readbs((SPELLS_INDEX + 1) + 2 * answer1),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x00))),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x04))),
 					Real2Host(ds_readd((RADIO_NAME_LIST + 0x08))),
@@ -686,7 +686,7 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 					(show_vals == 0))
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8c0),
+						(char*)get_ttx(560),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -702,13 +702,13 @@ signed short select_spell(Bit8u *hero, signed short show_vals)
 				(ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * retval) == 1) &&
 				(show_vals == 0))
 			{
-				GUI_output(get_ttx(0x93c));
+				GUI_output(get_ttx(591));
 				retval = -2;
 			} else {
 				if ((ds_readw(IN_FIGHT) != 0) &&
 					(ds_readbs((SPELL_DESCRIPTIONS + 5) + 10 * retval) == -1))
 				{
-					GUI_output(get_ttx(0x940));
+					GUI_output(get_ttx(592));
 					retval = -2;
 				}
 			}
@@ -811,7 +811,7 @@ signed short select_magic_user(void)
 	signed short answer;
 
 	/* select the hero who shoulds cast a spell */
-	answer = select_hero_ok(get_ttx(0x4f4));
+	answer = select_hero_ok(get_ttx(317));
 
 	if (answer != -1) {
 		/* valid answer => cast spell */
@@ -854,11 +854,11 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 				if (host_readbs(ptr + 0x7) == 1) {
 
-					GUI_output(get_ttx(0x3a8));
+					GUI_output(get_ttx(234));
 
 				} else {
 
-					host_writeb(Real2Host(hero) + HERO_ENEMY_ID, select_hero_from_group(get_ttx(0xbc)) + 1);
+					host_writeb(Real2Host(hero) + HERO_ENEMY_ID, select_hero_from_group(get_ttx(47)) + 1);
 
 					if (host_readbs(Real2Host(hero) + HERO_ENEMY_ID) <= 0) {
 						l_di = -1;
@@ -877,11 +877,11 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 		ptr = p_datseg + SPELL_DESCRIPTIONS + 10 * l_di;
 
 		if ((ds_readws(IN_FIGHT) == 0) && (host_readbs(ptr + 5) == 1)) {
-			GUI_output(get_ttx(0x93c));
+			GUI_output(get_ttx(591));
 			retval = 0;
 
 		} else if ((ds_readws(IN_FIGHT) != 0) && (host_readbs(ptr + 5) == -1)) {
-			GUI_output(get_ttx(0x940));
+			GUI_output(get_ttx(592));
 			retval = 0;
 		}
 
@@ -893,7 +893,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 				/* prepare output */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x97c),
+					(char*)get_ttx(607),
 					(char*)Real2Host(hero) + HERO_NAME2);
 
 				if (ds_readws(IN_FIGHT) == 0) {
@@ -904,7 +904,7 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 
 			} else if ((ds_readws(SPELLTEST_RESULT) <= 0) || (ds_readds(INGAME_TIMERS) > 0)) {
 
-				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x978));
+				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(606));
 
 				sub_ae_splash(Real2Host(hero), get_spell_cost(l_di, 1));
 
@@ -943,11 +943,11 @@ signed short use_spell(RealPt hero, signed short a2, signed char bonus)
 					retval = -1;
 
 					if (!host_readbs(Real2Host(ds_readd(DTP2)))) {
-						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x978));
+						strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(606));
 					}
 				} else if (ds_readws(SPELL_SPECIAL_AECOST) == -2) {
 
-					strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x978));
+					strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(606));
 					sub_ae_splash(Real2Host(hero), get_spell_cost(l_di, 1));
 					retval = 0;
 				} else if (ds_readws(SPELL_SPECIAL_AECOST) != -1) {

--- a/src/custom/schick/rewrite_m302de/seg099.cpp
+++ b/src/custom/schick/rewrite_m302de/seg099.cpp
@@ -51,7 +51,7 @@ void spell_beherrschung(void)
 			} else {
 				and_ptr_bs(get_spelltarget() + HERO_STATUS1, 0xdf);
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x4),
+					(char*)get_tx(1),
 					(char*)get_spelltarget() + HERO_NAME2);
 			}
 		}
@@ -72,7 +72,7 @@ void spell_gardanium(void)
 
 	/* prepare a question */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x8), (char*)(get_spelluser() + HERO_NAME2));
+		(char*)get_tx(2), (char*)(get_spelluser() + HERO_NAME2));
 
 	/* ask and get the answer */
 	answer = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -91,11 +91,11 @@ void spell_gardanium(void)
 			ds_writew(SPELL_SPECIAL_AECOST, answer);
 			/* prepare the message */
 			strcpy((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c));
+				(char*)get_tx(7));
 		} else {
 			/* not enough AE */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x97c), (char*)get_spelluser() + HERO_NAME2);
+				(char*)get_ttx(607), (char*)get_spelluser() + HERO_NAME2);
 			/* set AE costs */
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 		}
@@ -135,7 +135,7 @@ void spell_illusionen(void)
 	} else {
 		/* print a failure message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xc),
+			(char*)get_tx(3),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 
 		/* costs 2 AE */
@@ -165,7 +165,7 @@ void spell_verwandlung(void)
 			/* unset stoned bit */
 			and_ptr_bs(get_spelltarget() + HERO_STATUS1, 0xfb);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x10),
+				(char*)get_tx(4),
 				(char*)get_spelltarget() + HERO_NAME2);
 		}
 	} else {
@@ -177,17 +177,17 @@ void spell_verwandlung(void)
 			for (i = 0; i <= 6; i++)
 				inc_ptr_bs(get_spelltarget() + HERO_ATTRIB + i * 3);
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x8d4),
+				(char*)get_ttx(565),
 				(char*)get_spelltarget() + HERO_NAME2);
 		} else {
 
 #ifdef M302de_ORIGINAL_BUGFIX
 			/* Broken format string, %S must be %s */
-			host_writeb(get_tx(0x14) + 5, 's');
+			host_writeb(get_tx(5) + 5, 's');
 #endif
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x14),
+				(char*)get_tx(5),
 				(char*)get_spelltarget() + HERO_NAME2);
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 		}
@@ -212,7 +212,7 @@ void spell_band(void)
 		or_ptr_bs(get_spelltarget_e() + ENEMY_SHEET_STATUS1, 0x20);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x18),
+				(char*)get_tx(6),
 				Real2Host(GUI_names_grammar((signed short)0x8000,
 					host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	} else {
@@ -230,14 +230,14 @@ void spell_band(void)
 
 			/* prepare message */
 			strcpy((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c0));
+				(char*)get_tx(112));
 		} else {
 			/* set status bit */
 			or_ptr_bs(get_spelltarget() + HERO_STATUS1, 0x80);
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x18),
+					(char*)get_tx(6),
 					(char*)get_spelltarget() + HERO_NAME2);
 		}
 	}
@@ -256,7 +256,7 @@ void spell_bannbaladin(void)
 		ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x20),
+				(char*)get_tx(8),
 				Real2Host(GUI_names_grammar(0,
 					host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	} else {
@@ -270,7 +270,7 @@ void spell_bannbaladin(void)
 		or_ptr_bs(get_spelltarget_e() + ENEMY_SHEET_STATUS2, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x24),
+				(char*)get_tx(9),
 				Real2Host(GUI_names_grammar((signed short)0x8000,
 					host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	}
@@ -294,7 +294,7 @@ void spell_boeser_blick(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x28),
+			(char*)get_tx(10),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 
 	}
@@ -344,7 +344,7 @@ void spell_herrdertiere(void)
 		ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x2c),
+				(char*)get_tx(11),
 				Real2Host(GUI_names_grammar(0,
 					host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	} else {
@@ -358,7 +358,7 @@ void spell_herrdertiere(void)
 			or_ptr_bs(get_spelltarget_e() + ENEMY_SHEET_STATUS2, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x24),
+				(char*)get_tx(9),
 				Real2Host(GUI_names_grammar((signed short)0x8000,
 					host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 		}
@@ -380,7 +380,7 @@ void spell_horriphobus(void)
 		and_ptr_bs(get_spelltarget_e() + ENEMY_SHEET_STATUS2, 0xfd);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x30),
+			(char*)get_tx(12),
 			Real2Host(GUI_names_grammar((signed short)0x8000,
 				host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	}
@@ -426,7 +426,7 @@ void spell_somnigravis(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x34),
+			(char*)get_tx(13),
 			Real2Host(GUI_names_grammar((signed short)0x8000,
 				host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 		return;
@@ -446,14 +446,14 @@ void spell_somnigravis(void)
 
 		/* prepare message */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x1c0));
+			(char*)get_tx(112));
 	} else {
 		/* set the flag */
 		or_ptr_bs(get_spelltarget() + HERO_STATUS1, 2);
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x34),
+			(char*)get_tx(13),
 			(char*)get_spelltarget() + HERO_NAME2);
 	}
 }
@@ -474,7 +474,7 @@ void spell_zwingtanz(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x38),
+			(char*)get_tx(14),
 			Real2Host(GUI_names_grammar((signed short)0x8000,
 				host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 	}
@@ -557,7 +557,7 @@ void spell_skelettarius(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x3c),
+			(char*)get_tx(15),
 			Real2Host(GUI_names_grammar((signed short)0x8000,
 				host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 
@@ -567,7 +567,7 @@ void spell_skelettarius(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x40),
+			(char*)get_tx(16),
 			Real2Host(GUI_names_grammar((signed short)0x8000,
 				host_readbs(get_spelltarget_e() + ENEMY_SHEET_MON_ID), 1)));
 
@@ -653,7 +653,7 @@ void spell_axxeleratus(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x44),
+			(char*)get_tx(17),
 			(char*)get_spelltarget() + HERO_NAME2);
 
 	} else {
@@ -713,7 +713,7 @@ void spell_transversalis(void)
 
 		/* prepare message */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x48));
+			(char*)get_tx(18));
 
 	} else {
 		/* set spell costs */
@@ -768,7 +768,7 @@ void spell_balsam(void)
 	} else {
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x4c),
+			(char*)get_tx(19),
 			(char*)get_spelluser() + HERO_NAME2,
 			(char*)get_spelltarget() + HERO_NAME2);
 
@@ -817,14 +817,14 @@ void spell_hexenspeichel(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x50),
+			(char*)get_tx(20),
 			(char*)get_spelluser() + HERO_NAME2);
 		return;
 	}
 
 	/* prepare question */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x4c),
+		(char*)get_tx(19),
 		(char*)get_spelluser() + HERO_NAME2,
 		(char*)get_spelltarget() + HERO_NAME2);
 
@@ -863,7 +863,7 @@ void spell_klarum_purum(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x54),
+			(char*)get_tx(21),
 			(char*)get_spelltarget() + HERO_NAME2);
 
 		ds_writew(SPELL_SPECIAL_AECOST, 0);
@@ -883,7 +883,7 @@ void spell_klarum_purum(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x58),
+			(char*)get_tx(22),
 			(char*)get_spelltarget() + HERO_NAME2);
 	}
 }
@@ -899,7 +899,7 @@ void spell_ruhe_koerper(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0xcc),
+		(char*)get_tx(51),
 		(char*)get_spelltarget() + HERO_NAME2);
 }
 
@@ -916,7 +916,7 @@ void spell_tiere_heilen(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x5c),
+		(char*)get_tx(23),
 		(char*)get_spelluser() + HERO_NAME2);
 
 	/* ask how many AE should be spent */
@@ -949,7 +949,7 @@ void spell_adleraug(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x60),
+		(char*)get_tx(24),
 		(char*)get_spelluser() + HERO_NAME2);
 }
 
@@ -967,7 +967,7 @@ RealPt spell_analues(void)
 	item_pos = select_item_to_drop(get_spelluser());
 	item_id = host_readws(get_spelluser() + 14 * item_pos + HERO_ITEM_HEAD);
 
-	strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(0xd0));
+	strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(52));
 
 	if (item_id) {
 
@@ -980,7 +980,7 @@ RealPt spell_analues(void)
 
 					/* copy the matching result string */
 					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(ds_readbs((ANALUES_ITEMS + 4) + i * 5) * 4));
+						(char*)get_tx(ds_readbs((ANALUES_ITEMS + 4) + i * 5)));
 
 					/* set the magic flag */
 					or_ptr_bs(get_spelluser() + item_pos * 14 + (HERO_ITEM_HEAD + 4), 0x80);
@@ -988,7 +988,7 @@ RealPt spell_analues(void)
 				} else {
 					/* nothing found string */
 					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_tx(0xdc));
+						(char*)get_tx(55));
 					break;
 				}
 			}
@@ -999,7 +999,7 @@ RealPt spell_analues(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0xd4),
+			(char*)get_tx(53),
 			(char*)get_spelluser() + HERO_NAME2,
 			(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 	}

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -47,7 +47,7 @@ void spell_eigenschaften(void)
 	max = max * 8 / 10;
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x64),
+		(char*)get_tx(25),
 		Real2Host(GUI_name_singular(get_monname(host_readbs(get_spelltarget_e())))),
 		host_readbs(get_spelltarget_e() + 0x29),	/* Level */
 		host_readbs(get_spelltarget_e() + 0x1c),	/* AT */
@@ -55,7 +55,7 @@ void spell_eigenschaften(void)
 		host_readbs(get_spelltarget_e() + 0x2),		/* RS */
 		host_readbs(get_spelltarget_e() + 0x1b),	/* Attacks */
 		(host_readbs(get_spelltarget_e() + 0x1b) > 1) ?
-			get_tx(0x68) : get_tx(0x6c),
+			get_tx(26) : get_tx(27),
 		min,							/* TPmin */
 		max,							/* TPmax */
 		host_readws(get_spelltarget_e() + 0x13),	/* LE */
@@ -106,11 +106,11 @@ void spell_exposami(void)
 	if (count) {
 		/* Intro text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x7c));
+			(char*)get_tx(31));
 
 		for (i = 0; count - 1 > i; i++) {
 			sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-				(char*)get_tx(0x84),		/* "%d %s" */
+				(char*)get_tx(33),		/* "%d %s" */
 				arr[i][1],
 				(char*)Real2Host(GUI_names_grammar(((arr[i][1] > 1)? 4 : 0) + 0x4000,
 									arr[i][0], 1)));
@@ -119,17 +119,17 @@ void spell_exposami(void)
 
 			if (count - 2 > i) {
 				strcat((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x70));		/* "," */
+					(char*)get_tx(28));		/* "," */
 			}
 		}
 
 		if (count > 1) {
 			strcat((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x74));		/* "AND" */
+				(char*)get_tx(29));		/* "AND" */
 		}
 
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)get_tx(0x84),
+			(char*)get_tx(33),
 			arr[count - 1][1],	/* TODO: this field access produces other code */
 			(char*)Real2Host(GUI_names_grammar((arr[count - 1][1] > 1 ? 4 : 0) + 0x4000,
 								arr[count - 1][0], 1)));
@@ -138,11 +138,11 @@ void spell_exposami(void)
 			(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
 		strcat((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x78));			/* "." */
+			(char*)get_tx(30));			/* "." */
 	} else {
 		/* no more hidden enemies */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x80));
+			(char*)get_tx(32));
 	}
 }
 
@@ -160,7 +160,7 @@ void spell_odem_arcanum(void)
 		if (ks_magic_hidden(get_spelluser() + pos * 14 + HERO_ITEM_HEAD)) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x144),
+				(char*)get_tx(81),
 				(char*)Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)));
 
 			/* set known flag */
@@ -168,7 +168,7 @@ void spell_odem_arcanum(void)
 
 		} else {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x148),
+				(char*)get_tx(82),
 				(char*)Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)));
 		}
 	}
@@ -205,7 +205,7 @@ void spell_chamaelioni(void)
 
 	/* prepare the message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x14c),
+		(char*)get_tx(83),
 		(char*)get_spelluser() + HERO_NAME2,
 		(char*)Real2Host(GUI_get_ptr(host_readbs(get_spelluser() + HERO_SEX), 0)));
 
@@ -218,7 +218,7 @@ void spell_duplicatus(void)
 
 	/* prepare the message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x150),
+		(char*)get_tx(84),
 		(char*)get_spelluser() + HERO_NAME2,
 		(char*)Real2Host(GUI_get_ptr(host_readbs(get_spelluser() + HERO_SEX), 0)));
 
@@ -341,14 +341,14 @@ void spell_blitz(void)
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 			strcpy((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c0));
+				(char*)get_tx(112));
 		} else {
 			/* set the rounds counter */
 			host_writeb(get_spelltarget() + HERO_BLIND, 3);
 
 			/* prepare the message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x158),
+				(char*)get_tx(86),
 				(char*)get_spelltarget() + HERO_NAME2);
 		}
 	} else {
@@ -363,7 +363,7 @@ void spell_blitz(void)
 
 		/* prepare the message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x154),
+			(char*)get_tx(85),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 	}
 }
@@ -374,7 +374,7 @@ void spell_ecliptifactus(void)
 	signed short ae;
 
 	/* ask how many rounds */
-	rounds = GUI_input(get_tx(0x15c), 1);
+	rounds = GUI_input(get_tx(87), 1);
 
 	if (rounds != -1) {
 
@@ -388,14 +388,14 @@ void spell_ecliptifactus(void)
 			host_writeb(get_spelluser() + HERO_ECLIPTIFACTUS, (signed char)rounds + 1);
 			/* prepare the message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x160),
+				(char*)get_tx(88),
 				(char*)(get_spelluser() + HERO_NAME2),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(get_spelluser() + HERO_SEX), 3)),
 				rounds);
 		} else {
 			/* prepare the message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x97c),
+				(char*)get_ttx(607),
 				(char*)get_spelluser() + HERO_NAME2);
 			/* set costs to 0 */
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
@@ -421,7 +421,7 @@ void spell_eisenrost(void)
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 			strcpy((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c0));
+				(char*)get_tx(112));
 		} else {
 			/* get weapon id of the target */
 			id = host_readws(get_spelltarget() + HERO_ITEM_RIGHT);
@@ -434,7 +434,7 @@ void spell_eisenrost(void)
 				if (ks_broken(get_spelltarget() + HERO_ITEM_RIGHT)) {
 
 					strcpy((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x168));
+						(char*)get_tx(90));
 
 				} else {
 
@@ -442,7 +442,7 @@ void spell_eisenrost(void)
 						/* set broken flag */
 						or_ptr_bs(get_spelltarget() + (HERO_ITEM_RIGHT + 4), 0x01);
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx(0x170),
+							(char*)get_tx(92),
 							(char*)Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)),
 							(char*)(get_spelltarget() + HERO_NAME2));
 					} else {
@@ -460,11 +460,11 @@ void spell_eisenrost(void)
 		if (host_readbs(get_spelltarget_e() + ENEMY_SHEET_FLAGS) != 0)
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x164));
+				(char*)get_tx(89));
 		} else {
 			/* check if weapon is already broken */
 			if (host_readbs(get_spelltarget_e() + ENEMY_SHEET_BROKEN) != 0) {
-				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x168));
+				strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(90));
 			} else {
 
 				/* set weapon broken */
@@ -472,7 +472,7 @@ void spell_eisenrost(void)
 
 				/* prepare message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x16c),
+					(char*)get_tx(91),
 					(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 			}
 		}
@@ -492,7 +492,7 @@ void spell_fulminictus(void)
 		ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 		/* prepare message */
-		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x1c0));
+		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(112));
 	} else {
 		/* roll 3W6+0 damage */
 		damage = dice_roll(3, 6, 0);
@@ -532,7 +532,7 @@ void spell_ignifaxius(void)
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 			/* prepare message */
-			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x1c0));
+			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(112));
 			return;;
 		}
 	}
@@ -543,7 +543,7 @@ void spell_ignifaxius(void)
 
 		/* prepare question of spell level */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x174),
+			(char*)get_tx(93),
 			host_readbs(get_spelluser() + HERO_LEVEL) + 1);
 
 		level = GUI_input(Real2Host(ds_readd(DTP2)), 2);
@@ -672,7 +672,7 @@ void spell_plumbumbarum(void)
 			ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 			/* prepare message */
-			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(0x1c0));
+			strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_tx(112));
 
 		} else {
 
@@ -684,7 +684,7 @@ void spell_plumbumbarum(void)
 
 			/* prepare the message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x178),
+				(char*)get_tx(94),
 				(char*)get_spelltarget() + HERO_NAME2);
 			}
 
@@ -703,7 +703,7 @@ void spell_plumbumbarum(void)
 
 	/* prepare the message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x17c),
+		(char*)get_tx(95),
 		(char*)Real2Host(GUI_names_grammar((signed short)0x8001, host_readbs(get_spelltarget_e()), 1)));
 }
 
@@ -752,7 +752,7 @@ void spell_saft_kraft(void)
 	ds_writew(SPELL_SPECIAL_AECOST, rounds);
 
 #ifdef M302de_ORIGINAL_BUGFIX
-	char *p = (char*)get_tx(96 * 4);
+	char *p = (char*)get_tx(96);
 
 	if (p[10] == 'L' && p[11] == 'E') {
 		/* change "VERWANDLET" into "VERWANDELT" */
@@ -763,7 +763,7 @@ void spell_saft_kraft(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(96 * 4),
+		(char*)get_tx(96),
 		(char*)get_spelltarget() + HERO_NAME2);
 
 }
@@ -791,7 +791,7 @@ void spell_scharfes_auge(void)
 	set_mod_slot(slot, 3 * 9L, get_spelltarget() + (HERO_TA_FIGHT + 7), 3, (signed char)target);
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(97 * 4),
+		(char*)get_tx(97),
 		(char*)get_spelltarget() + HERO_NAME2);
 
 }

--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -642,7 +642,7 @@ void spell_brenne(void)
 			torch_pos = get_item_pos(get_spelluser(), ITEM_TORCH_OFF);
 		}
 
-		lantern_pos = get_item_pos(get_spelluser(), ITEM_LANTERN_ON);
+		lantern_pos = get_item_pos(get_spelluser(), ITEM_LANTERN_OFF);
 	}
 
 	if (torch_pos != -1) {

--- a/src/custom/schick/rewrite_m302de/seg101.cpp
+++ b/src/custom/schick/rewrite_m302de/seg101.cpp
@@ -55,7 +55,7 @@ void spell_arcano(void)
 
 	/* "Die Magieresistenz von %s steigt um 2 Punkte." */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(98 * 4),
+		(char*)get_tx(98),
 		(char*)Real2Host(ds_readd(SPELLTARGET)) + HERO_NAME2);
 }
 
@@ -80,7 +80,7 @@ void spell_armatrutz(void)
 
 	/* aks the user which boni he wants */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x18c), max_boni);
+		(char*)get_tx(99), max_boni);
 	boni = GUI_input(Real2Host(ds_readd(DTP2)), 1);
 
 	/* fix wrong input */
@@ -98,7 +98,7 @@ void spell_armatrutz(void)
 
 		/* prepare output message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x190),
+			(char*)get_tx(100),
 			(char*)get_spelluser() + HERO_NAME2,
 			boni);
 
@@ -130,7 +130,7 @@ void spell_inc_ch(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -139,9 +139,9 @@ void spell_inc_ch(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_CH)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_CH))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(414 * 4));
+			(char*)get_ttx(414));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -151,9 +151,9 @@ void spell_inc_ch(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(414 * 4));
+			(char*)get_ttx(414));
 	}
 }
 
@@ -175,7 +175,7 @@ void spell_feuerbann(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x198),
+			(char*)get_tx(102),
 			(char*)get_spelluser() + HERO_NAME2);
 	} else {
 		/* set AP costs to 0 */
@@ -202,7 +202,7 @@ void spell_inc_ff(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -211,9 +211,9 @@ void spell_inc_ff(void)
 	if (host_readbs(get_spelltarget() + 0x3e) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_FF))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(415 * 4));
+			(char*)get_ttx(415));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -223,9 +223,9 @@ void spell_inc_ff(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(415 * 4));
+			(char*)get_ttx(415));
 	}
 }
 
@@ -248,7 +248,7 @@ void spell_inc_ge(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -257,9 +257,9 @@ void spell_inc_ge(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_GE)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_GE))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(416 * 4));
+			(char*)get_ttx(416));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -269,9 +269,9 @@ void spell_inc_ge(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(416 * 4));
+			(char*)get_ttx(416));
 	}
 }
 
@@ -294,7 +294,7 @@ void spell_inc_in(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -303,9 +303,9 @@ void spell_inc_in(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_IN)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_IN))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(417 * 4));
+			(char*)get_ttx(417));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -315,9 +315,9 @@ void spell_inc_in(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(417 * 4));
+			(char*)get_ttx(417));
 	}
 }
 
@@ -340,7 +340,7 @@ void spell_inc_kk(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -349,9 +349,9 @@ void spell_inc_kk(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_KK)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_KK))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(418 * 4));
+			(char*)get_ttx(418));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -361,9 +361,9 @@ void spell_inc_kk(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(418 * 4));
+			(char*)get_ttx(418));
 	}
 }
 
@@ -386,7 +386,7 @@ void spell_inc_kl(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -395,9 +395,9 @@ void spell_inc_kl(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_KL)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_KL))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(413 * 4));
+			(char*)get_ttx(413));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -407,9 +407,9 @@ void spell_inc_kl(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(413 * 4));
+			(char*)get_ttx(413));
 	}
 }
 
@@ -432,7 +432,7 @@ void spell_inc_mu(void)
 
 		/* copy message text */
 		strcpy((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(112 * 4));
+			(char*)get_tx(112));
 
 		return;
 	}
@@ -441,9 +441,9 @@ void spell_inc_mu(void)
 	if (host_readbs(get_spelltarget() + (HERO_ATTRIB + 3 * ATTRIB_MU)) > host_readbs(get_spelltarget() + (HERO_ATTRIB_ORIG + 3 * ATTRIB_MU))) {
 		/* "Bei %s ist %s schon magisch gesteigert" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(113 * 4),
+			(char*)get_tx(113),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(412 * 4));
+			(char*)get_ttx(412));
 	} else {
 		/* get a free mod_slot */
 		slot = get_free_mod_slot();
@@ -453,9 +453,9 @@ void spell_inc_mu(void)
 
 		/* "Bei %s steigt %s um 2 Punkte" */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(101 * 4),
+			(char*)get_tx(101),
 			(char*)get_spelltarget() + HERO_NAME2,
-			(char*)get_ttx(412 * 4));
+			(char*)get_ttx(412));
 	}
 }
 
@@ -482,7 +482,7 @@ void spell_paral(void)
 		or_ptr_bs(get_spelltarget_e() + 0x31, 0x04);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x19c),
+			(char*)get_tx(103),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 	} else {
 		/* cast a hero */
@@ -500,14 +500,14 @@ void spell_paral(void)
 				ds_writew(SPELL_SPECIAL_AECOST, 0);
 
 				strcpy((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x1c0));
+					(char*)get_tx(112));
 			} else {
 				/* set the hero to stoned */
 				or_ptr_bs(get_spelltarget() + 0xaa, 0x4);
 
 				/* prepare message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x19c),
+					(char*)get_tx(103),
 					(char*)get_spelltarget() + HERO_NAME2);
 			}
 		} else {
@@ -538,7 +538,7 @@ void spell_salander(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x1a0),
+			(char*)get_tx(104),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 
 		/* set AE cost */
@@ -546,7 +546,7 @@ void spell_salander(void)
 	} else {
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x97c),
+			(char*)get_ttx(607),
 			(char*)Real2Host(ds_readd(SPELLUSER)) + HERO_NAME2);
 
 		/* no AE cost */
@@ -569,7 +569,7 @@ void spell_visibili(void)
 
 	/* ask the user how many rounds he wants to be invisible */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x1a4), (char*)get_spelluser() + HERO_NAME2);
+		(char*)get_tx(105), (char*)get_spelluser() + HERO_NAME2);
 	rounds = GUI_input(Real2Host(ds_readd(DTP2)), 2);
 
 	/* the spell has also no effect if it is already active */
@@ -592,12 +592,12 @@ void spell_visibili(void)
 		set_mod_slot(slot, (Bit32s)rounds * MINUTES(5), get_spelluser() + HERO_INVISIBLE, 1, (signed char)pos);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x1a8),
+			(char*)get_tx(106),
 			(char*)get_spelluser() + HERO_NAME2,
 			(char*)Real2Host(GUI_get_ptr(host_readbs(get_spelluser() + HERO_SEX), 0)));
 	} else {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x97c),
+			(char*)get_ttx(607),
 			(char*)get_spelluser() + HERO_NAME2);
 
 		ds_writew(SPELL_SPECIAL_AECOST, 0);
@@ -650,7 +650,7 @@ void spell_brenne(void)
 			/* lantern and torch are available, must decide */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(107 * 4),
+				(char*)get_tx(107),
 				(char*)get_spelluser() + HERO_NAME2);
 
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)),
@@ -682,7 +682,7 @@ void spell_brenne(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(108 * 4),
+			(char*)get_tx(108),
 			get_spelluser() + HERO_NAME2);
 
 	} else if (lantern_pos != -1) {
@@ -709,12 +709,12 @@ void spell_brenne(void)
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(119 * 4),
+				(char*)get_tx(119),
 				get_spelluser() + HERO_NAME2);
 		} else {
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(120 * 4),
+				(char*)get_tx(120),
 				get_spelluser() + HERO_NAME2);
 		}
 	} else {
@@ -722,7 +722,7 @@ void spell_brenne(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(121 * 4),
+			(char*)get_tx(121),
 			get_spelluser() + HERO_NAME2);
 	}
 }
@@ -744,7 +744,7 @@ void spell_dunkelheit(void)
 
 	/* copy message text */
 	strcpy((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(109 * 4));
+		(char*)get_tx(109));
 
 }
 
@@ -765,7 +765,7 @@ void spell_flimflam(void)
 
 	/* copy message text */
 	strcpy((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(110 * 4));
+		(char*)get_tx(110));
 
 }
 
@@ -804,7 +804,7 @@ void spell_silentium(void)
 
 	/* copy message text */
 	strcpy((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(111 * 4));
+		(char*)get_tx(111));
 }
 
 void spell_sturmgebr(void)

--- a/src/custom/schick/rewrite_m302de/seg102.cpp
+++ b/src/custom/schick/rewrite_m302de/seg102.cpp
@@ -307,7 +307,7 @@ void mspell_verwandlung(void)
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1c8),
+				(char*)get_tx(114),
 				Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 		}
 	} else {
@@ -341,7 +341,7 @@ void mspell_bannbaladin(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x1cc),
+		(char*)get_tx(115),
 		get_spelltarget() + HERO_NAME2);
 }
 
@@ -356,7 +356,7 @@ void mspell_boeser_blick(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x1d0),
+		(char*)get_tx(116),
 		get_spelltarget() + HERO_NAME2);
 }
 
@@ -372,7 +372,7 @@ void mspell_horriphobus(void)
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x1d4),
+		(char*)get_tx(117),
 		get_spelltarget() + HERO_NAME2);
 }
 
@@ -441,7 +441,7 @@ void mspell_blitz(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x158),
+			(char*)get_tx(86),
 			get_spelltarget() + HERO_NAME2);
 	} else {
 		/* target is a monster */
@@ -455,7 +455,7 @@ void mspell_blitz(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x154),
+			(char*)get_tx(85),
 			Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 	}
 }
@@ -485,7 +485,7 @@ void mspell_eisenrost(void)
 
 				/* prepare message */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x170),
+					(char*)get_tx(92),
 					Real2Host(GUI_names_grammar((signed short)0x8000, id, 0)),
 					get_spelltarget() + HERO_NAME2);
 			} else {
@@ -508,7 +508,7 @@ void mspell_eisenrost(void)
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x16c),
+				(char*)get_tx(91),
 				Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 		}
 	}
@@ -642,7 +642,7 @@ void mspell_plumbumbarum(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x178),
+			(char*)get_tx(94),
 			get_spelltarget() + HERO_NAME2);
 	} else {
 		/* target is a monster */
@@ -657,7 +657,7 @@ void mspell_plumbumbarum(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x17c),
+			(char*)get_tx(95),
 			Real2Host(GUI_names_grammar((signed short)0x8001, host_readbs(get_spelltarget_e()), 1)));
 	}
 }
@@ -720,7 +720,7 @@ void mspell_paral(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x19c),
+			(char*)get_tx(103),
 			Real2Host(GUI_names_grammar((signed short)0x8000, host_readbs(get_spelltarget_e()), 1)));
 	} else {
 		/* target is a hero */
@@ -734,7 +734,7 @@ void mspell_paral(void)
 
 		/* prepare message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x19c),
+			(char*)get_tx(103),
 			get_spelltarget() + HERO_NAME2);
 	}
 }

--- a/src/custom/schick/rewrite_m302de/seg103.cpp
+++ b/src/custom/schick/rewrite_m302de/seg103.cpp
@@ -41,30 +41,30 @@ signed short LVL_select_skill(Bit8u *hero, signed short show_values)
 
 	if (show_values != 0) {
 
-		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x334));
+		strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(205));
 
 		if (host_readbs(hero + HERO_TA_RISE) > 1) {
-			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(0x624));
+			strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_ttx(393));
 		}
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x330),
+			(char*)get_ttx(204),
 			/* sind / ist */
-			(host_readbs(hero + HERO_TA_RISE) > 1) ? get_ttx(0x4c4) : get_ttx(0x4c0),
+			(host_readbs(hero + HERO_TA_RISE) > 1) ? get_ttx(305) : get_ttx(304),
 			/* # of tries left */
 			host_readbs(hero + HERO_TA_RISE),
 			Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 	} else {
 
-		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x360));
+		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(216));
 	}
 
 	/* ask for the skill category */
 	answer = GUI_radio(Real2Host(ds_readd(DTP2)), 7,
-				get_ttx(0x190), get_ttx(0x194),
-				get_ttx(0x198), get_ttx(0x1a4),
-				get_ttx(0x19c), get_ttx(0x1a0),
-				get_ttx(0x1a8)) - 1;
+				get_ttx(100), get_ttx(101),
+				get_ttx(102), get_ttx(105),
+				get_ttx(103), get_ttx(104),
+				get_ttx(106)) - 1;
 
 	if (answer != -2) {
 
@@ -76,7 +76,7 @@ signed short LVL_select_skill(Bit8u *hero, signed short show_values)
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)) + 50 * i,
 					format_str.a,
-					get_ttx((l1 + i + 48) * 4),
+					get_ttx(l1 + i + 48),
 					host_readbs(hero + l1 + i + HERO_TA_FIGHT));
 
 				ds_writed(RADIO_NAME_LIST + 4 * i, (Bit32u)((RealPt)ds_readd(DTP2) + 50 * i));
@@ -88,7 +88,7 @@ signed short LVL_select_skill(Bit8u *hero, signed short show_values)
 			}
 		}
 
-		retval = GUI_radio(get_ttx(0x368), ds_readbs((SKILLS_INDEX + 1) + 2 * answer),
+		retval = GUI_radio(get_ttx(218), ds_readbs((SKILLS_INDEX + 1) + 2 * answer),
 				Real2Host(ds_readd(RADIO_NAME_LIST)),
 				Real2Host(ds_readd((RADIO_NAME_LIST + 4))),
 				Real2Host(ds_readd((RADIO_NAME_LIST + 2 * 4))),
@@ -290,14 +290,14 @@ signed short select_skill(void)
 		nr_skills++;
 	}
 
-	l_si = GUI_radio(get_ttx(0x368), (signed char)nr_skills,
-				get_ttx((a.a[0] + 48) * 4),
-				get_ttx((a.a[1] + 48) * 4),
-				get_ttx((a.a[2] + 48) * 4),
-				get_ttx((a.a[3] + 48) * 4),
-				get_ttx((a.a[4] + 48) * 4),
-				get_ttx((a.a[5] + 48) * 4),
-				get_ttx((a.a[6] + 48) * 4));
+	l_si = GUI_radio(get_ttx(218), (signed char)nr_skills,
+				get_ttx(a.a[0] + 48),
+				get_ttx(a.a[1] + 48),
+				get_ttx(a.a[2] + 48),
+				get_ttx(a.a[3] + 48),
+				get_ttx(a.a[4] + 48),
+				get_ttx(a.a[5] + 48),
+				get_ttx(a.a[6] + 48));
 
 	if (l_si != -1) {
 		return a.a[l_si - 1];
@@ -333,7 +333,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 		case 44 : {
 			ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-			patient_pos = select_hero_from_group(get_ttx(0x730));
+			patient_pos = select_hero_from_group(get_ttx(460));
 
 			if (patient_pos != -1) {
 				patient = get_hero(patient_pos);
@@ -344,13 +344,13 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					if (poison == 0) {
 						/* patient is not poisoned */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x73c),
+							(char*)get_ttx(463),
 							(char*)patient + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					} else if (host_readds(patient + HERO_HEAL_TIMER) > 0) {
 						/* patient timer is not zero */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xae4),
+							(char*)get_ttx(697),
 							(char*)patient + HERO_NAME2);
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					} else {
@@ -364,7 +364,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 							if (test_skill(hero, TA_HEILEN_GIFT, ds_readbs(POISON_PRICES + 2 * poison) + bonus) > 0) {
 								/* success */
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xac8),
+									(char*)get_ttx(690),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2);
 
@@ -374,20 +374,20 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 								host_writeb(patient + 0xd6 + 5 * poison, 1);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xad0),
+									(char*)get_ttx(692),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2);
 
 								if (GUI_bool(Real2Host(ds_readd(DTP2)))) {
 
 									do {
-										le = GUI_input(get_ttx(0xad4), 2);
+										le = GUI_input(get_ttx(693), 2);
 									} while (le <= 0);
 
 									if ((l_si = test_skill(hero, TA_HEILEN_GIFT, le + bonus)) > 0) {
 
 										sprintf((char*)Real2Host(ds_readd(DTP2)),
-											(char*)get_ttx(0xacc),
+											(char*)get_ttx(691),
 											(char*)hero + HERO_NAME2,
 											(char*)patient + HERO_NAME2,
 											le);
@@ -405,7 +405,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 										sub_hero_le(patient, l_di);
 
 										sprintf((char*)Real2Host(ds_readd(DTP2)),
-											(char*)get_ttx(0xad8),
+											(char*)get_ttx(694),
 											(char*)patient + HERO_NAME2,
 											l_di);
 
@@ -417,7 +417,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 							} else {
 								/* healing failed */
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xac4),
+									(char*)get_ttx(689),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2);
 
@@ -426,7 +426,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 						} else {
 							/* recognizing the poison failed */
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0xac0),
+								(char*)get_ttx(688),
 								(char*)hero + HERO_NAME2,
 								(char*)patient + HERO_NAME2);
 
@@ -440,7 +440,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 		case 45 : {
 			ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-			patient_pos = select_hero_from_group(get_ttx(0x730));
+			patient_pos = select_hero_from_group(get_ttx(460));
 
 			if (patient_pos != -1) {
 				patient = get_hero(patient_pos);
@@ -452,7 +452,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 		case 46 : {
 			ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-			patient_pos = select_hero_from_group(get_ttx(0x730));
+			patient_pos = select_hero_from_group(get_ttx(460));
 
 			if (patient_pos != -1) {
 				patient = get_hero(patient_pos);
@@ -461,14 +461,14 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					if (host_readws(patient + 0x60) >= host_readws(patient + 0x5e)) {
 						/* no need to heal */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x734),
+							(char*)get_ttx(461),
 							(char*)patient + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 					} else if (host_readds(patient + HERO_HEAL_TIMER) > 0) {
 						/* timer is still running */
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xae4),
+							(char*)get_ttx(697),
 							(char*)patient + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -484,7 +484,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 								add_hero_le(patient, l_si);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xacc),
+									(char*)get_ttx(691),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2,
 									l_si);
@@ -500,7 +500,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 								sub_hero_le(patient, l_di);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xad8),
+									(char*)get_ttx(694),
 									(char*)patient + HERO_NAME2,
 									l_di);
 
@@ -515,7 +515,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 							if (random_schick(20) <= 7) {
 								/* infected */
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xaec),
+									(char*)get_ttx(699),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2);
 
@@ -524,7 +524,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 							} else {
 								/* just failed */
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xae8),
+									(char*)get_ttx(698),
 									(char*)hero + HERO_NAME2,
 									(char*)patient + HERO_NAME2);
 							}
@@ -540,7 +540,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 			if (ds_readds((INGAME_TIMERS + 0x18)) > 0) {
 
-				GUI_output(get_tx(0x88));
+				GUI_output(get_tx(34));
 
 			} else {
 
@@ -551,7 +551,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x8c),
+						(char*)get_tx(35),
 						(char*)hero + HERO_NAME2,
 						Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
@@ -562,7 +562,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					ds_writed((INGAME_TIMERS + 0x18), 0xa8c0);
 					ds_writew(REQUEST_REFRESH, 1);
 				} else {
-					GUI_output(get_tx(0x90));
+					GUI_output(get_tx(36));
 
 					ds_writed((INGAME_TIMERS + 0x18), 0xa8c0);
 					l_si = -1;
@@ -574,7 +574,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 			if (ds_readds((INGAME_TIMERS + 0x1c)) > 0) {
 
-				GUI_output(get_tx(0x94));
+				GUI_output(get_tx(37));
 
 			} else {
 
@@ -585,7 +585,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0x8c),
+						(char*)get_tx(35),
 						(char*)hero + HERO_NAME2,
 						Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
 
@@ -596,7 +596,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 					ds_writed((INGAME_TIMERS + 0x1c), 0xa8c0);
 					ds_writew(REQUEST_REFRESH, 1);
 				} else {
-					GUI_output(get_tx(0x90));
+					GUI_output(get_tx(36));
 
 					ds_writed((INGAME_TIMERS + 0x1c), 0xa8c0);
 					l_si = -1;
@@ -613,7 +613,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 				make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x98),
+					(char*)get_tx(38),
 					Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 					(char*)hero + HERO_NAME2);
 
@@ -623,7 +623,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 
 				ds_writew(REQUEST_REFRESH, 1);
 			} else {
-				GUI_output(get_tx(0x9c));
+				GUI_output(get_tx(39));
 
 				ds_writeb(TAV_CHEATED_FLAGS + ds_readws(TYPEINDEX), 1);
 
@@ -641,7 +641,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 				make_valuta_str((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), money);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xa0),
+					(char*)get_tx(40),
 					Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 					(char*)hero + HERO_NAME2);
 
@@ -652,7 +652,7 @@ signed short use_skill(signed short hero_pos, signed char bonus, signed short sk
 				ds_writew(REQUEST_REFRESH, 1);
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0xa4),
+					(char*)get_tx(41),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -710,7 +710,7 @@ signed short GUI_use_skill2(signed short bonus, Bit8u *msg)
 		hero_pos = select_hero_ok(msg);
 
 		if ((hero_pos != -1) && (hero_busy(get_hero(hero_pos)))) {
-			GUI_output(get_ttx(0xb68));
+			GUI_output(get_ttx(730));
 			hero_pos = -1;
 		}
 		if (hero_pos != -1) {

--- a/src/custom/schick/rewrite_m302de/seg104.cpp
+++ b/src/custom/schick/rewrite_m302de/seg104.cpp
@@ -116,7 +116,7 @@ signed short do_alchemy(Bit8u* hero, signed short recipe_index, signed short fla
 		give_hero_new_item(hero, host_readws(r_ptr + 0x16), 1, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xb6c),
+			(char*)get_ttx(731),
 			hero + HERO_NAME2,
 			Real2Host(GUI_names_grammar(1, host_readws(r_ptr + 0x16), 0)));
 
@@ -129,7 +129,7 @@ signed short do_alchemy(Bit8u* hero, signed short recipe_index, signed short fla
 		give_hero_new_item(hero, host_readws(r_ptr + 2), 1, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xb70),
+			(char*)get_ttx(732),
 			hero + HERO_NAME2,
 			Real2Host(GUI_names_grammar(2, host_readws(r_ptr + 0x16), 0)));
 
@@ -159,7 +159,7 @@ signed short plan_alchemy(Bit8u *hero)
 	item_pos = get_item_pos(hero, 47);
 	if (item_pos == -1) {
 		/* no alchemyset */
-		GUI_output(get_tx(0xa8));
+		GUI_output(get_tx(42));
 		retval = 0;
 	} else {
 
@@ -181,7 +181,7 @@ signed short plan_alchemy(Bit8u *hero)
 			l7 = ds_readws(TEXTBOX_WIDTH);
 			ds_writew(TEXTBOX_WIDTH, 7);
 
-			answer = GUI_radio(get_tx(0xac), (signed char)recipes,
+			answer = GUI_radio(get_tx(43), (signed char)recipes,
 						Real2Host(ds_readd(RADIO_NAME_LIST)),
 						Real2Host(ds_readd((RADIO_NAME_LIST + 4))),
 						Real2Host(ds_readd((RADIO_NAME_LIST + 2 * 4))),
@@ -209,7 +209,7 @@ signed short plan_alchemy(Bit8u *hero)
 					if (ds_readws((ALCHEMY_RECIPES+24) + recipe_index * 28) > host_readws(hero + HERO_AE)) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x97c),
+							(char*)get_ttx(607),
 							(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -219,7 +219,7 @@ signed short plan_alchemy(Bit8u *hero)
 
 						if ((ds_readbs(LOCATION) == LOCATION_INN) && (ds_readbs(SLEEP_QUALITY) == -1)) {
 
-							GUI_output(get_ttx(0x568));
+							GUI_output(get_ttx(346));
 
 							return 0;
 						}
@@ -227,7 +227,7 @@ signed short plan_alchemy(Bit8u *hero)
 						/* check if the alchemic process takes more than 8h */
 						if ((ds_readbs((ALCHEMY_RECIPES+27) + recipe_index * 28) > 8) && (ds_readbs(LOCATION) != LOCATION_INN)) {
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx(0xb0),
+									(char*)get_tx(44),
 									ds_readbs((ALCHEMY_RECIPES+27) + recipe_index * 28));
 
 									GUI_output(Real2Host(ds_readd(DTP2)));
@@ -240,20 +240,20 @@ signed short plan_alchemy(Bit8u *hero)
 							{
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx(0xb4),
+									(char*)get_tx(45),
 									ds_readbs((ALCHEMY_RECIPES+27) + recipe_index * 28));
 
 								sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-									(char*)get_tx(0xbc),
+									(char*)get_tx(47),
 									(char*)hero + HERO_NAME2);
 
 								ds_writew(TEXTBOX_WIDTH, 7);
 
 								do {
 									l4 = GUI_radio(Real2Host(ds_readd(DTP2)), 3,
-											get_tx(0xb8),
+											get_tx(46),
 											Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-											get_tx(0xc0));
+											get_tx(48));
 								} while (l4 == -1);
 
 								ds_writew(TEXTBOX_WIDTH, 3);
@@ -307,7 +307,7 @@ signed short plan_alchemy(Bit8u *hero)
 				} else {
 					/* not all ingrendients */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx(0xc4),
+						(char*)get_tx(49),
 						(char*)Real2Host(GUI_name_singular((Bit8u*)get_itemname(ds_readws(ALCHEMY_MISSING_ITEM)))));
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -316,7 +316,7 @@ signed short plan_alchemy(Bit8u *hero)
 		} else {
 			/* no recipes */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0xc8),
+				(char*)get_tx(50),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -412,7 +412,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 			/* not diseased */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x738),
+				(char*)get_ttx(462),
 				(char*)patient + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -422,7 +422,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 			/* recently tried to cure with skill */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xae4),
+				(char*)get_ttx(697),
 				(char*)patient + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -431,7 +431,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 			/* no herb for this disease */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1d8),
+				(char*)get_tx(118),
 				(char*)healer + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -450,7 +450,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 					add_hero_le(patient, retval);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xadc),
+						(char*)get_ttx(695),
 						(char*)healer + HERO_NAME2,
 						(char*)patient + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(patient + 0x22), 3)),
@@ -482,7 +482,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 					sub_hero_le(patient, damage);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xad8),
+						(char*)get_ttx(694),
 						(char*)patient + HERO_NAME2, damage);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -491,7 +491,7 @@ signed short skill_cure_disease(Bit8u *healer, Bit8u *patient, signed short hand
 			} else {
 				/* failed to heal */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xae0),
+					(char*)get_ttx(696),
 					(char*)healer + HERO_NAME2,
 					(char*)patient + HERO_NAME2);
 

--- a/src/custom/schick/rewrite_m302de/seg105.cpp
+++ b/src/custom/schick/rewrite_m302de/seg105.cpp
@@ -325,7 +325,7 @@ signed short give_hero_new_item(Bit8u *hero, signed short item, signed short mod
 
 		if (mode != 0) {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc2c),
+				(char*)get_ttx(779),
 				(char*)(hero + HERO_NAME2));
 			GUI_output(Real2Host(ds_readd(DTP2)));
 		}
@@ -502,7 +502,7 @@ unsigned short drop_item(Bit8u *hero, signed short pos, signed short nr)
 			/* this item is not droppable */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x718),
+				(char*)get_ttx(454),
 				(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item, 0)));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -512,7 +512,7 @@ unsigned short drop_item(Bit8u *hero, signed short pos, signed short nr)
 			if (item_stackable(p_item)) {
 				if (nr == -1) {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x36c),
+						(char*)get_ttx(219),
 						(char*)Real2Host(GUI_names_grammar(6, item, 0)));
 
 					do {
@@ -544,7 +544,7 @@ unsigned short drop_item(Bit8u *hero, signed short pos, signed short nr)
 
 				retval = 1;
 			} else {
-				if (!(nr != -1 || GUI_bool(get_ttx(0x370)))) {
+				if (!(nr != -1 || GUI_bool(get_ttx(220)))) {
 				} else {
 
 					/* check if item is equipped */
@@ -639,12 +639,12 @@ signed short get_item(signed short id, signed short unused, signed short nr)
 			ds_writew(AUTOFIGHT, 0);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x894),
+				(char*)get_ttx(549),
 				(char*)Real2Host(GUI_names_grammar(((nr > 1) ? 4 : 0) + 2, id, 0)));
 
 			if (GUI_bool(Real2Host(ds_readd(DTP2)))) {
 
-				dropper = select_hero_ok(get_ttx(0x898));
+				dropper = select_hero_ok(get_ttx(550));
 
 				if (dropper != -1) {
 					hero_i = get_hero(dropper);
@@ -779,7 +779,7 @@ signed short select_item_to_drop(Bit8u *hero)
 
 	if (v6 == 0) {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xbb8),
+			(char*)get_ttx(750),
 			(char*)(hero + HERO_NAME2));
 		GUI_output(Real2Host(ds_readd(DTP2)));
 		return -1;
@@ -810,7 +810,7 @@ signed short select_item_to_drop(Bit8u *hero)
 		bak3 = ds_readw(BASEPOS_Y);
 		ds_writew(TEXTBOX_WIDTH, 6);
 		ds_writew(BASEPOS_X, ds_writew(BASEPOS_Y, 0));
-		v4 = GUI_radio((Bit8u*)get_ttx(0xbc0), (signed char)i,
+		v4 = GUI_radio((Bit8u*)get_ttx(752), (signed char)i,
 			Real2Host(ds_readd(RADIO_NAME_LIST + 0x00 + di * 4)),
 			Real2Host(ds_readd(RADIO_NAME_LIST + 0x04 + di * 4)),
 			Real2Host(ds_readd(RADIO_NAME_LIST + 0x08 + di * 4)),

--- a/src/custom/schick/rewrite_m302de/seg106.cpp
+++ b/src/custom/schick/rewrite_m302de/seg106.cpp
@@ -109,7 +109,7 @@ void move_item(signed short pos1, signed short pos2, Bit8u *hero)
 			v3 = 0;
 
 			if ((item1 == 0) && (item2 == 0)) {
-				GUI_output(get_ttx(0x344));
+				GUI_output(get_ttx(209));
 			} else {
 				if (item2 != 0) {
 					/* item have the same ids and are stackable */
@@ -129,9 +129,9 @@ void move_item(signed short pos1, signed short pos2, Bit8u *hero)
 					} else {
 						if (!can_hero_use_item(hero, item2)) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x374),
+								(char*)get_ttx(221),
 								(char*)hero + HERO_NAME2,
-								(char*)get_ttx( ((host_readbs(hero + HERO_SEX) != 0 ? 0x251 : 0x9) + host_readbs(hero + HERO_TYPE)) * 4),
+								(char*)get_ttx((host_readbs(hero + HERO_SEX) != 0 ? 593 : 9) + host_readbs(hero + HERO_TYPE)),
 								(char*)Real2Host(GUI_names_grammar(2, item2, 0)));
 
 
@@ -140,20 +140,20 @@ void move_item(signed short pos1, signed short pos2, Bit8u *hero)
 							if (!can_item_at_pos(item2, pos1)) {
 								if (is_in_word_array(item2, (signed short*)(p_datseg + ITEMS_PLURALWORDS)))
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0x378),
+										(char*)get_ttx(222),
 										(char*)Real2Host(GUI_names_grammar(0x4000, item2, 0)),
-										(char*)get_ttx(0x8b4));
+										(char*)get_ttx(557));
 								else
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0x378),
+										(char*)get_ttx(222),
 										(char*)Real2Host(GUI_names_grammar(0, item2, 0)),
-										(char*)get_ttx(0x8b0));
+										(char*)get_ttx(556));
 								GUI_output(Real2Host(ds_readd(DTP2)));
 							} else {
 								if (two_hand_collision(hero, item2, pos1)) {
 
 									sprintf((char*)Real2Host(ds_readd(DTP2)),
-										(char*)get_ttx(0xcf4),
+										(char*)get_ttx(829),
 										(char*)hero + HERO_NAME2);
 
 									GUI_output(Real2Host(ds_readd(DTP2)));
@@ -227,49 +227,49 @@ void print_item_description(Bit8u *hero, signed short pos)
 			is_in_word_array(host_readw(item_p), (signed short*)(p_datseg + ITEMS_PLURALWORDS))) {
 			/* more than one item or special */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x120),
-				get_ttx(0x4c4),
+				(char*)get_tx2(72),
+				get_ttx(305),
 				Real2Host(GUI_names_grammar(0x4004, host_readw(item_p), 0)));
 		} else {
 			/* one item */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x2c),
-				get_ttx(0x4c0),
+				(char*)get_tx2(11),
+				get_ttx(304),
 				Real2Host(GUI_names_grammar(0, host_readw(item_p), 0)));
 		}
 	} else {
 		/* no item */
-		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x344));
+		strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(209));
 	}
 
 
 	/* broken */
 	if (ks_broken(item_p)) {
-		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x778));
+		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(478));
 	}
 
 	/* magic */
 	if (ks_magic_hidden(item_p) &&	/* is magic */
 		ks_magic_known(item_p)) { /* and you know it */
-		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x77c));
+		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(479));
 	}
 
 	/* used */
 	if (host_readb(item_p + 7) != 0) {
-		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x780));
+		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(480));
 	}
 
 	/* poisoned */
 	if (host_readw(item_p) == 0xc1 || host_readw(item_p) == 0xc8 ||
 		ks_poison1(item_p) || ks_poison2(item_p) ||
 		host_readb(hero + HERO_ITEM_HEAD + 9 + pos * 14) != 0) {
-		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x890));
+		strcat((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(548));
 	}
 
 	/* staff */
 	if (host_readw(item_p) == 0x85) {
 		sprintf((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-			(char*)get_tx2(0xd4),
+			(char*)get_tx2(53),
 			host_readbs(hero + HERO_STAFFSPELL_LVL));
 		strcat((char*)Real2Host(ds_readd(DTP2)),
 			(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -298,7 +298,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 	/* check if item1 is an item */
 	if (item1 == 0) {
-		GUI_output(get_ttx(0x344));
+		GUI_output(get_ttx(209));
 		return;
 	}
 
@@ -310,7 +310,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 	if (item_undropable(item1_desc)) {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x718),
+			(char*)get_ttx(454),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item1, 0)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -320,7 +320,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 	if (item_undropable(item2_desc)) {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0x718),
+			(char*)get_ttx(454),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8002, item2, 0)));
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -333,9 +333,9 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 		if (!can_hero_use_item(hero2, item1)) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x374),
+				(char*)get_ttx(221),
 				(char*)(hero2 + HERO_NAME2),
-				(char*)get_ttx(((host_readbs(hero2 + HERO_SEX) ? 593 : 9) + host_readbs(hero2 + HERO_TYPE)) * 4),
+				(char*)get_ttx((host_readbs(hero2 + HERO_SEX) ? 593 : 9) + host_readbs(hero2 + HERO_TYPE)),
 				(char*)Real2Host(GUI_names_grammar(2, item1, 0)));
 
 
@@ -347,14 +347,14 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 			if (is_in_word_array(item1, (signed short*)(p_datseg + ITEMS_PLURALWORDS))) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x378),
+					(char*)get_ttx(222),
 					(char*)Real2Host(GUI_names_grammar(0x4000, item1, 0)),
-					(char*)get_ttx(0x8b4));
+					(char*)get_ttx(557));
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x378),
+					(char*)get_ttx(222),
 					(char*)Real2Host(GUI_names_grammar(0, item1, 0)),
-					(char*)get_ttx(0x8b0));
+					(char*)get_ttx(556));
 			}
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -363,7 +363,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 		} else if (two_hand_collision(hero2, item1, pos2)) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x10c),
+				(char*)get_tx2(67),
 				(char*)(hero2 + HERO_NAME2));
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -382,9 +382,9 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 		if (!can_hero_use_item(hero1, item2)) {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x374),
+				(char*)get_ttx(221),
 				(char*)(hero1 + HERO_NAME2),
-				(char*)get_ttx(((host_readbs(hero1 + HERO_SEX) ? 593 : 9) + host_readbs(hero1 + HERO_TYPE)) * 4),
+				(char*)get_ttx((host_readbs(hero1 + HERO_SEX) ? 593 : 9) + host_readbs(hero1 + HERO_TYPE)),
 				(char*)Real2Host(GUI_names_grammar(2, item2, 0)));
 
 #if defined(__BORLANDC__)
@@ -399,14 +399,14 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 			if (is_in_word_array(item2, (signed short*)(p_datseg + ITEMS_PLURALWORDS))) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x378),
+					(char*)get_ttx(222),
 					(char*)Real2Host(GUI_names_grammar(0x4000, item2, 0)),
-					(char*)get_ttx(0x8b4));
+					(char*)get_ttx(557));
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x378),
+					(char*)get_ttx(222),
 					(char*)Real2Host(GUI_names_grammar(0, item2, 0)),
-					(char*)get_ttx(0x8b0));
+					(char*)get_ttx(556));
 			}
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -428,7 +428,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 			if (host_readws(hero1 + (HERO_ITEM_HEAD+2) + pos1 * SIZEOF_KS_ITEM) > 1) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x348),
+					(char*)get_ttx(210),
 					host_readws(hero1 + (HERO_ITEM_HEAD+2) + pos1 * SIZEOF_KS_ITEM),
 					(char*)Real2Host(GUI_names_grammar(6, item1, 0)),
 					(char*)hero2 + HERO_NAME2);
@@ -457,7 +457,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 					drop_item(hero1, pos1, l_di);
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc2c),
+						(char*)get_ttx(779),
 						(char*)hero2 + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
@@ -477,7 +477,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 			if (host_readbs(hero2 + (HERO_ATTRIB + 3 * ATTRIB_KK)) * 100 <= host_readws(hero2 + HERO_LOAD) + desc1_5 - desc2_5) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xc2c),
+					(char*)get_ttx(779),
 					(char*)hero2 + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -553,7 +553,7 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 		if (host_readws(hero1 + (HERO_ITEM_HEAD+2) + pos1 * SIZEOF_KS_ITEM) > 1) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0x348),
+				(char*)get_ttx(210),
 				host_readws(hero1+ (HERO_ITEM_HEAD + 2) + pos1 * SIZEOF_KS_ITEM),
 				(char*)Real2Host(GUI_names_grammar(6, item1, 0)),
 				(char*)hero2 + HERO_NAME2);
@@ -584,13 +584,13 @@ void pass_item(Bit8u *hero1, signed short old_pos1, Bit8u *hero2, signed short p
 
 		} else {
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc2c),
+				(char*)get_ttx(779),
 				(char*)hero2 + HERO_NAME2);
 			GUI_output(Real2Host(ds_readd(DTP2)));
 		}
 	} else if (host_readbs(hero2 + (HERO_ATTRIB + 3 * ATTRIB_KK)) * 100 <= host_readws(hero2 + HERO_LOAD) + host_readws(item1_desc + 5)) {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xc2c),
+			(char*)get_ttx(779),
 			(char*)hero2 + HERO_NAME2);
 		GUI_output(Real2Host(ds_readd(DTP2)));
 	} else {

--- a/src/custom/schick/rewrite_m302de/seg107.cpp
+++ b/src/custom/schick/rewrite_m302de/seg107.cpp
@@ -71,11 +71,11 @@ void use_item(signed short item_pos, signed short hero_pos)
 				{
 					/* german grammar, singular and plural are the same */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xc60),
+						(char*)get_ttx(792),
 						(char*)Real2Host(GUI_name_singular((Bit8u*)get_itemname(ds_readws(USED_ITEM_ID)))));
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8ec),
+						(char*)get_ttx(571),
 						(char*)Real2Host(GUI_names_grammar(0, ds_readws(USED_ITEM_ID), 0)));
 				}
 
@@ -89,7 +89,7 @@ void use_item(signed short item_pos, signed short hero_pos)
 
 			} else if ((host_readws(get_itemuser() + 14 * ds_readws(USED_ITEM_POS) + (HERO_ITEM_HEAD + 2))) <= 0) {
 				/* magic item is used up */
-				GUI_output(get_ttx(0x9f8));
+				GUI_output(get_ttx(638));
 			} else {
 				/* special item */
 #if !defined(__BORLANDC__)
@@ -118,7 +118,7 @@ void item_arcano(void)
 
 	/* ask who should be affected */
 	host_writeb(get_spelluser() + HERO_ENEMY_ID,
-		select_hero_from_group(get_ttx(0x9f4)) + 1);
+		select_hero_from_group(get_ttx(637)) + 1);
 
 	if (host_readbs(get_spelluser() + HERO_ENEMY_ID) > 0) {
 		/* use it */
@@ -139,24 +139,24 @@ void item_read_recipe(void)
 	Bit8u *str;
 
 	switch (ds_readws(USED_ITEM_ID)) {
-	case 0xa7: str = get_ttx(0x9fc); break;
-	case 0xa9: str = get_ttx(0xa00); break;
-	case 0xca: str = get_ttx(0xa24); break;
-	case 0xcb: str = get_ttx(0xa28); break;
-	case 0xcc: str = get_ttx(0xa2c); break;
-	case 0xcd: str = get_ttx(0xa30); break;
-	case 0xce: str = get_ttx(0xa34); break;
-	case 0xba: str = get_ttx(0xaa4); break;
-	case 0xf0: str = get_ttx(0xaa8); break;
-	case 0xf2: str = get_ttx(0xab0); break;
-	case 0xf3: str = get_ttx(0xab4); break;
-	case 0xf4: str = get_ttx(0xab8); break;
-	case 0xf1: str = get_ttx(0xaac); break;
+	case 0xa7: str = get_ttx(639); break;
+	case 0xa9: str = get_ttx(640); break;
+	case 0xca: str = get_ttx(649); break;
+	case 0xcb: str = get_ttx(650); break;
+	case 0xcc: str = get_ttx(651); break;
+	case 0xcd: str = get_ttx(652); break;
+	case 0xce: str = get_ttx(653); break;
+	case 0xba: str = get_ttx(681); break;
+	case 0xf0: str = get_ttx(682); break;
+	case 0xf2: str = get_ttx(684); break;
+	case 0xf3: str = get_ttx(685); break;
+	case 0xf4: str = get_ttx(686); break;
+	case 0xf1: str = get_ttx(683); break;
 	}
 
 	/* prepare message */
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_ttx(0x9f0),
+		(char*)get_ttx(636),
 		(char*)str);
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
@@ -169,15 +169,15 @@ void item_read_document(void)
 	signed short textbox_width_bak;
 
 	switch (ds_readws(USED_ITEM_ID)) {
-	case 0xaa: str = get_ttx(0xa04); break;
-	case 0xbb: str = get_ttx(0xa14); break;
-	case 0xbd: str = get_ttx(0xa18); break;
-	case 0xbe: str = get_ttx(0xa1c); break;
-	case 0xc0: str = get_ttx(0xa20); break;
-	case 0xde: str = get_ttx(0xa38); break;
-	case 0xe0: str = get_ttx(0xa3c); break;
-	case 0xeb: str = get_ttx(0xa44); break;
-	case 0xf7: str = get_ttx(0xbdc); break;
+	case 0xaa: str = get_ttx(641); break;
+	case 0xbb: str = get_ttx(645); break;
+	case 0xbd: str = get_ttx(646); break;
+	case 0xbe: str = get_ttx(647); break;
+	case 0xc0: str = get_ttx(648); break;
+	case 0xde: str = get_ttx(654); break;
+	case 0xe0: str = get_ttx(655); break;
+	case 0xeb: str = get_ttx(657); break;
+	case 0xf7: str = get_ttx(759); break;
 	}
 
 	textbox_width_bak = ds_readws(TEXTBOX_WIDTH);
@@ -203,7 +203,7 @@ void item_armatrutz(void)
 
 	/* ask who should be affected */
 	host_writeb(get_spelluser() + HERO_ENEMY_ID,
-		select_hero_from_group(get_ttx(0x9f4)) + 1);
+		select_hero_from_group(get_ttx(637)) + 1);
 
 	if (host_readbs(get_spelluser() + HERO_ENEMY_ID) > 0) {
 		/* use it */
@@ -264,7 +264,7 @@ void item_debtbook(void)
 		ds_writeb_z(INFORMER_FLAGS + INFORMER_HJORE, 1);
 	}
 
-	GUI_output(get_ttx(0xa08));
+	GUI_output(get_ttx(642));
 }
 
 /* Borlandified and identical */
@@ -280,9 +280,9 @@ void item_orcdocument(void)
 			ds_writeb(ORCDOCUMENT_READ_FLAG, 1);
 		}
 
-		GUI_output(get_ttx(0xa10));
+		GUI_output(get_ttx(644));
 	} else {
-		GUI_output(get_ttx(0xa0c));
+		GUI_output(get_ttx(643));
 	}
 }
 
@@ -395,11 +395,11 @@ void item_weapon_poison(void)
 		give_hero_new_item(get_itemuser(), bottle, 1, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xb8c),
+			(char*)get_ttx(739),
 			(char*)Real2Host(GUI_names_grammar((signed short)0x8000, host_readws(get_itemuser() + HERO_ITEM_RIGHT), 0)));
 	} else {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_ttx(0xc94),
+			(char*)get_ttx(805),
 			(char*)get_itemuser() + HERO_NAME2);
 	}
 
@@ -410,7 +410,7 @@ void item_myastmatic(void)
 {
 	/* MYASTMATIC, ID 238 */
 	if (ds_readws(IN_FIGHT) == 0) {
-		GUI_output(get_ttx(0xabc));
+		GUI_output(get_ttx(687));
 		return;
 	}
 }
@@ -419,7 +419,7 @@ void item_hylailic(void)
 {
 	/* HYLAILIC FIRE, ID 239 */
 	if (ds_readws(IN_FIGHT) == 0) {
-		GUI_output(get_ttx(0xabc));
+		GUI_output(get_ttx(687));
 		return;
 	}
 }
@@ -429,7 +429,7 @@ void item_magic_book(void)
 	/* BOOK, ID 246 */
 
 	/* print message */
-	GUI_output(get_ttx(0xbb4));
+	GUI_output(get_ttx(749));
 
 	/* Heptagon +2 */
 	add_ptr_bs(get_itemuser() + (HERO_SP_DEMON + 3), 2);
@@ -480,12 +480,12 @@ void item_brenne(void)
 
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1dc),
+				(char*)get_tx(119),
 				(char*)get_itemuser() + HERO_NAME2);
 		} else {
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1e0),
+				(char*)get_tx(120),
 				(char*)get_itemuser() + HERO_NAME2);
 		}
 	} else {
@@ -494,7 +494,7 @@ void item_brenne(void)
 			/* No tinderbox */
 			/* prepare message */
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx(0x1e8),
+				(char*)get_tx(122),
 				(char*)get_itemuser() + HERO_NAME2);
 		} else {
 
@@ -545,7 +545,7 @@ void item_bag(void)
 #endif
 
 	/* print message */
-	GUI_output(get_ttx(0xc1c));
+	GUI_output(get_ttx(775));
 
 	/* drop the BAG */
 	drop_item(get_itemuser(), get_item_pos(get_itemuser(), 221), 1);

--- a/src/custom/schick/rewrite_m302de/seg108.cpp
+++ b/src/custom/schick/rewrite_m302de/seg108.cpp
@@ -84,7 +84,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 			/* consume quietly */
 			if (!ds_readbs(CONSUME_QUIET)) {
-				GUI_output(get_ttx(0x33c));
+				GUI_output(get_ttx(207));
 			}
 
 			/* drop one unit of that item */
@@ -115,7 +115,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 				/* consume quietly */
 				if (!ds_readbs(CONSUME_QUIET)) {
-					GUI_output(get_ttx(0x340));
+					GUI_output(get_ttx(208));
 				}
 
 
@@ -146,7 +146,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 				}
 			} else {
 				/* print empty message */
-				GUI_output(get_ttx(0x6b4));
+				GUI_output(get_ttx(429));
 			}
 		}
 
@@ -157,11 +157,11 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 		if (host_readb(item_p + 3) == 0) {
 
 			if (is_in_word_array(item, (signed short*)(p_datseg + HERBS_UNEATABLE))) {
-				GUI_output(get_ttx(0x7cc));
+				GUI_output(get_ttx(499));
 			} else if (is_in_word_array(item, (signed short*)(p_datseg + HERBS_TOXIC)) ||
 					is_in_word_array(item, (signed short*)(p_datseg + POISON_POTIONS))) {
 				/* herbs and poisons */
-				GUI_output(get_ttx(0x7d0));
+				GUI_output(get_ttx(500));
 			} else {
 				/* consume with effects */
 
@@ -183,7 +183,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 					add_hero_le(consumer, 2);
 
 					/* prepare output */
-					strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x7d4));
+					strcpy((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(501));
 					break;
 				}
 				case 0x3c: {
@@ -197,7 +197,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 					add_hero_le(consumer, l_di);
 
 					/* prepare output */
-					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x7d8), l_di);
+					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(502), l_di);
 
 					break;
 				}
@@ -217,7 +217,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7dc),
+						(char*)get_ttx(503),
 						(char*)consumer + HERO_NAME2);
 					break;
 				}
@@ -236,7 +236,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7dc),
+						(char*)get_ttx(503),
 						(char*)consumer + HERO_NAME2);
 					break;
 				}
@@ -250,7 +250,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7e0),
+						(char*)get_ttx(504),
 						(char*)consumer + HERO_NAME2);
 					break;
 				}
@@ -264,7 +264,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 					add_hero_le(consumer, l_di);
 					/* prepare output */
 
-					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(0x7e4), l_di);
+					sprintf((char*)Real2Host(ds_readd(DTP2)), (char*)get_ttx(505), l_di);
 					break;
 				}
 				case 0x40: {
@@ -301,8 +301,8 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 				/* prepare output */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x7f4), (char*)consumer + HERO_NAME2,
-					(char*)get_ttx((0x19b + l_si) * 4), 5);
+					(char*)get_ttx(509), (char*)consumer + HERO_NAME2,
+					(char*)get_ttx(411 + l_si), 5);
 
 				/* print output */
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -324,8 +324,8 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 				/* prepare output */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xa40), (char*)consumer + HERO_NAME2,
-					(char*)get_ttx((0x19b + id_bad_elex) * 4), 7);
+					(char*)get_ttx(656), (char*)consumer + HERO_NAME2,
+					(char*)get_ttx(411 + id_bad_elex), 7);
 
 				/* print output */
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -346,12 +346,12 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* singular POINT/ PUNKT */
 					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0x620));
+						(char*)get_ttx(392));
 
 					if (l_si > 1) {
 						/* make plural POINTS/PUNKTE */
 						strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0x624));
+						(char*)get_ttx(393));
 					}
 
 					/* add LE */
@@ -362,7 +362,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7f8),
+						(char*)get_ttx(510),
 						(char*)consumer + HERO_NAME2,
 						l_si,
 						(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -384,17 +384,17 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* singular POINT/ PUNKT */
 					strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0x620));
+						(char*)get_ttx(392));
 
 					if (l_si > 1) {
 						/* make plural POINTS/PUNKTE */
 						strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-						(char*)get_ttx(0x624));
+						(char*)get_ttx(393));
 					}
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7f8),
+						(char*)get_ttx(510),
 						(char*)consumer + HERO_NAME2,
 						l_si,
 						(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)));
@@ -434,7 +434,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x7fc),
+						(char*)get_ttx(511),
 						(char*)consumer + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(consumer + HERO_SEX), 0)));
 
@@ -451,7 +451,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 					/* prepare output */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xb88),
+						(char*)get_ttx(738),
 						(char*)consumer + HERO_NAME2);
 					break;
 				}
@@ -474,15 +474,15 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 						/* prepare output */
 						strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-							(char*)get_ttx(0x620));
+							(char*)get_ttx(392));
 
 						if (l_si > 1) {
 							strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-								(char*)get_ttx(0x624));
+								(char*)get_ttx(393));
 						}
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x800),
+							(char*)get_ttx(512),
 							l_si,
 							(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 							(char*)consumer + HERO_NAME2);
@@ -491,7 +491,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 						/* prepare output */
 						strcpy((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xc90));
+							(char*)get_ttx(804));
 
 						/* give owner a glassbottle */
 						give_hero_new_item(owner, 0x1f, 2, 1);
@@ -520,19 +520,19 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 						/* prepare output */
 						if (host_readws(consumer + HERO_AE) >= host_readws(consumer + HERO_AE_ORIG)) {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x804),
+								(char*)get_ttx(513),
 								(char*)consumer + HERO_NAME2);
 						} else {
 							strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-								(char*)get_ttx(0x620));
+								(char*)get_ttx(392));
 
 							if (l_si > 1) {
 								strcat((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
-									(char*)get_ttx(0x624));
+									(char*)get_ttx(393));
 							}
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x800),
+								(char*)get_ttx(512),
 								l_si,
 								(char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)),
 								(char*)consumer + HERO_NAME2);
@@ -542,7 +542,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 						/* prepare output */
 						strcpy((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xc90));
+							(char*)get_ttx(804));
 
 						/* give owner a glassbottle */
 						give_hero_new_item(owner, 0x1f, 2, 1);
@@ -564,7 +564,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x74c),
+						(char*)get_ttx(467),
 						(char*)consumer + HERO_NAME2);
 					break;
 				}
@@ -580,7 +580,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 					give_hero_new_item(owner, 0x1f, 2, 1);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x74c),
+						(char*)get_ttx(467),
 						(char*)consumer + HERO_NAME2);
 					break;
 
@@ -598,7 +598,7 @@ void consume(Bit8u *owner, Bit8u *consumer, signed short pos)
 		ds_writew(REQUEST_REFRESH, 1);
 	} else {
 		/* this item cannot be consumed */
-		GUI_output(get_ttx(0x338));
+		GUI_output(get_ttx(206));
 	}
 }
 

--- a/src/custom/schick/rewrite_m302de/seg109.cpp
+++ b/src/custom/schick/rewrite_m302de/seg109.cpp
@@ -281,15 +281,15 @@ void TRV_found_herb_place(signed short a0)
 	randval = random_schick(5) + 2;
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x00),
-		(char*)get_tx(4 * randval),
+		(char*)get_tx(0),
+		(char*)get_tx(randval),
 		(char*)hero + HERO_NAME2,
-		(char*)(a0 != 0 ? get_tx(0xa8) : p_datseg + EMPTY_STRING10));
+		(char*)(a0 != 0 ? get_tx(42) : p_datseg + EMPTY_STRING10));
 
 	do {
 		answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-				get_tx(0x04),
-				get_tx(0x08));
+				get_tx(1),
+				get_tx(2));
 
 	} while (answer == -1);
 
@@ -307,11 +307,11 @@ void TRV_inside_herb_place(void)
 	load_ani(1);
 	draw_main_screen();
 	init_ani(0);
-	hero_pos = select_hero_ok(get_ttx(0x518));
+	hero_pos = select_hero_ok(get_ttx(326));
 
 	if (hero_pos != -1) {
 
-		hours = GUI_input(get_ttx(0x51c), 1);
+		hours = GUI_input(get_ttx(327), 1);
 
 		if (hours > 0) {
 			bak = ds_readbs(SPECIAL_SCREEN);
@@ -334,13 +334,13 @@ signed short TRV_found_camp_place(signed short a0)
 
 	randval = random_schick(5) + 10;
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x020),
-		(char*)get_tx(4 * randval),
-		(char*)(a0 == 1 ? get_tx(0xa8) : (a0 == 2 ? get_tx(0xb4) : p_datseg + EMPTY_STRING11)));
+		(char*)get_tx(8),
+		(char*)get_tx(randval),
+		(char*)(a0 == 1 ? get_tx(42) : (a0 == 2 ? get_tx(45) : p_datseg + EMPTY_STRING11)));
 	do {
 		answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-					get_tx(0x24),
-					get_tx(0x28));
+					get_tx(9),
+					get_tx(10));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -377,13 +377,13 @@ void TRV_found_replenish_place(signed short a0)
 	signed short answer;
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x040),
-		(char*)get_tx(4 * (random_schick(5) + 11)),
-		(char*)(a0 != 0 ? get_tx(0xb4) : p_datseg + EMPTY_STRING12));
+		(char*)get_tx(16),
+		(char*)get_tx(random_schick(5) + 11),
+		(char*)(a0 != 0 ? get_tx(45) : p_datseg + EMPTY_STRING12));
 	do {
 		answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-					get_tx(0x54),
-					get_tx(0x58));
+					get_tx(21),
+					get_tx(22));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -431,7 +431,7 @@ void TRV_found_inn(signed short city, signed short type)
 	draw_main_screen();
 	init_ani(0);
 
-	if (GUI_bool(get_tx(0x5c))) {
+	if (GUI_bool(get_tx(23))) {
 		ds_writew(CITYINDEX, city);
 		ds_writew(TYPEINDEX, type);
 		ds_writeb(LOCATION, LOCATION_INN);
@@ -460,7 +460,7 @@ signed short TRV_enter_hut_question(void)
 	draw_main_screen();
 	init_ani(0);
 
-	answer = GUI_bool(get_tx(0x60));
+	answer = GUI_bool(get_tx(24));
 
 	set_var_to_zero();
 	ds_writew(REQUEST_REFRESH, 1);
@@ -476,13 +476,13 @@ signed short TRV_follow_trail_question(void)
 	hero = Real2Host(get_first_hero_available_in_group());
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx(0x64),
+		(char*)get_tx(25),
 		(char*)hero + HERO_NAME2);
 
 	do {
 		answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-				get_tx(0x68),
-				get_tx(0x6c));
+				get_tx(26),
+				get_tx(27));
 
 	} while (answer == -1);
 
@@ -503,20 +503,20 @@ signed short TRV_cross_a_ford(Bit8u *msg, signed short time, signed short mod)
 
 	do {
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x88),
+			(char*)get_tx(34),
 			(char*)msg);
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-						get_tx(0x8c),
-						get_tx(0x90));
+						get_tx(35),
+						get_tx(36));
 		} while (answer == -1);
 
 		if (answer == 1) {
 			done = 1;
 			TRV_ford_test(mod, time);
 		} else {
-			answer = GUI_bool(get_tx(0x9c));
+			answer = GUI_bool(get_tx(39));
 
 			if (answer == 1) {
 				done = ds_writew(TRV_RETURN, 1);
@@ -554,18 +554,18 @@ void TRV_ford_test(signed short mod, signed short time)
 				timewarp(MINUTES(time));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x94),
+					(char*)get_tx(37),
 					(char*)hero + HERO_NAME2);
 
 				hero_disease_test(hero, 2, 20 - (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) + host_readbs(hero + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK))));
 
-				loose_random_item(hero, 1, get_ttx(0x7e8));
+				loose_random_item(hero, 1, get_ttx(506));
 			} else {
 				/* test succeded */
 				timewarp(MINUTES(10));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x98),
+					(char*)get_tx(38),
 					(char*)hero + HERO_NAME2);
 			}
 
@@ -587,15 +587,15 @@ signed short TRV_ferry(Bit8u *msg, signed short price)
 	do {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx(0x70),
+			(char*)get_tx(28),
 			(char*)msg,
 			price, 5 * price);
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 3,
-						get_tx(0x74),
-						get_tx(0x78),
-						get_tx(0x7c));
+						get_tx(29),
+						get_tx(30),
+						get_tx(31));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -604,7 +604,7 @@ signed short TRV_ferry(Bit8u *msg, signed short price)
 			p_money = get_party_money();
 
 			if ((Bit32u)price > p_money) {
-				GUI_output(get_ttx(0x644));
+				GUI_output(get_ttx(401));
 			} else {
 				done = 1;
 				p_money -= price;
@@ -618,13 +618,13 @@ signed short TRV_ferry(Bit8u *msg, signed short price)
 			p_money = get_party_money();
 
 			if ((Bit32u)price > p_money) {
-				GUI_output(get_ttx(0x644));
+				GUI_output(get_ttx(401));
 			} else {
 				p_money -= price;
 				set_party_money(p_money);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx(0x80),
+					(char*)get_tx(32),
 					done = random_schick(6));
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -635,7 +635,7 @@ signed short TRV_ferry(Bit8u *msg, signed short price)
 			}
 		} else {
 
-			if (GUI_bool(get_tx(0x84))) {
+			if (GUI_bool(get_tx(33))) {
 				ds_writew(TRV_RETURN, done = 1);
 			}
 		}
@@ -662,18 +662,18 @@ void tevent_002(void)
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
 				NULL,
-				get_tx2(0x00),
+				get_tx2(0),
 				3,
-				get_tx2(0x04),
-				get_tx2(0x08),
-				get_tx2(0x0c));
+				get_tx2(1),
+				get_tx2(2),
+				get_tx2(3));
 
 	} while (answer == -1);
 
 	/* talk to the hunter for 15 min */
 	if (answer == 1 || answer == 2) {
 
-		GUI_dialog_na(0, answer == 1 ? get_tx2(0x10) : get_tx2(0x14));
+		GUI_dialog_na(0, answer == 1 ? get_tx2(4) : get_tx2(5));
 
 		timewarp(MINUTES(15));
 	}
@@ -681,7 +681,7 @@ void tevent_002(void)
 
 void tevent_003(void)
 {
-	TRV_ferry(get_tx(0x114), 5);
+	TRV_ferry(get_tx(69), 5);
 }
 
 void tevent_004(void)
@@ -712,7 +712,7 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 	draw_main_screen();
 	init_ani(0);
 
-	GUI_output(get_tx2(4 * city_index));
+	GUI_output(get_tx2(city_index));
 
 	hero = get_hero(0);
 	for (i = l_di = 0; i <= 6; i++, hero += SIZEOF_HERO) {
@@ -729,28 +729,28 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 	if (l_di) {
 
 		do {
-			answer = GUI_radio(get_tx2(4 * (city_index + 1)), 2,
-						get_tx2(4 * (city_index + 7)),
-						get_tx2(4 * (city_index + 8)));
+			answer = GUI_radio(get_tx2(city_index + 1), 2,
+						get_tx2(city_index + 7),
+						get_tx2(city_index + 8));
 		} while (answer == -1);
 
 	} else {
 
-		i = select_hero_ok_forced(get_tx2(4 * (city_index + 2)));
+		i = select_hero_ok_forced(get_tx2(city_index + 2));
 
 		hero = get_hero(i);
 
 		if (test_skill(hero, TA_SCHLEICHEN, (signed char)mod2) <= 0) {
 
 			do {
-				answer = GUI_radio(get_tx2(4 * (city_index + 1)), 2,
-							get_tx2(4 * (city_index + 7)),
-							get_tx2(4 * (city_index + 8)));
+				answer = GUI_radio(get_tx2(city_index + 1), 2,
+							get_tx2(city_index + 7),
+							get_tx2(city_index + 8));
 			} while (answer == -1);
 		} else {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(4 * (city_index + 3)),
+				(char*)get_tx2(city_index + 3),
 				(char*)hero + HERO_NAME2);
 
 			GUI_input(Real2Host(ds_readd(DTP2)), l_di = 0);
@@ -766,7 +766,7 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 			if (l_di == 2 || i == 99 || l4 == 99) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(4 * (city_index + 4)),
+					(char*)get_tx2(city_index + 4),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -782,13 +782,13 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 			} else {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(4 * (l_di == 1 ? city_index + 5 : city_index + 6)),
+					(char*)get_tx2(l_di == 1 ? city_index + 5 : city_index + 6),
 					(char*)hero + HERO_NAME2);
 
 				do {
 					answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-								get_tx2(4 * (city_index + 7)),
-								get_tx2(4 * (city_index + 8)));
+								get_tx2(city_index + 7),
+								get_tx2(city_index + 8));
 				} while (answer == -1);
 			}
 		}
@@ -804,7 +804,7 @@ void TRV_hunt_generic(signed short ani_id, signed short city_index, signed short
 
 	} else if (answer == 1) {
 
-		GUI_output(get_tx2(4 * (city_index + 9)));
+		GUI_output(get_tx2(city_index + 9));
 
 		timewarp(HOURS(2));
 
@@ -828,7 +828,7 @@ void tevent_005(void)
 
 void tevent_006(void)
 {
-	TRV_ferry(get_tx(0x114), 4);
+	TRV_ferry(get_tx(69), 4);
 }
 
 void tevent_007(void)
@@ -856,16 +856,16 @@ void TRV_barrier(signed short text_start)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(4 * (text_start + 0)), 2,
-						get_tx2(4 * (text_start + 1)),
-						get_tx2(4 * (text_start + 2)));
+						get_tx2(text_start + 0), 2,
+						get_tx2(text_start + 1),
+						get_tx2(text_start + 2));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			timewarp(HOURS(2));
 
-			GUI_dialog_na(0, get_tx2(4 * (text_start + 3)));
+			GUI_dialog_na(0, get_tx2(text_start + 3));
 
 			done = 1;
 		} else {
@@ -899,7 +899,7 @@ void TRV_barrier(signed short text_start)
 
 				if (l_di || get_first_hero_with_item(27) == -1) {
 
-					GUI_dialog_na(0, get_tx2(4 * (text_start + 4)));
+					GUI_dialog_na(0, get_tx2(text_start + 4));
 
 				} else {
 					hero = get_hero(0);
@@ -925,13 +925,13 @@ void TRV_barrier(signed short text_start)
 
 					if (l_di >= 3) {
 
-						GUI_dialog_na(0, get_tx2(4 * (text_start + 6)));
+						GUI_dialog_na(0, get_tx2(text_start + 6));
 					} else {
 
-						hero = get_hero(select_hero_ok_forced(get_tx2(4 * (text_start + 5))));
+						hero = get_hero(select_hero_ok_forced(get_tx2(text_start + 5)));
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(4 * (text_start + 7)),
+								(char*)get_tx2(text_start + 7),
 								(char*)hero + HERO_NAME2,
 								Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)),
 								Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
@@ -939,13 +939,13 @@ void TRV_barrier(signed short text_start)
 
 						hero_disease_test(hero, 2, 30);
 
-						loose_random_item(hero, 30, get_ttx(0x7e8));
+						loose_random_item(hero, 30, get_ttx(506));
 					}
 					done = 1;
 				}
 			} else {
 				/* not enough */
-				GUI_dialog_na(0, get_tx2(4 * (text_start + 4)));
+				GUI_dialog_na(0, get_tx2(text_start + 4));
 			}
 		}
 
@@ -981,22 +981,22 @@ void tevent_010(void)
 
 void tevent_012(void)
 {
-	TRV_cross_a_ford(get_tx(0xd4), 30, 0);
+	TRV_cross_a_ford(get_tx(53), 30, 0);
 }
 
 void tevent_018(void)
 {
-	TRV_cross_a_ford(get_tx(0xd4), 20, 0);
+	TRV_cross_a_ford(get_tx(53), 20, 0);
 }
 
 void tevent_019(void)
 {
-	TRV_cross_a_ford(get_tx(0x118), 20, 0);
+	TRV_cross_a_ford(get_tx(70), 20, 0);
 }
 
 void tevent_023(void)
 {
-	TRV_ferry(get_tx(0x114), 3);
+	TRV_ferry(get_tx(69), 3);
 }
 
 void tevent_092(void)

--- a/src/custom/schick/rewrite_m302de/seg110.cpp
+++ b/src/custom/schick/rewrite_m302de/seg110.cpp
@@ -46,23 +46,23 @@ void tevent_011(void)
 		ds_writeb(TEVENT011_FLAG, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x60),
+			(char*)get_tx2(24),
 			(char*)hero + HERO_NAME2,
 			(char*)hero + HERO_NAME2);
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-						get_tx2(0x64),
-						get_tx2(0x68));
+						get_tx2(25),
+						get_tx2(26));
 		} while (answer == -1);
 
 		if (answer == 2)
 		{
 			do {
-				answer = GUI_radio(get_tx2(0x6c), 3,
-							get_tx2(0x70),
-							get_tx2(0x74),
-							get_tx2(0x78));
+				answer = GUI_radio(get_tx2(27), 3,
+							get_tx2(28),
+							get_tx2(29),
+							get_tx2(30));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -108,14 +108,14 @@ void TRV_swim2(signed char mod, signed short percent)
 			{
 				/* skill test succeeded */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x7c),
+					(char*)get_tx2(31),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
 			} else {
 				/* skill test failed */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x80),
+					(char*)get_tx2(32),
 					(char*)hero + HERO_NAME2,
 					(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -125,7 +125,7 @@ void TRV_swim2(signed char mod, signed short percent)
 
 				if (percent)
 				{
-					loose_random_item(hero, percent, get_ttx(0x7e8));
+					loose_random_item(hero, percent, get_ttx(506));
 				}
 
 				sub_hero_le(hero, random_schick(5));
@@ -142,9 +142,9 @@ void TRV_a_path(void)
 	signed short answer;
 
 	do {
-		answer = GUI_radio(get_tx2(0x84), 2,
-					get_tx2(0x88),
-					get_tx2(0x8c));
+		answer = GUI_radio(get_tx2(33), 2,
+					get_tx2(34),
+					get_tx2(35));
 	} while (answer == -1);
 
 	if (answer == 1)
@@ -156,9 +156,9 @@ void TRV_a_path(void)
 		/* swim back */
 
 		do {
-			answer = GUI_radio(get_tx2(0x90), 2,
-						get_tx2(0x70),
-						get_tx2(0x74));
+			answer = GUI_radio(get_tx2(36), 2,
+						get_tx2(28),
+						get_tx2(29));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -174,7 +174,7 @@ void TRV_a_path(void)
 			TRV_swim2(0, 0);
 		}
 
-		GUI_output(get_tx2(0x94));
+		GUI_output(get_tx2(37));
 	}
 }
 
@@ -200,15 +200,15 @@ void tevent_014(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0xac), 2,
-						get_tx2(0xb0),
-						get_tx2(0xb4));
+						get_tx2(43), 2,
+						get_tx2(44),
+						get_tx2(45));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			/* examine the corpse */
-			loot_corpse((RealPt)RealMake(datseg, TEVENT014_CORPSE), get_tx2(0xb8), p_datseg + TEVENT014_FLAG);
+			loot_corpse((RealPt)RealMake(datseg, TEVENT014_CORPSE), get_tx2(46), p_datseg + TEVENT014_FLAG);
 		}
 	}
 }
@@ -217,7 +217,7 @@ void tevent_014_chest(RealPt chest)
 {
 	host_writed(Real2Host(chest) + 11, (Bit32u)RealMake(datseg, TEVENT014_CHEST));
 
-	loot_chest(Real2Host(chest), get_tx2(0xbc), get_tx2(0xc0));
+	loot_chest(Real2Host(chest), get_tx2(47), get_tx2(48));
 }
 
 void tevent_015(void)
@@ -247,21 +247,21 @@ void tevent_020(void)
 		ds_writeb(TEVENT020_FLAG, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0xc4),
+			(char*)get_tx2(49),
 			(char*)hero + HERO_NAME2);
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-						get_tx2(0xc8),
-						get_tx2(0xcc));
+						get_tx2(50),
+						get_tx2(51));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			do {
-				answer = GUI_radio(get_tx2(0xd0), 2,
-							get_tx2(0xd4),
-							get_tx2(0xd8));
+				answer = GUI_radio(get_tx2(52), 2,
+							get_tx2(53),
+							get_tx2(54));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -302,9 +302,9 @@ void tevent_022(void)
 				ds_readb(TEVENT022_TRACK_FLAG) != 0)
 			{
 				do {
-					answer = GUI_radio(get_tx2(0xec), 2,
-								get_tx2(0xf0),
-								get_tx2(0xf4));
+					answer = GUI_radio(get_tx2(59), 2,
+								get_tx2(60),
+								get_tx2(61));
 				} while (answer == -1);
 
 				if (answer == 1)
@@ -339,12 +339,12 @@ void tevent_025(void)
 
 void tevent_026(void)
 {
-	TRV_cross_a_ford(get_tx2(0x120), 60, 0);
+	TRV_cross_a_ford(get_tx2(72), 60, 0);
 }
 
 void tevent_027(void)
 {
-	TRV_cross_a_ford(get_tx2(0x124), 30, 0);
+	TRV_cross_a_ford(get_tx2(73), 30, 0);
 }
 
 void tevent_028(void)
@@ -365,8 +365,8 @@ void tevent_029(void)
 
 	load_in_head(51);
 
-	GUI_dialog_na(0, get_tx2(0x128));
-	GUI_dialog_na(0, get_tx2(0x12c));
+	GUI_dialog_na(0, get_tx2(74));
+	GUI_dialog_na(0, get_tx2(75));
 
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -379,7 +379,7 @@ void tevent_029(void)
 		/* skill test succeeded */
 		timewarp(HOURS(3));
 
-		GUI_dialog_na(0, get_tx2(0x130));
+		GUI_dialog_na(0, get_tx2(76));
 	} else {
 		/* skill test failed */
 		hero = get_hero(0);
@@ -411,7 +411,7 @@ void tevent_029(void)
 
 		timewarp(HOURS(5));
 
-		GUI_dialog_na(0, get_tx2(0x134));
+		GUI_dialog_na(0, get_tx2(77));
 	}
 }
 
@@ -439,9 +439,9 @@ void tevent_031(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x00), 2,
-						get_tx2(0x04),
-						get_tx2(0x08));
+						get_tx2(0), 2,
+						get_tx2(1),
+						get_tx2(2));
 		} while (answer == -1);
 
 		if (answer == 2)
@@ -488,17 +488,17 @@ void tevent_033(void)
 
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-					get_tx2(0x0c), 3,
-					get_tx2(0x10),
-					get_tx2(0x14),
-					get_tx2(0x18));
+					get_tx2(3), 3,
+					get_tx2(4),
+					get_tx2(5),
+					get_tx2(6));
 	} while (answer == -1);
 
 	if (answer == 1 || answer == 2)
 	{
 		timewarp(MINUTES(15));
 
-		GUI_dialog_na(0, (Bit8u*)(answer == 1 ? get_tx2(0x1c) : get_tx2(0x20)));
+		GUI_dialog_na(0, (Bit8u*)(answer == 1 ? get_tx2(7) : get_tx2(8)));
 	}
 }
 
@@ -519,9 +519,9 @@ void tevent_035(void)
 	if (!ds_readb(TEVENT035_FLAG))
 	{
 		do {
-			answer = GUI_radio(get_tx2(0x24), 2,
-						get_tx2(0x28),
-						get_tx2(0x2c));
+			answer = GUI_radio(get_tx2(9), 2,
+						get_tx2(10),
+						get_tx2(11));
 		} while (answer == -1);
 
 		if (answer == 2)
@@ -590,9 +590,9 @@ void tevent_041(void)
 	if (test_skill(Real2Host(get_first_hero_available_in_group()), TA_FAEHRTENSUCHEN, 0) > 0 && !ds_readb(TEVENT041_FLAG))
 	{
 		do {
-			answer = GUI_radio(get_tx2(0x50), 2,
-						get_tx2(0x54),
-						get_tx2(0x58));
+			answer = GUI_radio(get_tx2(20), 2,
+						get_tx2(21),
+						get_tx2(22));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -639,15 +639,15 @@ void tevent_044(void)
 		hero = Real2Host(get_first_hero_available_in_group());
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-			(char*)get_tx2(0x84),
+			(char*)get_tx2(33),
 			(char*)hero + HERO_NAME2,
 			(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
 						Real2Host(ds_readd(DTP2)) + 0x400, 2,
-						get_tx2(0x88),
-						get_tx2(0x8c));
+						get_tx2(34),
+						get_tx2(35));
 		} while (answer == -1);
 
 		if (answer == 2)
@@ -673,17 +673,17 @@ void tevent_045(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x90), 3,
-						get_tx2(0x94),
-						get_tx2(0x98),
-						get_tx2(0x9c));
+						get_tx2(36), 3,
+						get_tx2(37),
+						get_tx2(38),
+						get_tx2(39));
 		} while (answer == -1);
 
 		if (answer == 1 || answer == 2)
 		{
 			timewarp(MINUTES(15));
 
-			GUI_dialog_na(0, (Bit8u*)(answer == 1 ? get_tx2(0xa0) : get_tx2(0xa4)));
+			GUI_dialog_na(0, (Bit8u*)(answer == 1 ? get_tx2(40) : get_tx2(41)));
 		}
 	}
 }
@@ -705,9 +705,9 @@ void tevent_046(void)
 	init_ani(0);
 
 	do {
-		answer = GUI_radio(get_tx2(0xa8), 2,
-					get_tx2(0xac),
-					get_tx2(0xb0));
+		answer = GUI_radio(get_tx2(42), 2,
+					get_tx2(43),
+					get_tx2(44));
 	} while (answer == -1);
 
 	if (answer == 1)
@@ -725,14 +725,14 @@ void tevent_046(void)
 		if (test_skill(hero, TA_SINNESSCHAERFE, 0) > 0)
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0xb4),
+				(char*)get_tx2(45),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 			do {
 				answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-							get_tx2(0xb8),
-							get_tx2(0xbc));
+							get_tx2(46),
+							get_tx2(47));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -745,7 +745,7 @@ void tevent_046(void)
 		if (!enter_inn)
 		{
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0xc0),
+				(char*)get_tx2(48),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -755,9 +755,9 @@ void tevent_046(void)
 			TRV_fight_event(FIGHTS_F046, 46);
 
 			do {
-				answer = GUI_radio(get_tx2(0xc4), 2,
-							get_tx2(0xc8),
-							get_tx2(0xcc));
+				answer = GUI_radio(get_tx2(49), 2,
+							get_tx2(50),
+							get_tx2(51));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -788,9 +788,9 @@ void tevent_048(void)
 				ds_readb(TEVENT048_TRACK_FLAG) != 0)
 			{
 				do {
-					answer = GUI_radio(get_tx2(0xd0), 2,
-								get_tx2(0xd4),
-								get_tx2(0xd8));
+					answer = GUI_radio(get_tx2(52), 2,
+								get_tx2(53),
+								get_tx2(54));
 				} while (answer == -1);
 
 				if (answer == 1)

--- a/src/custom/schick/rewrite_m302de/seg111.cpp
+++ b/src/custom/schick/rewrite_m302de/seg111.cpp
@@ -76,7 +76,7 @@ void tevent_057(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0x04), 2, get_tx2(0x08), get_tx2(0x0c));
+		answer = GUI_radio(get_tx2(1), 2, get_tx2(2), get_tx2(3));
 
 	} while (answer == -1);
 
@@ -86,13 +86,13 @@ void tevent_057(void)
 
 			timewarp(HOURS(2));
 
-			GUI_output(get_tx2(0x10));
+			GUI_output(get_tx2(4));
 
 		} else {
 
 			timewarp(HOURS(6));
 
-			GUI_output(get_tx2(0x14));
+			GUI_output(get_tx2(5));
 
 			hero = get_hero(0);
 
@@ -122,7 +122,7 @@ void tevent_057(void)
 				{
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x20),
+						(char*)get_tx2(8),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -132,7 +132,7 @@ void tevent_057(void)
 
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x1c),
+						(char*)get_tx2(7),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -142,7 +142,7 @@ void tevent_057(void)
 			}
 		}
 
-		GUI_output(get_tx2(0x18));
+		GUI_output(get_tx2(6));
 	}
 }
 
@@ -175,9 +175,9 @@ void tevent_059(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-						get_tx2(0x24), 2,
-						get_tx2(0x28),
-						get_tx2(0x2c));
+						get_tx2(9), 2,
+						get_tx2(10),
+						get_tx2(11));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -186,28 +186,28 @@ void tevent_059(void)
 			{
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-								get_tx2(0x30), 3,
-								get_tx2(0x34),
-								get_tx2(0x38),
-								get_tx2(0x3c));
+								get_tx2(12), 3,
+								get_tx2(13),
+								get_tx2(14),
+								get_tx2(15));
 				} while (answer == -1);
 
 				if (answer == 1) {
-					GUI_dialog_na(0, get_tx2(0x40));
+					GUI_dialog_na(0, get_tx2(16));
 				} else if (answer == 2) {
-					GUI_dialog_na(0, get_tx2(0x44));
+					GUI_dialog_na(0, get_tx2(17));
 				} else if (test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0) {
-					GUI_dialog_na(0, get_tx2(0x44));
+					GUI_dialog_na(0, get_tx2(17));
 				} else {
-					GUI_dialog_na(0, get_tx2(0x40));
+					GUI_dialog_na(0, get_tx2(16));
 				}
 
 			} else {
 				GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-						get_tx2(0x30), 1,
-						get_tx2(0x48));
+						get_tx2(12), 1,
+						get_tx2(18));
 
-				GUI_dialog_na(0, get_tx2(0x44));
+				GUI_dialog_na(0, get_tx2(17));
 			}
 		}
 
@@ -232,9 +232,9 @@ void tevent_060(void)
 	do {
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-						get_tx2(0x4c), 2,
-						get_tx2(0x50),
-						get_tx2(0x54));
+						get_tx2(19), 2,
+						get_tx2(20),
+						get_tx2(21));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -245,7 +245,7 @@ void tevent_060(void)
 
 				timewarp(HOURS(3));
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(0x58), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(22), 0);
 
 				done = 1;
 			} else {
@@ -256,9 +256,9 @@ void tevent_060(void)
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-								get_tx2(0x60), 2,
-								get_tx2(0x68),
-								get_tx2(0x6c));
+								get_tx2(24), 2,
+								get_tx2(26),
+								get_tx2(27));
 				} while (answer == -1);
 
 				if (answer == 1) {
@@ -278,7 +278,7 @@ void tevent_060(void)
 						}
 					}
 
-					GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(0x74), 0);
+					GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(29), 0);
 
 					done = 1;
 				} else {
@@ -292,7 +292,7 @@ void tevent_060(void)
 
 				timewarp(HOURS(3));
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(0x5c), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL, get_tx2(23), 0);
 
 				done = 1;
 			} else {
@@ -303,9 +303,9 @@ void tevent_060(void)
 
 				do {
 					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-								get_tx2(0x64), 2,
-								get_tx2(0x6c),
-								get_tx2(0x70));
+								get_tx2(25), 2,
+								get_tx2(27),
+								get_tx2(28));
 				} while (answer == -1);
 
 				if (answer == 2) {
@@ -344,7 +344,7 @@ void tevent_060(void)
 
 						timewarp(HOURS(1));
 
-						GUI_dialog_na(0, get_tx2(0x80));
+						GUI_dialog_na(0, get_tx2(32));
 
 						done = 1;
 
@@ -354,16 +354,16 @@ void tevent_060(void)
 
 						timewarp(HOURS(1));
 
-						GUI_dialog_na(0, get_tx2(0x7c));
+						GUI_dialog_na(0, get_tx2(31));
 
 						done = 1;
 					} else {
 
-						GUI_dialog_na(0, get_tx2(0x78));
+						GUI_dialog_na(0, get_tx2(30));
 
 						timewarp(HOURS(2));
 
-						GUI_dialog_na(0, get_tx2(0x84));
+						GUI_dialog_na(0, get_tx2(33));
 					}
 				} else {
 					timewarp(HOURS(2));
@@ -391,16 +391,16 @@ void tevent_061(void)
 		/* TODO: is this correct ? */
 		if (!TRV_follow_trail_question()) {
 
-			GUI_output(get_tx2(0x88));
-			GUI_output(get_tx2(0x8c));
+			GUI_output(get_tx2(34));
+			GUI_output(get_tx2(35));
 
 			load_in_head(53);
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-							get_tx2(0x90), 2,
-							get_tx2(0x94),
-							get_tx2(0x98));
+							get_tx2(36), 2,
+							get_tx2(37),
+							get_tx2(38));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -414,9 +414,9 @@ void tevent_061(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), (Bit8u*)NULL,
-						get_tx2(0x9c), 2,
-						get_tx2(0xa0),
-						get_tx2(0xa4));
+						get_tx2(39), 2,
+						get_tx2(40),
+						get_tx2(41));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -445,7 +445,7 @@ void tevent_063(void)
 	max = 9999;
 
 	/* intro message */
-	GUI_output(get_tx2(0xb8));
+	GUI_output(get_tx2(46));
 
 	hero = get_hero(0);
 
@@ -467,7 +467,7 @@ void tevent_063(void)
 	hero = get_hero(vomiter);
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx2(0xbc),
+		(char*)get_tx2(47),
 		(char*)hero + HERO_NAME2);
 
 	/* print who vomits */
@@ -482,7 +482,7 @@ void tevent_063(void)
 	set_mod_slot(i, DAYS(1), hero + (HERO_ATTRIB + 3 * ATTRIB_MU), -2, (signed char)vomiter);
 
 	/* outro message */
-	GUI_output(get_tx2(0xc0));
+	GUI_output(get_tx2(48));
 }
 
 /* Gorahs place */
@@ -503,18 +503,18 @@ void tevent_064(void)
 		do {
 
 			do {
-				answer = GUI_radio(silentium_flag != 0 ? get_tx2(0x198) : get_tx2(0xc4), 3,
-							get_tx2(0xc8),
-							get_tx2(0xcc),
-							get_tx2(0xd0));
+				answer = GUI_radio(silentium_flag != 0 ? get_tx2(102) : get_tx2(49), 3,
+							get_tx2(50),
+							get_tx2(51),
+							get_tx2(52));
 			} while (answer == -1);
 
 			if (answer == 1) {
 
-				hero = get_hero(select_hero_ok_forced(get_ttx(0x4f4)));
+				hero = get_hero(select_hero_ok_forced(get_ttx(317)));
 
 				if (host_readbs(hero + HERO_TYPE) < 7) {
-					GUI_output(get_ttx(0x528));
+					GUI_output(get_ttx(330));
 				} else {
 					approach_flag = 1;
 				}
@@ -528,11 +528,11 @@ void tevent_064(void)
 
 						ds_writeb(TEVENT064_SILENT_FLAG, 1);
 
-						GUI_output(get_tx2(0xd4));
+						GUI_output(get_tx2(53));
 					} else {
 						sub_ae_splash(hero, 1);
 
-						GUI_output(get_ttx(0x978));
+						GUI_output(get_ttx(606));
 					}
 				}
 
@@ -540,7 +540,7 @@ void tevent_064(void)
 
 				approach_flag = 1;
 
-				GUI_output(get_tx2(0xd8));
+				GUI_output(get_tx2(54));
 
 				hero = get_hero(0);
 
@@ -565,9 +565,9 @@ void tevent_064(void)
 				approach_flag = 1;
 
 				do {
-					answer = GUI_radio(get_tx2(0xdc), 2,
-							get_tx2(0xe0),
-							get_tx2(0xe4));
+					answer = GUI_radio(get_tx2(55), 2,
+							get_tx2(56),
+							get_tx2(57));
 				} while (answer == -1);
 
 				if (answer == 2)  return;
@@ -576,25 +576,25 @@ void tevent_064(void)
 		} while (approach_flag == 0);
 
 		do {
-			answer = GUI_radio(get_tx2(0xe8), 2,
-					get_tx2(0xec),
-					get_tx2(0xf0));
+			answer = GUI_radio(get_tx2(58), 2,
+					get_tx2(59),
+					get_tx2(60));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			if (!ds_readb(TEVENT064_SILENT_FLAG)) {
-				GUI_output(get_tx2(0xf4));
+				GUI_output(get_tx2(61));
 			}
 
-			GUI_output(get_tx2(0xf8));
+			GUI_output(get_tx2(62));
 
 			result = TRV_fight_event(FIGHTS_F064, 64);
 
 			ds_writeb(TEVENT064_SILENT_FLAG, 1);
 
 		} else {
-			GUI_output(ds_readb(TEVENT064_SILENT_FLAG) != 0 ? get_tx2(0xf8) : get_tx2(0xfc));
+			GUI_output(ds_readb(TEVENT064_SILENT_FLAG) != 0 ? get_tx2(62) : get_tx2(63));
 			result = TRV_fight_event(FIGHTS_F064, 64);
 		}
 
@@ -605,19 +605,19 @@ void tevent_064(void)
 
 			do {
 				do {
-					answer = GUI_radio(get_tx2(0x100), 2,
-							get_tx2(0x104),
-							get_tx2(0x108));
+					answer = GUI_radio(get_tx2(64), 2,
+							get_tx2(65),
+							get_tx2(66));
 				} while (answer == -1);
 
 				if (answer == 1) {
 
-					loot_multi_chest(p_datseg + TEVENT064_HUT_CONTENT, get_tx2(0x11c));
+					loot_multi_chest(p_datseg + TEVENT064_HUT_CONTENT, get_tx2(71));
 
 					do {
-						answer = GUI_radio(get_tx2(0x10c), 2,
-							get_tx2(0x110),
-							get_tx2(0x114));
+						answer = GUI_radio(get_tx2(67), 2,
+							get_tx2(68),
+							get_tx2(69));
 					} while (answer == -1);
 
 					if (answer == 1) {
@@ -627,7 +627,7 @@ void tevent_064(void)
 
 			} while (answer != 2);
 
-			GUI_output(get_tx2(0x118));
+			GUI_output(get_tx2(70));
 
 			ds_writews(TRV_RETURN, ds_readws(TRV_RETURN) == 0 ? 1 : -1);
 		}
@@ -636,22 +636,22 @@ void tevent_064(void)
 
 		do {
 			do {
-				answer = GUI_radio(get_tx2(0x100), 2,
-					get_tx2(0x104),
-					get_ttx(0xcb8));
+				answer = GUI_radio(get_tx2(64), 2,
+					get_tx2(65),
+					get_ttx(814));
 
 			} while (answer == -1);
 
 			if (answer == 1) {
 
-				loot_multi_chest(p_datseg + TEVENT064_HUT_CONTENT, get_tx2(0x11c));
+				loot_multi_chest(p_datseg + TEVENT064_HUT_CONTENT, get_tx2(71));
 
 				if (ds_readbs(TEVENT064_CHEST) != -1) {
 
 					do {
-						answer = GUI_radio(get_tx2(0x10c), 2,
-							get_tx2(0x110),
-							get_ttx(0xcb8));
+						answer = GUI_radio(get_tx2(67), 2,
+							get_tx2(68),
+							get_ttx(814));
 
 					} while (answer == -1);
 
@@ -668,7 +668,7 @@ void tevent_064(void)
 
 void tevent_064_chest(void)
 {
-	loot_multi_chest(p_datseg + TEVENT064_CHEST, get_tx2(0x128));
+	loot_multi_chest(p_datseg + TEVENT064_CHEST, get_tx2(74));
 }
 
 /* The rider Orvil <-> Ala */
@@ -683,11 +683,11 @@ void tevent_065(void)
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2),
 				NULL,
-				get_tx2(0x12c),
+				get_tx2(75),
 				3,
-				get_tx2(0x130),
-				get_tx2(0x134),
-				get_tx2(0x138));
+				get_tx2(76),
+				get_tx2(77),
+				get_tx2(78));
 
 	} while (answer == -1);
 
@@ -696,7 +696,7 @@ void tevent_065(void)
 
 		timewarp(MINUTES(15));
 
-		GUI_dialog_na(0, answer == 1 ? get_tx2(0x13c): get_tx2(0x140));
+		GUI_dialog_na(0, answer == 1 ? get_tx2(79): get_tx2(80));
 
 		if (answer == 2) {
 			/* Make Umbrik Siebenstein known */
@@ -725,14 +725,14 @@ void tevent_066(void)
 		{
 
 			do {
-				l_si = GUI_radio(get_tx2(0x144), 2,
-							get_tx2(0x148),
-							get_tx2(0x14c));
+				l_si = GUI_radio(get_tx2(81), 2,
+							get_tx2(82),
+							get_tx2(83));
 			} while (l_si == -1);
 
 			if (l_si == 1) {
 
-				GUI_output(get_tx2(0x150));
+				GUI_output(get_tx2(84));
 
 				hero = get_hero(0);
 				for (l_di = count = 0; l_di <= 6; l_di++, hero += SIZEOF_HERO)
@@ -748,18 +748,18 @@ void tevent_066(void)
 
 				if (count != 0) {
 
-					GUI_output(get_tx2(0x154));
+					GUI_output(get_tx2(85));
 
 				} else {
 					do {
-						l_si = GUI_radio(get_tx2(0x158), 2,
-									get_tx2(0x15c),
-									get_tx2(0x160));
+						l_si = GUI_radio(get_tx2(86), 2,
+									get_tx2(87),
+									get_tx2(88));
 					} while (l_si == -1);
 
 					if (l_si == 1) {
 
-						GUI_output(get_tx2(0x164));
+						GUI_output(get_tx2(89));
 						return;
 					}
 				}

--- a/src/custom/schick/rewrite_m302de/seg112.cpp
+++ b/src/custom/schick/rewrite_m302de/seg112.cpp
@@ -37,13 +37,13 @@ void tevent_067(void)
 	if ((test_skill(Real2Host(get_first_hero_available_in_group()), TA_SINNESSCHAERFE, 6) > 0 && !ds_readb(TEVENT067_FLAG)) ||
 		ds_readb(TEVENT067_FLAG) != 0)
 	{
-		GUI_output(get_tx2(0x168));
+		GUI_output(get_tx2(90));
 
 		do {
-			answer = GUI_radio(get_tx2(0x16c), 3,
-						get_tx2(0x170),
-						get_tx2(0x174),
-						get_tx2(0x178));
+			answer = GUI_radio(get_tx2(91), 3,
+						get_tx2(92),
+						get_tx2(93),
+						get_tx2(94));
 		} while (answer == -1);
 
 		if (answer == 2) {
@@ -68,9 +68,9 @@ void tevent_067(void)
 
 			if (!ds_readb(TEVENT067_FLAG) && count >= 3) {
 
-				loot_multi_chest(p_datseg + TEVENT067_CHEST, get_tx2(0x180));
+				loot_multi_chest(p_datseg + TEVENT067_CHEST, get_tx2(96));
 
-				GUI_output(get_tx2(0x184));
+				GUI_output(get_tx2(97));
 
 				hero = Real2Host(get_first_hero_available_in_group());
 
@@ -81,7 +81,7 @@ void tevent_067(void)
 				ds_writeb(LOCATION, 0);
 			} else {
 
-				GUI_output(get_tx2(0x17c));
+				GUI_output(get_tx2(95));
 
 				hero = get_hero(0);
 				for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
@@ -104,12 +104,12 @@ void tevent_067(void)
 		}
 	} else {
 
-		GUI_output(get_tx2(0x168));
+		GUI_output(get_tx2(90));
 
 		do {
-			answer = GUI_radio(get_tx2(0x148), 2,
-						get_tx2(0x170),
-						get_tx2(0x174));
+			answer = GUI_radio(get_tx2(82), 2,
+						get_tx2(92),
+						get_tx2(93));
 		} while (answer == -1);
 
 		if (answer == 2) {
@@ -165,7 +165,7 @@ void tevent_070(void)
 			if (!TRV_follow_trail_question()) {
 
 				do {
-					l_si = GUI_radio(get_tx2(0x00), 2, get_tx2(0x04), get_tx2(0x08));
+					l_si = GUI_radio(get_tx2(0), 2, get_tx2(1), get_tx2(2));
 
 				} while (l_si == -1);
 
@@ -197,7 +197,7 @@ void tevent_071(void)
 		if (test_skill(hero, TA_FAEHRTENSUCHEN, 4) > 0) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x34),
+				(char*)get_tx2(13),
 				(char*)hero + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
@@ -205,18 +205,18 @@ void tevent_071(void)
 
 			do {
 				l_si = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-						get_tx2(0x38),
-						get_tx2(0x3c));
+						get_tx2(14),
+						get_tx2(15));
 			} while (l_si == -1);
 
 			if (l_si == 2) {
 				/* investigate */
 
 				do {
-					l_si = GUI_radio(get_tx2(0x40), 3,
-							get_tx2(0x44),
-							get_tx2(0x48),
-							get_tx2(0x4c));
+					l_si = GUI_radio(get_tx2(16), 3,
+							get_tx2(17),
+							get_tx2(18),
+							get_tx2(19));
 				} while (l_si == -1);
 
 				if (l_si == 1) {
@@ -235,18 +235,18 @@ void tevent_071(void)
 				if (l_si == 1 || l_si == 2) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x58),
+						(char*)get_tx2(22),
 						(char*)hero + HERO_NAME2);
 					do {
 						l_si = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-								get_tx2(0x5c),
-								get_tx2(0x60));
+								get_tx2(23),
+								get_tx2(24));
 					} while (l_si == -1);
 
 					if (l_si == 1) {
 						/* destroy monolith */
 
-						GUI_output(get_tx2(0x64));
+						GUI_output(get_tx2(25));
 
 						/* REWARD: get gods estimation + 500 for each god */
 						for (i = 1; i <= 14; i++) {
@@ -270,9 +270,9 @@ void tevent_071(void)
 					i = (!have_raft ? 1 : 2);
 
 					do {
-						l_si = GUI_radio(get_tx2(0x68), (signed char)i,
-								get_tx2(0x6c),
-								get_tx2(0x70));
+						l_si = GUI_radio(get_tx2(26), (signed char)i,
+								get_tx2(27),
+								get_tx2(28));
 					} while (l_si == -1);
 
 					if (l_si == 1) {
@@ -312,17 +312,17 @@ void TRV_swimm(signed short mod, signed short percent)
 
 				hero_disease_test(hero, 2, 20 - (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) + host_readbs(hero + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK))));
 
-				loose_random_item(hero, percent, get_ttx(0x7e8));
+				loose_random_item(hero, percent, get_ttx(506));
 
 				sub_hero_le(hero, random_schick(5));
 
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x54),
+					(char*)get_tx2(21),
 					(char*)hero + HERO_NAME2);
 			} else {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x50),
+					(char*)get_tx2(20),
 					(char*)hero + HERO_NAME2);
 			}
 
@@ -350,7 +350,7 @@ void tevent_unused01(void)
 		ds_writeb(TEVENTU01_FLAG, 1);
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x74),
+			(char*)get_tx2(29),
 			(char*)hero + HERO_NAME2,
 			(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 			(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
@@ -358,17 +358,17 @@ void tevent_unused01(void)
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-					get_tx2(0x78),
-					get_tx2(0x7c));
+					get_tx2(30),
+					get_tx2(31));
 		} while (answer == -1);
 
 		if (answer == 2) {
 
 			do {
-				answer = GUI_radio(get_tx2(0x80), 3,
-						get_tx2(0x84),
-						get_tx2(0x88),
-						get_tx2(0x8c));
+				answer = GUI_radio(get_tx2(32), 3,
+						get_tx2(33),
+						get_tx2(34),
+						get_tx2(35));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -384,7 +384,7 @@ void tevent_unused01(void)
 
 			if (answer == 1 || answer == 2) {
 
-				GUI_output(get_tx2(0x98));
+				GUI_output(get_tx2(38));
 
 				ds_writeb(GATHER_HERBS_SPECIAL, 63);
 				TRV_inside_herb_place();
@@ -393,9 +393,9 @@ void tevent_unused01(void)
 				options = (!has_raft ? 1 : 2);
 
 				do {
-					answer = GUI_radio(get_tx2(0x9c), (signed char)options,
-								get_tx2(0xa0),
-								get_tx2(0xa4));
+					answer = GUI_radio(get_tx2(39), (signed char)options,
+								get_tx2(40),
+								get_tx2(41));
 				} while (answer == -1);
 
 				if (answer == 1) {
@@ -433,15 +433,15 @@ void tevent_073(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							get_tx2(0xa8), 2,
-							get_tx2(0xac), get_tx2(0xb0));
+							get_tx2(42), 2,
+							get_tx2(43), get_tx2(44));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
-			GUI_dialog_na(0, get_tx2(0xb4));
+			GUI_dialog_na(0, get_tx2(45));
 
-			loot_multi_chest(p_datseg + TEVENT073_CORPSE, get_tx2(0x1a4));
+			loot_multi_chest(p_datseg + TEVENT073_CORPSE, get_tx2(105));
 
 			ds_writeb(TEVENT073_FLAG, 1);
 		}
@@ -463,10 +463,10 @@ void tevent_074(void)
 		load_in_head(49);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc4), get_tx2(0xb8), 3,
-						get_tx2(0xbc),
-						get_tx2(0xc0),
-						get_tx2(0xc4));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(49), get_tx2(46), 3,
+						get_tx2(47),
+						get_tx2(48),
+						get_tx2(49));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -501,10 +501,10 @@ void tevent_074(void)
 				hero = get_hero(answer);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-					(char*)get_tx2(0xd8),
+					(char*)get_tx2(54),
 					(char*)hero + HERO_NAME2);
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc4),
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(49),
 						Real2Host(ds_readd(DTP2)) + 0x400, 0);
 
 				/* this hero gets a damage of 2W6+4 */
@@ -514,10 +514,10 @@ void tevent_074(void)
 
 			/* try to make a deal */
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc4), get_tx2(0xc8), 3,
-							get_tx2(0xcc),
-							get_tx2(0xd0),
-							get_tx2(0xd4));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(49), get_tx2(50), 3,
+							get_tx2(51),
+							get_tx2(52),
+							get_tx2(53));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -566,18 +566,18 @@ void tevent_075(void)
 	if (!ds_readb(TEVENT075_FLAG)) {
 
 		do {
-			answer = GUI_radio(get_tx2(0xdc), 2,
-						get_tx2(0xe0),
-						get_tx2(0xe4));
+			answer = GUI_radio(get_tx2(55), 2,
+						get_tx2(56),
+						get_tx2(57));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			do {
-				answer = GUI_radio(get_tx2(0xe8), 3,
-							get_tx2(0xec),
-							get_tx2(0xf0),
-							get_tx2(0xf4));
+				answer = GUI_radio(get_tx2(58), 3,
+							get_tx2(59),
+							get_tx2(60),
+							get_tx2(61));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -617,7 +617,7 @@ void tevent_075(void)
 
 				if (answer > 1) {
 
-					GUI_output(get_tx2(0xf8));
+					GUI_output(get_tx2(62));
 
 					ds_writeb(FIG_INITIATIVE, 1);
 
@@ -659,13 +659,13 @@ void tevent_076(void)
 		{
 			ds_writeb(TEVENT076_FLAG, 1);
 
-			GUI_dialog_na(53, get_tx2(0xfc));
+			GUI_dialog_na(53, get_tx2(63));
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-								get_tx2(0x100), 2,
-								get_tx2(0x104),
-								get_tx2(0x108));
+								get_tx2(64), 2,
+								get_tx2(65),
+								get_tx2(66));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -679,9 +679,9 @@ void tevent_076(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							get_tx2(0x10c), 2,
-							get_tx2(0x110),
-							get_tx2(0x114));
+							get_tx2(67), 2,
+							get_tx2(68),
+							get_tx2(69));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -705,11 +705,11 @@ void tevent_077(void)
 		load_in_head(4);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc8),
-						get_tx2(0x118), 3,
-						get_tx2(0x11c),
-						get_tx2(0x120),
-						get_tx2(0x124));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(50),
+						get_tx2(70), 3,
+						get_tx2(71),
+						get_tx2(72),
+						get_tx2(73));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -742,10 +742,10 @@ void tevent_077(void)
 				hero = get_hero(answer);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-					(char*)get_tx2(0xd8),
+					(char*)get_tx2(54),
 					(char*)hero + HERO_NAME2);
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc8),
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(50),
 						Real2Host(ds_readd(DTP2)) + 0x400, 0);
 
 				/* the last hero looses between 6 and 16 LE */
@@ -756,10 +756,10 @@ void tevent_077(void)
 
 			/* try to make a deal */
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xc8), get_tx2(0x128), 3,
-							get_tx2(0x12c),
-							get_tx2(0x130),
-							get_tx2(0x134));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(50), get_tx2(74), 3,
+							get_tx2(75),
+							get_tx2(76),
+							get_tx2(77));
 			} while (answer == -1);
 
 			if (answer == 1) {

--- a/src/custom/schick/rewrite_m302de/seg113.cpp
+++ b/src/custom/schick/rewrite_m302de/seg113.cpp
@@ -56,13 +56,13 @@ void tevent_080(void)
 			ds_writeb(TEVENT080_TATZELWURM, 1);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x15c),
+				(char*)get_tx2(87),
 				(char*)hero + HERO_NAME2);
 
 			do {
 				answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-							get_tx2(0x160),
-							get_tx2(0x164));
+							get_tx2(88),
+							get_tx2(89));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -70,9 +70,9 @@ void tevent_080(void)
 				timewarp(HOURS(1));
 
 				do {
-					answer = GUI_radio(get_tx2(0x168), 2,
-								get_tx2(0x16c),
-								get_tx2(0x170));
+					answer = GUI_radio(get_tx2(90), 2,
+								get_tx2(91),
+								get_tx2(92));
 				} while (answer == -1);
 
 				if (answer == 2) {
@@ -80,14 +80,14 @@ void tevent_080(void)
 					timewarp(HOURS(1));
 
 					do {
-						answer = GUI_radio(get_tx2(0x174), 2,
-									get_tx2(0x178),
-									get_tx2(0x17c));
+						answer = GUI_radio(get_tx2(93), 2,
+									get_tx2(94),
+									get_tx2(95));
 					} while (answer == -1);
 
 					if (answer == 1) {
 
-						GUI_output(get_tx2(0x180));
+						GUI_output(get_tx2(96));
 
 						ds_writeb(TEVENT080_TATZELWURM, 2);
 
@@ -111,7 +111,7 @@ void tevent_081(void)
 
 void tevent_082(void)
 {
-	TRV_cross_a_ford(get_tx(0xcc), 30, 1);
+	TRV_cross_a_ford(get_tx(51), 30, 1);
 }
 
 void tevent_083(void)
@@ -137,9 +137,9 @@ void tevent_084(void)
 		do {
 
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x184), 2,
-						get_tx2(0x188),
-						get_tx2(0x18c));
+						get_tx2(97), 2,
+						get_tx2(98),
+						get_tx2(99));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -193,8 +193,8 @@ void tevent_086(void)
 
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-					get_tx2(0x190), 2,
-					get_tx2(0x194), get_tx2(0x198));
+					get_tx2(100), 2,
+					get_tx2(101), get_tx2(102));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -210,7 +210,7 @@ void tevent_086(void)
 			}
 		}
 
-		GUI_dialog_na(0, get_tx2(0x19c));
+		GUI_dialog_na(0, get_tx2(103));
 
 		if (!ds_readb(TEVENT086_FLAG)) {
 
@@ -219,7 +219,7 @@ void tevent_086(void)
 
 	} else {
 
-		GUI_dialog_na(0, get_tx2(0x1a0));
+		GUI_dialog_na(0, get_tx2(104));
 
 		if (!ds_readb(TEVENT086_FLAG)) {
 
@@ -240,7 +240,7 @@ void tevent_088(void)
 
 void tevent_089(void)
 {
-	TRV_cross_a_ford(get_tx(0xcc), 40, 2);
+	TRV_cross_a_ford(get_tx(51), 40, 2);
 }
 
 void tevent_097(void)
@@ -269,10 +269,10 @@ void tevent_098(void)
 	i = get_first_hero_with_item(121) != -1 || get_first_hero_with_item(32) != -1 ? 3 : 2;
 
 	do {
-		answer = GUI_radio(get_tx2(0x6c), (signed char)i,
-				get_tx2(0x70),
-				get_tx2(0x74),
-				get_tx2(0x78));
+		answer = GUI_radio(get_tx2(27), (signed char)i,
+				get_tx2(28),
+				get_tx2(29),
+				get_tx2(30));
 	} while (answer == -1);
 
 	do {
@@ -292,7 +292,7 @@ void tevent_098(void)
 					if (test_skill(hero, TA_AKROBATIK, 0) > 0) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx2(0x7c),
+							(char*)get_tx2(31),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -300,7 +300,7 @@ void tevent_098(void)
 					} else {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx2(0x80),
+							(char*)get_tx2(32),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -312,7 +312,7 @@ void tevent_098(void)
 
 		} else if (answer == 2) {
 
-			GUI_output(get_tx2(0x84));
+			GUI_output(get_tx2(33));
 
 			/* Original-Bug: hero not initialized */
 #ifdef M302de_ORIGINAL_BUGFIX
@@ -321,7 +321,7 @@ void tevent_098(void)
 #endif
 			hero_disease_test(hero, 2, 20 - (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) + host_readbs(hero + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK))));
 
-			loose_random_item(hero, 1, get_ttx(0x7e8));
+			loose_random_item(hero, 1, get_ttx(506));
 
 			ds_writeb(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -330,12 +330,12 @@ void tevent_098(void)
 			TRV_load_textfile(-1);
 		} else {
 
-			hero = get_hero(hero_pos = select_hero_ok_forced(get_tx2(0x88)));
+			hero = get_hero(hero_pos = select_hero_ok_forced(get_tx2(34)));
 
 			if (test_skill(hero, TA_AKROBATIK, 0) > 0) {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x8c),
+					(char*)get_tx2(35),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -351,7 +351,7 @@ void tevent_098(void)
 						if (test_attrib(hero, ATTRIB_GE, -4) > 0) {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx2(0x90),
+								(char*)get_tx2(36),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -359,7 +359,7 @@ void tevent_098(void)
 						} else {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_tx2(0x80),
+								(char*)get_tx2(32),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -371,7 +371,7 @@ void tevent_098(void)
 			} else {
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x80),
+					(char*)get_tx2(32),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -379,10 +379,10 @@ void tevent_098(void)
 				hero_disappear(hero, i, 33);
 
 				do {
-					answer = GUI_radio(get_tx2(0x94), 3,
-								get_tx2(0x70),
-								get_tx2(0x74),
-								get_tx2(0x78));
+					answer = GUI_radio(get_tx2(37), 3,
+								get_tx2(28),
+								get_tx2(29),
+								get_tx2(30));
 				} while (answer == -1);
 
 				repeat = 1;
@@ -444,9 +444,9 @@ void tevent_099(void)
 	if (!ds_readb(TEVENT099_FLAG)) {
 
 		do {
-			answer = GUI_radio(get_tx2(0x98), 2,
-						get_tx2(0x9c),
-						get_tx2(0xa0));
+			answer = GUI_radio(get_tx2(38), 2,
+						get_tx2(39),
+						get_tx2(40));
 		} while (answer == -1);
 
 		/* Original-Bug: The 2nd option "try to flee (or avoid the fight)" is not a try.
@@ -488,14 +488,14 @@ void tevent_101(void)
 	if (!ds_readb(TEVENT101_FLAG)) {
 
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0xa4),
+			(char*)get_tx2(41),
 			(mod = random_schick(4) + 2));
 
 
 		do {
 			answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-						get_tx2(0xa8),
-						get_tx2(0xac));
+						get_tx2(42),
+						get_tx2(43));
 		} while (answer == -1);
 
 		ds_writew(MAX_ENEMIES, mod);
@@ -548,9 +548,9 @@ void tevent_103(void)
 #endif
 
 	do {
-		answer = GUI_radio(get_tx2(0xb0), 2,
-					get_tx2(0xb4),
-					get_tx2(0xb8));
+		answer = GUI_radio(get_tx2(44), 2,
+					get_tx2(45),
+					get_tx2(46));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -559,12 +559,12 @@ void tevent_103(void)
 
 			timewarp(HOURS(4));
 
-			GUI_output(get_tx2(0xbc));
+			GUI_output(get_tx2(47));
 		} else {
 
 			timewarp(HOURS(6));
 
-			GUI_output(get_tx2(0xc4));
+			GUI_output(get_tx2(49));
 
 			answer = -1;
 		}
@@ -574,12 +574,12 @@ void tevent_103(void)
 
 			timewarp(HOURS(6));
 
-			GUI_output(get_tx2(0xc0));
+			GUI_output(get_tx2(48));
 		} else {
 
 			timewarp(HOURS(8));
 
-			GUI_output(get_tx2(0xc8));
+			GUI_output(get_tx2(50));
 
 			answer = -1;
 		}
@@ -591,12 +591,12 @@ void tevent_103(void)
 
 			timewarp(HOURS(4));
 
-			GUI_output(get_tx2(0xcc));
+			GUI_output(get_tx2(51));
 		} else {
 
 			timewarp(HOURS(6));
 
-			GUI_output(get_tx2(0xd0));
+			GUI_output(get_tx2(52));
 
 			ds_writebs(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -604,7 +604,7 @@ void tevent_103(void)
 
 			TRV_load_textfile(-1);
 
-			GUI_output(get_tx2(0xd4));
+			GUI_output(get_tx2(53));
 		}
 	}
 }
@@ -624,7 +624,7 @@ void tevent_104(void)
 
 	do {
 
-		GUI_dialog_na(0, get_tx2(0xd8));
+		GUI_dialog_na(0, get_tx2(54));
 
 		hero = get_hero(0);
 
@@ -644,7 +644,7 @@ void tevent_104(void)
 					timewarp(MINUTES(30));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-						(char*)get_tx2(0xdc),
+						(char*)get_tx2(55),
 						(char*)hero + HERO_NAME2);
 
 					GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -658,7 +658,7 @@ void tevent_104(void)
 
 			/* everything is fine */
 
-			GUI_dialog_na(0, get_tx2(0xfc));
+			GUI_dialog_na(0, get_tx2(63));
 			done = 1;
 
 		} else if (l_si == nr_heros) {
@@ -667,8 +667,8 @@ void tevent_104(void)
 
 			do {
 				l_si = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							get_tx2(0xe0), 2,
-							get_tx2(0xe4), get_tx2(0xe8));
+							get_tx2(56), 2,
+							get_tx2(57), get_tx2(58));
 			} while (l_si == -1);
 
 			if (l_si == 2) {
@@ -700,25 +700,25 @@ void tevent_104(void)
 
 				do {
 					l_si = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-								(nr_heros == 0 ? get_tx2(0xec) : get_tx2(0x15c)), 3,
-								get_tx2(0xf0), get_tx2(0xf4), get_tx2(0xf8));
+								(nr_heros == 0 ? get_tx2(59) : get_tx2(87)), 3,
+								get_tx2(60), get_tx2(61), get_tx2(62));
 				} while (l_si == -1);
 
 				if (l_si == 1) {
 
 					timewarp(HOURS(2));
 
-					GUI_dialog_na(0, get_tx2(0xfc));
+					GUI_dialog_na(0, get_tx2(63));
 
 					done = 1;
 
 				} else if (l_si == 2) {
 
-					hero = get_hero(select_hero_ok_forced(get_ttx(0x4f4)));
+					hero = get_hero(select_hero_ok_forced(get_ttx(317)));
 
 					if (host_readbs(hero + HERO_TYPE) < 7) {
 						/* hero is not a spell user */
-						GUI_output(get_ttx(0x528));
+						GUI_output(get_ttx(330));
 					} else {
 
 						spell_result = test_spell(hero, 7, 0);
@@ -727,7 +727,7 @@ void tevent_104(void)
 
 							sub_ae_splash(hero, get_spell_cost(7, 0));
 
-							GUI_output(get_tx2(0x40));
+							GUI_output(get_tx2(16));
 
 							done = 1;
 
@@ -740,7 +740,7 @@ void tevent_104(void)
 						} else {
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x97c),
+								(char*)get_ttx(607),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -752,7 +752,7 @@ void tevent_104(void)
 
 					timewarp(HOURS(4));
 
-					GUI_dialog_na(0, get_tx2(0xfc));
+					GUI_dialog_na(0, get_tx2(63));
 
 					done = 1;
 				}
@@ -794,8 +794,8 @@ void tevent_107(void)
 	init_ani(0);
 
 	do {
-		answer = GUI_radio(get_tx2(0x100), 2,
-					get_tx2(0x104), get_tx2(0x108));
+		answer = GUI_radio(get_tx2(64), 2,
+					get_tx2(65), get_tx2(66));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -811,7 +811,7 @@ void tevent_107(void)
 				if (get_first_hero_with_item(121) != -1) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x118),
+						(char*)get_tx2(70),
 						(char*)hero + HERO_NAME2);
 
 					sub_hero_le(hero, random_schick(11) + 1);
@@ -819,7 +819,7 @@ void tevent_107(void)
 				} else {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x11c),
+						(char*)get_tx2(71),
 						(char*)hero + HERO_NAME2);
 
 					sub_hero_le(hero, random_schick(11) + 4);
@@ -829,7 +829,7 @@ void tevent_107(void)
 			}
 		}
 
-		GUI_output(get_tx2(0x114));
+		GUI_output(get_tx2(69));
 
 	} else {
 
@@ -837,13 +837,13 @@ void tevent_107(void)
 
 			timewarp(HOURS(3));
 
-			GUI_output(get_tx2(0x10c));
+			GUI_output(get_tx2(67));
 
 		} else {
 
 			timewarp(HOURS(12));
 
-			GUI_output(get_tx2(0x110));
+			GUI_output(get_tx2(68));
 
 		}
 	}
@@ -860,12 +860,12 @@ void tevent_108(void)
 	{
 		ds_writeb(TEVENT108_FLAG, 1);
 
-		GUI_dialog_na(53, get_tx2(0x120));
+		GUI_dialog_na(53, get_tx2(72));
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x124), 2,
-						get_tx2(0x128), get_tx2(0x12c));
+						get_tx2(73), 2,
+						get_tx2(74), get_tx2(75));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -878,8 +878,8 @@ void tevent_108(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x130), 2,
-						get_tx2(0x134), get_tx2(0x138));
+						get_tx2(76), 2,
+						get_tx2(77), get_tx2(78));
 		} while (answer == -1);
 
 		if (answer == 1) {

--- a/src/custom/schick/rewrite_m302de/seg114.cpp
+++ b/src/custom/schick/rewrite_m302de/seg114.cpp
@@ -38,9 +38,9 @@ void tevent_110(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0x13c), 2,
-					get_tx2(0x140),
-					get_tx2(0x144));
+		answer = GUI_radio(get_tx2(79), 2,
+					get_tx2(80),
+					get_tx2(81));
 	} while (answer == -1);
 
 	if (answer == 1)
@@ -60,7 +60,7 @@ void tevent_110(void)
 				{
 					/* one hero in the group has a rope */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x154),
+						(char*)get_tx2(85),
 						(char*)hero + HERO_NAME2);
 
 					sub_hero_le(hero, random_schick(10));
@@ -68,7 +68,7 @@ void tevent_110(void)
 				} else {
 					/* all heros in the group have no ropes */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x158),
+						(char*)get_tx2(86),
 						(char*)hero + HERO_NAME2);
 
 					sub_hero_le(hero, random_schick(16) + 4);
@@ -79,7 +79,7 @@ void tevent_110(void)
 
 		}
 
-		GUI_output(get_tx2(0x150));
+		GUI_output(get_tx2(84));
 
 	} else {
 
@@ -89,11 +89,11 @@ void tevent_110(void)
 		{
 			/* success */
 			timewarp(HOURS(4));
-			GUI_output(get_tx2(0x148));
+			GUI_output(get_tx2(82));
 		} else {
 			/* fail */
 			timewarp(DAYS(1) + HOURS(6));
-			GUI_output(get_tx2(0x14c));
+			GUI_output(get_tx2(83));
 		}
 	}
 }
@@ -119,7 +119,7 @@ void tevent_111(void)
 		draw_main_screen();
 		init_ani(0);
 
-		GUI_output(get_tx2(0x00));
+		GUI_output(get_tx2(0));
 
 		hero = get_hero(0);
 		for (i = counter = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -136,14 +136,14 @@ void tevent_111(void)
 		if (counter)
 		{
 			do {
-				answer = GUI_radio(get_tx2(0x04), 2,
-							get_tx2(0x1c),
-							get_tx2(0x20));
+				answer = GUI_radio(get_tx2(1), 2,
+							get_tx2(7),
+							get_tx2(8));
 			} while (answer == -1);
 
 			if (answer == 1)
 			{
-				GUI_output(get_tx2(0x24));
+				GUI_output(get_tx2(9));
 
 				add_hero_ap_all(7);
 
@@ -154,20 +154,20 @@ void tevent_111(void)
 
 		} else {
 
-			hero = get_hero(select_hero_ok_forced(get_tx2(0x08)));
+			hero = get_hero(select_hero_ok_forced(get_tx2(2)));
 
 			if (test_skill(hero, TA_SCHLEICHEN, 0) <= 0)
 			{
 				/* skill test failed */
 				do {
-					answer = GUI_radio(get_tx2(0x04), 2,
-								get_tx2(0x1c),
-								get_tx2(0x20));
+					answer = GUI_radio(get_tx2(1), 2,
+								get_tx2(7),
+								get_tx2(8));
 				} while (answer == -1);
 
 				if (answer == 1)
 				{
-					GUI_output(get_tx2(0x24));
+					GUI_output(get_tx2(9));
 
 					add_hero_ap_all(7);
 
@@ -180,7 +180,7 @@ void tevent_111(void)
 				/* skill test succeeded */
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x0c),
+					(char*)get_tx2(3),
 					(char*)hero + HERO_NAME2);
 
 				GUI_input(Real2Host(ds_readd(DTP2)), counter = unlucky_tests = 0);
@@ -196,7 +196,7 @@ void tevent_111(void)
 				if (counter == 3 || unlucky_tests >= 2)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x10),
+						(char*)get_tx2(4),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -215,21 +215,21 @@ void tevent_111(void)
 				{
 
 					do {
-						answer = GUI_radio(get_tx2(0x14), 2,
-									get_tx2(0x28),
-									get_tx2(0x2c));
+						answer = GUI_radio(get_tx2(5), 2,
+									get_tx2(10),
+									get_tx2(11));
 					} while (answer == -1);
 
 					if (answer == 1)
 					{
-						GUI_output(get_tx2(0x30));
+						GUI_output(get_tx2(12));
 
 						add_hero_ap_all(7);
 
 						add_hero_ap(hero, 5);
 					} else {
 
-						GUI_output(get_tx2(0x34));
+						GUI_output(get_tx2(13));
 
 						add_hero_ap_all(15);
 
@@ -256,18 +256,18 @@ void tevent_111(void)
 
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x18),
+						(char*)get_tx2(6),
 						(char*)hero + HERO_NAME2);
 
 					do {
 						answer = GUI_radio(Real2Host(ds_readd(DTP2)), 2,
-									get_tx2(0x1c),
-									get_tx2(0x20));
+									get_tx2(7),
+									get_tx2(8));
 					} while (answer == -1);
 
 					if (answer == 1)
 					{
-						GUI_output(get_tx2(0x24));
+						GUI_output(get_tx2(9));
 
 						add_hero_ap_all(7);
 
@@ -316,14 +316,14 @@ void tevent_113(void)
 	Bit32s est_diff;
 
 	do {
-		answer = GUI_radio(get_tx2(0x38), 2,
-					get_tx2(0x3c),
-					get_tx2(0x40));
+		answer = GUI_radio(get_tx2(14), 2,
+					get_tx2(15),
+					get_tx2(16));
 	} while (answer == -1);
 
 	if (answer == 1)
 	{
-		GUI_output(get_tx2(0x44));
+		GUI_output(get_tx2(17));
 
 		/* enter the temple */
 		ds_writew(TYPEINDEX, 58);
@@ -332,7 +332,7 @@ void tevent_113(void)
 		do_location();
 		TRV_load_textfile(-1);
 
-		GUI_output(get_tx2(0x48));
+		GUI_output(get_tx2(18));
 
 		/* calculate the difference of the estimation */
 		est_diff = ds_readds(GODS_ESTIMATION + 4 * 7) - est_old;
@@ -367,17 +367,17 @@ void tevent_114(void)
 	do {
 
 		do {
-			answer = GUI_radio(get_tx2(0x4c), 2,
-						get_tx2(0x50),
-						get_tx2(0x54));
+			answer = GUI_radio(get_tx2(19), 2,
+						get_tx2(20),
+						get_tx2(21));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			do {
-				answer = GUI_radio(get_tx2(0x70), 2,
-							get_tx2(0x74),
-							get_tx2(0x78));
+				answer = GUI_radio(get_tx2(28), 2,
+							get_tx2(29),
+							get_tx2(30));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -389,11 +389,11 @@ void tevent_114(void)
 			if (answer == 2)
 			{
 				/* go on careful */
-				GUI_output(get_tx2(0x58));
+				GUI_output(get_tx2(22));
 			}
 
 		} else {
-			GUI_output(get_tx2(0x58));
+			GUI_output(get_tx2(22));
 		}
 
 		if (done == 0)
@@ -412,7 +412,7 @@ void tevent_114(void)
 						timewarp(MINUTES(30));
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx2(0x5c),
+							(char*)get_tx2(23),
 							(char*)hero + HERO_NAME2,
 							(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
 
@@ -420,9 +420,9 @@ void tevent_114(void)
 
 						sub_hero_le(hero, random_schick(8));
 
-						loose_random_item(hero, 50, get_ttx(0x7e8));
-						loose_random_item(hero, 50, get_ttx(0x7e8));
-						loose_random_item(hero, 50, get_ttx(0x7e8));
+						loose_random_item(hero, 50, get_ttx(506));
+						loose_random_item(hero, 50, get_ttx(506));
+						loose_random_item(hero, 50, get_ttx(506));
 					}
 				}
 			}
@@ -430,12 +430,12 @@ void tevent_114(void)
 			if (!ds_readb(TEVENT114_OLIMONE_FLAG))
 			{
 				/* meet OLIMONE */
-				GUI_output(get_tx2(0x60));
+				GUI_output(get_tx2(24));
 
 				load_in_head(12);
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xd0), get_tx2(0x64), 0);
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0xd0), get_tx2(0x68), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(52), get_tx2(25), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(52), get_tx2(26), 0);
 
 				/* get RECIPE FOR POTENT HEALING POTION */
 				get_item(240, 1, 1);
@@ -444,7 +444,7 @@ void tevent_114(void)
 				hero = get_hero(get_first_hero_with_item(240));
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0x6c),
+					(char*)get_tx2(27),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -464,7 +464,7 @@ void tevent_114(void)
 				ds_writeb(TEVENT114_OLIMONE_FLAG, (signed char)(done = 1));
 
 			} else {
-				GUI_output(get_tx2(0x100));
+				GUI_output(get_tx2(64));
 
 				timewarp(HOURS(8));
 
@@ -502,8 +502,8 @@ void tevent_117(void)
 	signed short i;
 	Bit8u *hero;
 
-	GUI_output(get_tx2(0x7c));
-	GUI_output(get_tx2(0x80));
+	GUI_output(get_tx2(31));
+	GUI_output(get_tx2(32));
 
 	for (hero = get_hero(0), i = 0; i <= 6; i++, hero += SIZEOF_HERO)
 	{
@@ -515,13 +515,13 @@ void tevent_117(void)
 			/* attrib test failed */
 			sub_hero_le(hero, random_schick(11) + 1);
 
-			loose_random_item(hero, 15, get_ttx(0x7e8));
-			loose_random_item(hero, 15, get_ttx(0x7e8));
-			loose_random_item(hero, 15, get_ttx(0x7e8));
+			loose_random_item(hero, 15, get_ttx(506));
+			loose_random_item(hero, 15, get_ttx(506));
+			loose_random_item(hero, 15, get_ttx(506));
 		}
 	}
 
-	GUI_output(get_tx2(0x84));
+	GUI_output(get_tx2(33));
 }
 
 /* a herb place */
@@ -556,9 +556,9 @@ void tevent_122(void)
 	if (!ds_readb(TEVENT122_FLAG))
 	{
 		do {
-			answer = GUI_radio(get_tx2(0x88), 2,
-						get_tx2(0x8c),
-						get_tx2(0x90));
+			answer = GUI_radio(get_tx2(34), 2,
+						get_tx2(35),
+						get_tx2(36));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -570,8 +570,8 @@ void tevent_122(void)
 
 				load_in_head(4);
 
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x110), get_tx2(0x94), 0);
-				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(0x110), get_tx2(0xfc), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(68), get_tx2(37), 0);
+				GUI_dialogbox((RealPt)ds_readd(DTP2), get_tx(68), get_tx2(63), 0);
 			}
 		} else {
 			sub_hero_ap_all(20);
@@ -597,10 +597,10 @@ void tevent_123(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x98), 3,
-						get_tx2(0x9c),
-						get_tx2(0xa0),
-						get_tx2(0xa4));
+						get_tx2(38), 3,
+						get_tx2(39),
+						get_tx2(40),
+						get_tx2(41));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -618,7 +618,7 @@ void tevent_123(void)
 					counter++;
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-						(char*)get_tx2(0xa8),
+						(char*)get_tx2(42),
 						(char*)hero + HERO_NAME2);
 
 					GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -627,7 +627,7 @@ void tevent_123(void)
 
 			if (!counter)
 			{
-				GUI_dialog_na(0, get_tx2(0xac));
+				GUI_dialog_na(0, get_tx2(43));
 				done = 1;
 			}
 
@@ -639,10 +639,10 @@ void tevent_123(void)
 			/* fight acrophobia */
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							get_tx2(0xb0), 3,
-							get_tx2(0xb4),
-							get_tx2(0xb8),
-							get_tx2(0xbc));
+							get_tx2(44), 3,
+							get_tx2(45),
+							get_tx2(46),
+							get_tx2(47));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -660,7 +660,7 @@ void tevent_123(void)
 						if (attrib_result == 99 && skill_result == -1)
 						{
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0xc0),
+								(char*)get_tx2(48),
 								(char*)hero + HERO_NAME2);
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -672,7 +672,7 @@ void tevent_123(void)
 						} else if (attrib_result > 0 || skill_result <= 0)
 						{
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0xa8),
+								(char*)get_tx2(42),
 								(char*)hero + HERO_NAME2);
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -684,21 +684,21 @@ void tevent_123(void)
 
 				if (!counter)
 				{
-					GUI_dialog_na(0, get_tx2(0xac));
+					GUI_dialog_na(0, get_tx2(43));
 					done = 1;
 				}
 
 			} else if (answer == 2)
 			{
 				/* cast a spell */
-				hero = get_hero(select_hero_ok_forced(get_ttx(0x4f4)));
+				hero = get_hero(select_hero_ok_forced(get_ttx(317)));
 
 				if (test_spell(hero, 70, 0) > 0)
 				{
 					/* success */
 					sub_ae_splash(hero, get_spell_cost(70, 0));
 
-					GUI_dialog_na(0, get_tx2(0xac));
+					GUI_dialog_na(0, get_tx2(43));
 
 					done = 1;
 				} else {
@@ -713,7 +713,7 @@ void tevent_123(void)
 							!hero_dead(hero))
 						{
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0xa8),
+								(char*)get_tx2(42),
 								(char*)hero + HERO_NAME2);
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -734,7 +734,7 @@ void tevent_123(void)
 						{
 							/* unlucky */
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0xc0),
+								(char*)get_tx2(48),
 								(char*)hero + HERO_NAME2);
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -747,7 +747,7 @@ void tevent_123(void)
 						{
 							/* succeeded */
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0xa8),
+								(char*)get_tx2(42),
 								(char*)hero + HERO_NAME2);
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -759,7 +759,7 @@ void tevent_123(void)
 
 				if (!counter)
 				{
-					GUI_dialog_na(0, get_tx2(0xac));
+					GUI_dialog_na(0, get_tx2(43));
 					done = 1;
 				}
 			}

--- a/src/custom/schick/rewrite_m302de/seg115.cpp
+++ b/src/custom/schick/rewrite_m302de/seg115.cpp
@@ -41,45 +41,45 @@ void tevent_016(void)
 		load_in_head(46);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x4c), 2,
-						get_tx2(0x50),
-						get_tx2(0x54));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(19), 2,
+						get_tx2(20),
+						get_tx2(21));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			/* ignore */
-			GUI_dialog_na(0, get_tx2(0x58));
+			GUI_dialog_na(0, get_tx2(22));
 		} else {
 			/* wave */
 
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x5c), 2,
-							get_tx2(0x60),
-							get_tx2(0x64));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(23), 2,
+							get_tx2(24),
+							get_tx2(25));
 			} while (answer == -1);
 
 			if (answer == 1)
 			{
 				/* run away */
-				GUI_dialog_na(0, get_tx2(0x68));
+				GUI_dialog_na(0, get_tx2(26));
 			} else {
 				/* go towards them */
 
 				do {
-					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x6c), 2,
-								get_tx2(0x70),
-								get_tx2(0x74));
+					answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(27), 2,
+								get_tx2(28),
+								get_tx2(29));
 				} while (answer == -1);
 
 				if (answer == 2)
 				{
 					/* walk away */
-					GUI_dialog_na(0, get_tx2(0x78));
+					GUI_dialog_na(0, get_tx2(30));
 				} else {
 					/* help them */
 
-					GUI_dialog_na(0, get_tx2(0x7c));
+					GUI_dialog_na(0, get_tx2(31));
 
 					hero = get_hero(get_hero_KK_best());
 
@@ -87,13 +87,13 @@ void tevent_016(void)
 					if (test_attrib(hero, ATTRIB_KK, 3) > 0)
 					{
 						/* success */
-						GUI_dialog_na(0, get_tx2(0x80));
-						GUI_dialog_na(0, get_tx2(0x90));
+						GUI_dialog_na(0, get_tx2(32));
+						GUI_dialog_na(0, get_tx2(36));
 
 						add_hero_ap_all(5);
 					} else {
 						/* fail */
-						GUI_dialog_na(0, get_tx2(0x84));
+						GUI_dialog_na(0, get_tx2(33));
 
 						hero = get_hero(get_random_hero());
 
@@ -104,17 +104,17 @@ void tevent_016(void)
 							timewarp(MINUTES(15));
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0x8c),
+								(char*)get_tx2(35),
 								(char*)hero + HERO_NAME2,
 								(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
 							GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
 
-							GUI_dialog_na(0, get_tx2(0x90));
+							GUI_dialog_na(0, get_tx2(36));
 						} else {
 							/* fail */
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0x88),
+								(char*)get_tx2(34),
 								(char*)hero + HERO_NAME2,
 								(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 								(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)),
@@ -126,7 +126,7 @@ void tevent_016(void)
 							timewarp(HOURS(1));
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-								(char*)get_tx2(0x94),
+								(char*)get_tx2(37),
 								(char*)hero + HERO_NAME2,
 								(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 1)));
 
@@ -134,7 +134,7 @@ void tevent_016(void)
 
 							add_hero_ap(hero, 5);
 
-							loose_random_item(hero, 10, get_ttx(0x7e8));
+							loose_random_item(hero, 10, get_ttx(506));
 
 							hero_disease_test(hero, 2, 20 - (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) + host_readbs(hero + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK))));
 						}
@@ -154,8 +154,8 @@ void tevent_090(void)
 	signed short i;
 	Bit8u *hero;
 
-	GUI_output(get_tx2(0x00));
-	GUI_output(get_tx2(0x04));
+	GUI_output(get_tx2(0));
+	GUI_output(get_tx2(1));
 
 	hero = get_hero(0);
 	for (i = 0; i <= 6; i++, hero += SIZEOF_HERO)
@@ -168,12 +168,12 @@ void tevent_090(void)
 			/* failed */
 			sub_hero_le(hero, random_schick(10));
 
-			loose_random_item(hero, 10, get_ttx(0x7e8));
-			loose_random_item(hero, 10, get_ttx(0x7e8));
+			loose_random_item(hero, 10, get_ttx(506));
+			loose_random_item(hero, 10, get_ttx(506));
 		}
 	}
 
-	GUI_output(get_tx2(0x08));
+	GUI_output(get_tx2(2));
 }
 
 void tevent_091(void)
@@ -205,14 +205,14 @@ void tevent_094(void)
 	{
 		signed short answer;
 
-		GUI_output(get_tx2(0x0c));
+		GUI_output(get_tx2(3));
 
 		load_in_head(53);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x10), 2,
-						get_tx2(0x14),
-						get_tx2(0x18));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(4), 2,
+						get_tx2(5),
+						get_tx2(6));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -236,7 +236,7 @@ void tevent_095(void)
 
 	do {
 
-		GUI_output(get_tx2(0x1c));
+		GUI_output(get_tx2(7));
 
 		hero = get_hero(0);
 
@@ -253,7 +253,7 @@ void tevent_095(void)
 					timewarp(MINUTES(30));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x20),
+						(char*)get_tx2(8),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -266,16 +266,16 @@ void tevent_095(void)
 		if (!counter_failed)
 		{
 			/* no hero failed HA-test */
-			GUI_output(get_tx2(0x40));
+			GUI_output(get_tx2(16));
 			done = 1;
 
 		} else if (counter_failed == counter_heros)
 		{
 			/* all heros failed HA-test */
 			do {
-				counter_failed = GUI_radio(get_tx2(0x24), 2,
-								get_tx2(0x28),
-								get_tx2(0x2c));
+				counter_failed = GUI_radio(get_tx2(9), 2,
+								get_tx2(10),
+								get_tx2(11));
 			} while (counter_failed == -1);
 
 			if (counter_failed == 2)
@@ -295,10 +295,10 @@ void tevent_095(void)
 
 			do {
 				do {
-					counter_failed = GUI_radio((counter_heros == 0 ? get_tx2(0x30) : get_tx2(0x15c)), 3,
-									get_tx2(0x34),
-									get_tx2(0x38),
-									get_tx2(0x3c));
+					counter_failed = GUI_radio((counter_heros == 0 ? get_tx2(12) : get_tx2(87)), 3,
+									get_tx2(13),
+									get_tx2(14),
+									get_tx2(15));
 				} while (counter_failed == -1);
 
 				if (counter_failed == 1)
@@ -307,19 +307,19 @@ void tevent_095(void)
 
 					timewarp(HOURS(2));
 
-					GUI_output(get_tx2(0x40));
+					GUI_output(get_tx2(16));
 
 					done = 1;
 
 				} else if (counter_failed == 2)
 				{
 					/* try a spell */
-					hero = get_hero(select_hero_ok_forced(get_ttx(0x4f4)));
+					hero = get_hero(select_hero_ok_forced(get_ttx(317)));
 
 					if (host_readbs(hero + HERO_TYPE) < 7)
 					{
 						/* this hero is no magic-user */
-						GUI_output(get_ttx(0x528));
+						GUI_output(get_ttx(330));
 					} else {
 
 						ret_spell_test = test_spell(hero, 7, 0);
@@ -331,7 +331,7 @@ void tevent_095(void)
 							/* TODO: magicians with 4th staff spell may pay less */
 							sub_ae_splash(hero, get_spell_cost(7, 0));
 
-							GUI_output(get_tx2(0x40));
+							GUI_output(get_tx2(16));
 
 							done = 1;
 
@@ -350,7 +350,7 @@ void tevent_095(void)
 
 							/* TODO: this gets output, but no spell costst ??? */
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x97c),
+								(char*)get_ttx(607),
 								(char*)hero + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -365,7 +365,7 @@ void tevent_095(void)
 					/* wait for 4 hours */
 					timewarp(HOURS(4));
 
-					GUI_output(get_tx2(0x40));
+					GUI_output(get_tx2(16));
 
 					done = 1;
 				}
@@ -379,9 +379,9 @@ void tevent_096(void)
 	signed short answer;
 
 	do {
-		answer = GUI_radio(get_tx2(0x44), 2,
-					get_tx2(0x48),
-					get_tx2(0x4c));
+		answer = GUI_radio(get_tx2(17), 2,
+					get_tx2(18),
+					get_tx2(19));
 	} while (answer == -1);
 
 	if (answer == 1)
@@ -392,11 +392,11 @@ void tevent_096(void)
 		{
 			timewarp(HOURS(3));
 
-			GUI_output(get_tx2(0x50));
+			GUI_output(get_tx2(20));
 		} else {
 			timewarp(HOURS(4));
 
-			GUI_output(get_tx2(0x58));
+			GUI_output(get_tx2(22));
 
 			answer = -1;
 		}
@@ -407,11 +407,11 @@ void tevent_096(void)
 		{
 			timewarp(HOURS(4));
 
-			GUI_output(get_tx2(0x54));
+			GUI_output(get_tx2(21));
 		} else {
 			timewarp(HOURS(5));
 
-			GUI_output(get_tx2(0x5c));
+			GUI_output(get_tx2(23));
 
 			answer = -1;
 		}
@@ -426,12 +426,12 @@ void tevent_096(void)
 			/* find the way again */
 			timewarp(HOURS(3));
 
-			GUI_output(get_tx2(0x60));
+			GUI_output(get_tx2(24));
 		} else {
 			/* lost the way completely */
 			timewarp(HOURS(4));
 
-			GUI_output(get_tx2(0x64));
+			GUI_output(get_tx2(25));
 
 			ds_writeb(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -439,7 +439,7 @@ void tevent_096(void)
 
 			TRV_load_textfile(-1);
 
-			GUI_output(get_tx2(0x68));
+			GUI_output(get_tx2(26));
 		}
 	}
 }
@@ -450,17 +450,17 @@ void tevent_126(void)
 	signed short answer;
 
 	do {
-		answer = GUI_radio(get_tx2(0x00), 2,
-					get_tx2(0x04),
-					get_tx2(0x08));
+		answer = GUI_radio(get_tx2(0), 2,
+					get_tx2(1),
+					get_tx2(2));
 	} while (answer == -1);
 
 	if (answer == 1)
 	{
 		do {
-			answer = GUI_radio(get_tx2(0x0c), 2,
-						get_tx2(0x10),
-						get_tx2(0x14));
+			answer = GUI_radio(get_tx2(3), 2,
+						get_tx2(4),
+						get_tx2(5));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -478,15 +478,15 @@ void tevent_127(void)
 
 	do {
 		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-					get_tx2(0x18), 3,
-					get_tx2(0x1c),
-					get_tx2(0x20),
-					get_tx2(0x24));
+					get_tx2(6), 3,
+					get_tx2(7),
+					get_tx2(8),
+					get_tx2(9));
 	} while (answer == -1);
 
 	if (answer == 1 || answer == 2)
 	{
-		GUI_dialog_na(0, (answer == 1 ? get_tx2(0x28) : get_tx2(0x2c)));
+		GUI_dialog_na(0, (answer == 1 ? get_tx2(10) : get_tx2(11)));
 
 		timewarp(MINUTES(30));
 	}
@@ -519,15 +519,15 @@ void tevent_129(void)
 	{
 		ds_writeb(TEVENT129_FLAG, 1);
 
-		GUI_output(get_tx2(0x30));
+		GUI_output(get_tx2(12));
 
 		load_in_head(53);
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x34), 2,
-						get_tx2(0x38),
-						get_tx2(0x3c));
+						get_tx2(13), 2,
+						get_tx2(14),
+						get_tx2(15));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -540,9 +540,9 @@ void tevent_129(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x40), 2,
-						get_tx2(0x44),
-						get_tx2(0x48));
+						get_tx2(16), 2,
+						get_tx2(17),
+						get_tx2(18));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -560,37 +560,37 @@ void tevent_047(void)
 	l_di = 0;
 
 	do {
-		answer = GUI_radio(get_tx2(0x00), 2,
-					get_tx2(0x04),
-					get_tx2(0x08));
+		answer = GUI_radio(get_tx2(0), 2,
+					get_tx2(1),
+					get_tx2(2));
 	} while (answer == -1);
 
 	if (answer == 1)
 	{
 		/* ignore */
-		GUI_output(get_tx2(0x0c));
+		GUI_output(get_tx2(3));
 
 	} else {
 		/* wave */
 		do {
-			answer = GUI_radio(get_tx2(0x10), 2,
-						get_tx2(0x14),
-						get_tx2(0x18));
+			answer = GUI_radio(get_tx2(4), 2,
+						get_tx2(5),
+						get_tx2(6));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			/* run away */
 			do {
-				answer = GUI_radio(get_tx2(0x1c), 2,
-							get_tx2(0x24),
-							get_tx2(0x20));
+				answer = GUI_radio(get_tx2(7), 2,
+							get_tx2(9),
+							get_tx2(8));
 			} while (answer == -1);
 
 			if (answer == 1)
 			{
 				/* run */
-				GUI_output(get_tx2(0x28));
+				GUI_output(get_tx2(10));
 			} else {
 				/* wait */
 				l_di = 1;
@@ -604,15 +604,15 @@ void tevent_047(void)
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							(!l_di ? get_tx2(0x3c) : get_tx2(0x2c)), 2,
-							get_tx2(0x30),
-							get_tx2(0x34));
+							(!l_di ? get_tx2(15) : get_tx2(11)), 2,
+							get_tx2(12),
+							get_tx2(13));
 			} while (answer == -1);
 
 			if (answer == 1)
 			{
 				/* deny */
-				GUI_dialog_na(0, get_tx2(0x38));
+				GUI_dialog_na(0, get_tx2(14));
 			} else {
 				/* accept */
 
@@ -622,20 +622,20 @@ void tevent_047(void)
 				{
 					do {
 						answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-									get_tx2(0x40), 3,
-									get_tx2(0x44),
-									get_tx2(0x48),
-									get_tx2(0x4c));
+									get_tx2(16), 3,
+									get_tx2(17),
+									get_tx2(18),
+									get_tx2(19));
 					} while (answer == -1);
 
 					if (answer == 3)
 					{
 						/* no thanks */
-						GUI_dialog_na(0, get_tx2(0x50));
+						GUI_dialog_na(0, get_tx2(20));
 					} else {
 						/* 1 = LJASDAHL, 2 = OTTARJE */
-						GUI_dialog_na(0, answer == 1 ? get_tx2(0x5c) : get_tx2(0x60));
-						GUI_dialog_na(0, get_tx2(0x64));
+						GUI_dialog_na(0, answer == 1 ? get_tx2(23) : get_tx2(24));
+						GUI_dialog_na(0, get_tx2(25));
 
 						if (answer == 1)
 						{
@@ -653,19 +653,19 @@ void tevent_047(void)
 				} else {
 					do {
 						answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-									get_tx2(0x54), 2,
-									get_tx2(0x58),
-									get_tx2(0x4c));
+									get_tx2(21), 2,
+									get_tx2(22),
+									get_tx2(19));
 					} while (answer == -1);
 
 					if (answer == 2)
 					{
 						/* deny */
-						GUI_dialog_na(0, get_tx2(0x50));
+						GUI_dialog_na(0, get_tx2(20));
 					} else {
 						/* travel to VARNHEIM */
-						GUI_dialog_na(0, get_tx2(0x5c));
-						GUI_dialog_na(0, get_tx2(0x64));
+						GUI_dialog_na(0, get_tx2(23));
+						GUI_dialog_na(0, get_tx2(25));
 
 						ds_writeb(CURRENT_TOWN, 43);
 						ds_writew(X_TARGET, 4);
@@ -686,15 +686,15 @@ void tevent_100(void)
 	if (ds_readb(TEVENT100_FLAG) != 0)
 	{
 		do {
-			answer = GUI_radio(get_tx2(0xd0), 3,
-						get_tx2(0xd4),
-						get_tx2(0xd8),
-						get_tx2(0xdc));
+			answer = GUI_radio(get_tx2(52), 3,
+						get_tx2(53),
+						get_tx2(54),
+						get_tx2(55));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
-			GUI_output(get_tx2(0xe0));
+			GUI_output(get_tx2(56));
 
 			ds_writeb(EVENT_ANI_BUSY, 1);
 
@@ -702,12 +702,12 @@ void tevent_100(void)
 			draw_main_screen();
 			init_ani(0);
 
-			GUI_output(get_tx2(0xe4));
+			GUI_output(get_tx2(57));
 
 			do {
-				answer = GUI_radio(get_tx2(0xe8), 2,
-							get_tx2(0xec),
-							get_tx2(0xf0));
+				answer = GUI_radio(get_tx2(58), 2,
+							get_tx2(59),
+							get_tx2(60));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -715,13 +715,13 @@ void tevent_100(void)
 				ds_writeb(TRAVEL_DETOUR, 7);
 			} else {
 
-				GUI_output(get_tx2(0x10c));
+				GUI_output(get_tx2(67));
 
 				/* FF+4 */
 				if (test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_GE, 4) > 0)
 				{
 					/* success */
-					GUI_output(get_tx2(0x110));
+					GUI_output(get_tx2(68));
 				} else {
 					/* fail */
 					Bit8u *hero;
@@ -735,7 +735,7 @@ void tevent_100(void)
 
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x114),
+						(char*)get_tx2(69),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
@@ -743,7 +743,7 @@ void tevent_100(void)
 					GUI_output(Real2Host(ds_readd(DTP2)));
 				}
 
-				GUI_output(get_tx2(0x118));
+				GUI_output(get_tx2(70));
 			}
 
 			ds_writew(REQUEST_REFRESH, 1);

--- a/src/custom/schick/rewrite_m302de/seg116.cpp
+++ b/src/custom/schick/rewrite_m302de/seg116.cpp
@@ -57,25 +57,25 @@ void tevent_130(void)
 
 		do {
 			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-						get_tx2(0x4c), 2,
-						get_tx2(0x50),
-						get_tx2(0x54));
+						get_tx2(19), 2,
+						get_tx2(20),
+						get_tx2(21));
 		} while (answer == -1);
 
 		if (answer == 1) {
 
 			do {
 				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL,
-							get_tx2(0x58), 3,
-							get_tx2(0x5c),
-							get_tx2(0x60),
-							get_tx2(0x64));
+							get_tx2(22), 3,
+							get_tx2(23),
+							get_tx2(24),
+							get_tx2(25));
 			} while (answer == -1);
 
 			if (answer == 1 || answer == 2) {
-				GUI_dialog_na(0, answer == 1 ? get_tx2(0x68) : get_tx2(0x6c));
+				GUI_dialog_na(0, answer == 1 ? get_tx2(26) : get_tx2(27));
 			} else {
-					GUI_dialog_na(0, test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0 ? get_tx2(0x6c) : get_tx2(0x68));
+					GUI_dialog_na(0, test_attrib(Real2Host(get_first_hero_available_in_group()), ATTRIB_CH, 0) > 0 ? get_tx2(27) : get_tx2(26));
 			}
 		}
 
@@ -94,12 +94,12 @@ void tevent_131(void)
 
 		ds_writeb(TEVENT131_FLAG, 1);
 
-		GUI_output(get_tx2(0x70));
+		GUI_output(get_tx2(28));
 
 		do {
-			answer = GUI_radio(get_tx2(0x74), 2,
-						get_tx2(0x78),
-						get_tx2(0x7c));
+			answer = GUI_radio(get_tx2(29), 2,
+						get_tx2(30),
+						get_tx2(31));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -111,9 +111,9 @@ void tevent_131(void)
 		if (ds_readb(TEVENT131_FLAG) != 0) {
 
 			do {
-				answer = GUI_radio(get_tx2(0x80), 2,
-							get_tx2(0x84),
-							get_tx2(0x88));
+				answer = GUI_radio(get_tx2(32), 2,
+							get_tx2(33),
+							get_tx2(34));
 			} while (answer == -1);
 
 			if (answer == 1) {
@@ -150,16 +150,16 @@ void tevent_133(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0x8c), 2,
-					get_tx2(0x90),
-					get_tx2(0x94));
+		answer = GUI_radio(get_tx2(35), 2,
+					get_tx2(36),
+					get_tx2(37));
 	} while (answer == -1);
 
 	if (answer == 1) {
 		ds_writews(TRV_RETURN, 1);
 	} else {
 
-		GUI_output(get_tx2(0x98));
+		GUI_output(get_tx2(38));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
@@ -176,7 +176,7 @@ void tevent_133(void)
 					timewarp(HOURS(1));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x9c),
+						(char*)get_tx2(39),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)),
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
@@ -185,14 +185,14 @@ void tevent_133(void)
 
 					sub_hero_le(hero, random_schick(8));
 
-					loose_random_item(hero, 50, get_ttx(0x7e8));
-					loose_random_item(hero, 50, get_ttx(0x7e8));
-					loose_random_item(hero, 50, get_ttx(0x7e8));
+					loose_random_item(hero, 50, get_ttx(506));
+					loose_random_item(hero, 50, get_ttx(506));
+					loose_random_item(hero, 50, get_ttx(506));
 				}
 			}
 		}
 
-		GUI_output(get_tx2(0xa0));
+		GUI_output(get_tx2(40));
 	}
 }
 
@@ -221,12 +221,12 @@ void tevent_135(void)
 	draw_main_screen();
 	init_ani(0);
 
-	GUI_output(get_tx2(0xa4));
+	GUI_output(get_tx2(41));
 
 	do {
-		answer = GUI_radio(get_tx2(0xa8), 2,
-					get_tx2(0xac),
-					get_tx2(0xb0));
+		answer = GUI_radio(get_tx2(42), 2,
+					get_tx2(43),
+					get_tx2(44));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -234,31 +234,31 @@ void tevent_135(void)
 		do {
 			done = 0;
 
-			hero = get_hero(select_hero_ok_forced(get_tx2(0xb4)));
+			hero = get_hero(select_hero_ok_forced(get_tx2(45)));
 
 			l_si = 1;
 			if (test_skill(hero, TA_KLETTERN, -1) > 0) {
 				l_si = 2;
-				GUI_output(get_tx2(0xb8));
+				GUI_output(get_tx2(46));
 
 				if (test_skill(hero, TA_KLETTERN, 1) > 0) {
 					l_si = 3;
-					GUI_output(get_tx2(0xbc));
+					GUI_output(get_tx2(47));
 
 					if (test_skill(hero, TA_KLETTERN, 0) > 0) {
 						l_si = 4;
-						GUI_output(get_tx2(0xc0));
+						GUI_output(get_tx2(48));
 
 						if (test_skill(hero, TA_KLETTERN, 2) > 0) {
 							l_si = 5;
-							GUI_output(get_tx2(0xc4));
+							GUI_output(get_tx2(49));
 
 							if (test_skill(hero, TA_KLETTERN, 1) > 0) {
 
-								GUI_output(get_tx2(0xc8));
+								GUI_output(get_tx2(50));
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx2(0xd8),
+									(char*)get_tx2(54),
 									(char*)hero + HERO_NAME2,
 									(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 3)));
 								GUI_output(Real2Host(ds_readd(DTP2)));
@@ -266,7 +266,7 @@ void tevent_135(void)
 								load_in_head(45);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-									(char*)get_tx2(0xdc),
+									(char*)get_tx2(55),
 									(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 									(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -280,14 +280,14 @@ void tevent_135(void)
 
 								if (count < 5) {
 									sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-										(char*)get_tx2(0xe0),
+										(char*)get_tx2(56),
 										(char*)hero + HERO_NAME2,
-										(char*)get_tx2(0xe4));
+										(char*)get_tx2(57));
 								} else {
 									sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-										(char*)get_tx2(0xe0),
+										(char*)get_tx2(56),
 										(char*)hero + HERO_NAME2,
-										(char*)get_tx(4 * random_interval(54, 67)));
+										(char*)get_tx(random_interval(54, 67)));
 								}
 
 								GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -299,7 +299,7 @@ void tevent_135(void)
 								}
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)) + 0x400,
-									(char*)get_tx2(0xe8),
+									(char*)get_tx2(58),
 									(char*)hero + HERO_NAME2,
 									(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
 								GUI_dialog_na(0, Real2Host(ds_readd(DTP2)) + 0x400);
@@ -314,7 +314,7 @@ void tevent_135(void)
 
 			if (l_si) {
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_tx2(0xcc),
+					(char*)get_tx2(51),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -327,7 +327,7 @@ void tevent_135(void)
 
 				if (l_si <= 0) {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)(!l_si ? get_tx2(0xd4) : get_tx2(0xd0)),
+						(char*)(!l_si ? get_tx2(53) : get_tx2(52)),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -335,7 +335,7 @@ void tevent_135(void)
 
 				if (count_heroes_available_in_group()) {
 
-					if (!GUI_bool(get_tx2(0xec))) {
+					if (!GUI_bool(get_tx2(59))) {
 						done = 1;
 					}
 				} else {
@@ -363,9 +363,9 @@ void tevent_137(void)
 		ds_writeb(TEVENT137_FLAG, 1);
 
 		do {
-			answer = GUI_radio(get_tx2(0xf0), 2,
-						get_tx2(0xf4),
-						get_tx2(0xf8));
+			answer = GUI_radio(get_tx2(60), 2,
+						get_tx2(61),
+						get_tx2(62));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -419,9 +419,9 @@ void tevent_139(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0xfc), 2,
-					get_tx2(0x100),
-					get_tx2(0x104));
+		answer = GUI_radio(get_tx2(63), 2,
+					get_tx2(64),
+					get_tx2(65));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -439,11 +439,11 @@ void tevent_139(void)
 
 		timewarp(HOURS(6));
 
-		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 3)) > 0 ? get_tx2(0x108) : get_tx2(0x110));
+		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 3)) > 0 ? get_tx2(66) : get_tx2(68));
 	} else {
 		timewarp(HOURS(2));
 
-		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 5)) > 0 ? get_tx2(0x10c) : get_tx2(0x114));
+		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 5)) > 0 ? get_tx2(67) : get_tx2(69));
 	}
 
 	if (i <= 0) {
@@ -451,13 +451,13 @@ void tevent_139(void)
 
 			timewarp(HOURS(2));
 
-			GUI_output(get_tx2(0x118));
+			GUI_output(get_tx2(70));
 
 		} else {
 
 			timewarp(HOURS(3));
 
-			GUI_output(get_tx2(0x11c));
+			GUI_output(get_tx2(71));
 
 			ds_writeb(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -518,9 +518,9 @@ void tevent_143(void)
 	Bit8u *hero;
 
 	do {
-		answer = GUI_radio(get_tx2(0x00), 2,
-					get_tx2(0x04),
-					get_tx2(0x08));
+		answer = GUI_radio(get_tx2(0), 2,
+					get_tx2(1),
+					get_tx2(2));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -537,11 +537,11 @@ void tevent_143(void)
 
 		timewarp(HOURS(4));
 
-		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 2)) > 0 ? get_tx2(0x0c) : get_tx2(0x14));
+		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 2)) > 0 ? get_tx2(3) : get_tx2(5));
 	} else {
 		timewarp(HOURS(1));
 
-		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 4)) > 0 ? get_tx2(0x10) : get_tx2(0x18));
+		GUI_output((i = test_skill(Real2Host(get_first_hero_available_in_group()), TA_ORIENTIERUNG, 4)) > 0 ? get_tx2(4) : get_tx2(6));
 	}
 
 	if (i <= 0) {
@@ -550,13 +550,13 @@ void tevent_143(void)
 
 			timewarp(HOURS(1));
 
-			GUI_output(get_tx2(0x1c));
+			GUI_output(get_tx2(7));
 
 		} else {
 
 			timewarp(HOURS(3));
 
-			GUI_output(get_tx2(0x20));
+			GUI_output(get_tx2(8));
 
 			ds_writeb(LOCATION, LOCATION_WILDCAMP);
 			do_location();
@@ -579,10 +579,10 @@ void tevent_144(void)
 		if (ds_readbs(YEAR) == 17 && ds_readbs(MONTH) == 10 && ds_readbs(DAY_OF_MONTH) >= 10) {
 			right_time_flag = 1;
 		} else {
-			if (ds_readb(ORCDOCUMENT_READ_FLAG) != 0 && GUI_bool(get_tx2(0xb8))) {
+			if (ds_readb(ORCDOCUMENT_READ_FLAG) != 0 && GUI_bool(get_tx2(46))) {
 			/* the time is not right, forward time  */
 
-				GUI_output(get_tx2(0xbc));
+				GUI_output(get_tx2(47));
 
 				/* set date */
 				ds_writebs(YEAR, 17);
@@ -605,25 +605,25 @@ void tevent_144(void)
 			hero = get_hero(grimring_hero_pos);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x28),
+				(char*)get_tx2(10),
 				(char*)hero + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x2c),
+				(char*)get_tx2(11),
 				(char*)hero + HERO_NAME2);
 
 			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, Real2Host(ds_readd(DTP2)), 0);
-			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(0x30), 0);
-			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(0x34), 0);
+			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(12), 0);
+			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(13), 0);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_tx2(0x38),
+				(char*)get_tx2(14),
 				(char*)hero + HERO_NAME2);
 
 			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, Real2Host(ds_readd(DTP2)), 0);
-			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(0x3c), 0);
+			GUI_dialogbox((RealPt)ds_readd(BUFFER10_PTR), (RealPt)0, get_tx2(15), 0);
 
 			do {
 				status_menu(grimring_hero_pos);
@@ -637,7 +637,7 @@ void tevent_144(void)
 				if (grimring_hero_pos == 6) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x98),
+						(char*)get_tx2(38),
 						(char*)get_hero(6) + HERO_NAME2);
 
 					GUI_dialogbox((RealPt)ds_readd(HEROS) + SIZEOF_HERO * 6 + HERO_PORTRAIT,
@@ -652,7 +652,7 @@ void tevent_144(void)
 			final_intro();
 			if (!TRV_fight_event(FIGHTS_F144, 144)) {
 				/* you won the final fight */
-				GUI_output(get_tx2(0x44));
+				GUI_output(get_tx2(17));
 
 				ds_writews(GAME_STATE, GAME_STATE_VICTORY);
 
@@ -662,7 +662,7 @@ void tevent_144(void)
 				ds_writews(NPC_MONTHS, 200);
 			} else {
 				/* you lost the final fight */
-				GUI_output(get_tx2(0x48));
+				GUI_output(get_tx2(18));
 				ds_writews(GAME_STATE, GAME_STATE_DEAD);
 			}
 		}
@@ -672,7 +672,7 @@ void tevent_144(void)
 /* TODO: this function is unused */
 void tevent_144_unused(void)
 {
-	GUI_output(get_tx2(0x40));
+	GUI_output(get_tx2(16));
 }
 
 void TLK_old_woman(signed short state)

--- a/src/custom/schick/rewrite_m302de/seg117.cpp
+++ b/src/custom/schick/rewrite_m302de/seg117.cpp
@@ -90,7 +90,7 @@ void hunt_karen(void)
 	pause_traveling(21);
 
 	do {
-		answer = GUI_radio(get_tx2(0x00), 2, get_tx2(0x04), get_tx2(0x08));
+		answer = GUI_radio(get_tx2(0), 2, get_tx2(1), get_tx2(2));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -117,7 +117,7 @@ void hunt_karen(void)
 			if (count_heroes_in_group() <= passed) {
 				/* all heros passed STEALTH */
 
-				GUI_output(get_tx2(0x14));
+				GUI_output(get_tx2(5));
 
 				/* make a MISSLE WEAPON+0 test and count the heroes who passed it */
 				hero = get_hero(0);
@@ -135,27 +135,27 @@ void hunt_karen(void)
 				if ((count_heroes_in_group() / 2) <= passed) {
 					/* over the half of the group passed MISSLE WEAPON+0 */
 
-					GUI_output(get_tx2(0x20));
+					GUI_output(get_tx2(8));
 					/* get 80 FOOD PACKAGES */
 					get_item(45, 1, 80);
 
 				} else if (passed) {
 					/* at least one of the group passed MISSLE WEAPON+0 */
 
-					GUI_output(get_tx2(0x1c));
+					GUI_output(get_tx2(7));
 					/* get 40 FOOD PACKAGES */
 					get_item(45, 1, 40);
 				} else {
 					/* everybody failed MISSLE WEAPON+0 */
-					GUI_output(get_tx2(0x18));
+					GUI_output(get_tx2(6));
 				}
 			} else {
 				/* at least one hero failed STEALTH+2 */
-				GUI_output(get_tx2(0x10));
+				GUI_output(get_tx2(4));
 			}
 		} else {
 			/* no hunting weapon in the group */
-			GUI_output(get_tx2(0x24));
+			GUI_output(get_tx2(9));
 		}
 	}
 
@@ -172,7 +172,7 @@ void hunt_wildboar(void)
 	pause_traveling(25);
 
 	do {
-		answer = GUI_radio(get_tx2(0x28), 2, get_tx2(0x2c), get_tx2(0x30));
+		answer = GUI_radio(get_tx2(10), 2, get_tx2(11), get_tx2(12));
 	} while (answer == -1);
 
 	if (answer == 1) {
@@ -199,7 +199,7 @@ void hunt_wildboar(void)
 			if (count_heroes_in_group() <= passed) {
 				/* all heros passed STEALTH */
 
-				GUI_output(get_tx2(0x3c));
+				GUI_output(get_tx2(15));
 
 				/* make a MISSLE WEAPON+0 test and count the heroes who passed it */
 				hero = get_hero(0);
@@ -217,21 +217,21 @@ void hunt_wildboar(void)
 				if ((count_heroes_in_group() / 2) <= passed) {
 					/* over the half of the group passed MISSLE WEAPON+0 */
 
-					GUI_output(get_tx2(0x44));
+					GUI_output(get_tx2(17));
 					/* get 30 FOOD PACKAGES */
 					get_item(45, 1, 30);
 
 				} else {
 					/* everybody failed MISSLE WEAPON+0 */
-					GUI_output(get_tx2(0x40));
+					GUI_output(get_tx2(16));
 				}
 			} else {
 				/* at least one hero failed STEALTH+0 */
-				GUI_output(get_tx2(0x38));
+				GUI_output(get_tx2(14));
 			}
 		} else {
 			/* no hunting weapon in the group */
-			GUI_output(get_tx2(0x48));
+			GUI_output(get_tx2(18));
 		}
 	}
 
@@ -247,19 +247,19 @@ void hunt_cavebear(void)
 	pause_traveling(32);
 
 	do {
-		answer = GUI_radio(get_tx2(0x4c), 2, get_tx2(0x50), get_tx2(0x54));
+		answer = GUI_radio(get_tx2(19), 2, get_tx2(20), get_tx2(21));
 	} while (answer == -1);
 
 	if (answer == 1) {
 
 		/* print message */
-		GUI_output(get_tx2(0x60));
+		GUI_output(get_tx2(24));
 
 		/* time to flee = 1.5 hour */
 		timewarp(0x1fa4);
 
 	} else {
-		GUI_output(get_tx2(0x58));
+		GUI_output(get_tx2(22));
 
 		hero = get_hero(0);
 		for (i = 0; i <= 6; i++, hero += SIZEOF_HERO) {
@@ -293,7 +293,7 @@ void hunt_cavebear(void)
 			}
 		}
 
-		GUI_output(get_tx2(0x5c));
+		GUI_output(get_tx2(23));
 	}
 
 	resume_traveling();
@@ -310,7 +310,7 @@ void hunt_viper(void)
 	/* load snake picture */
 	pause_traveling(30);
 
-	GUI_output(get_tx2(0x64));
+	GUI_output(get_tx2(25));
 
 	hero_i = get_hero(0);
 
@@ -338,7 +338,7 @@ void hunt_viper(void)
 
 		/* print a message */
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x68),
+			(char*)get_tx2(26),
 			hero_i + HERO_NAME2);
 
 		GUI_output(Real2Host(ds_readd(DTP2)));
@@ -356,7 +356,7 @@ void hunt_viper(void)
 			sub_hero_le(hero_i, dice_roll(3, 6, 0) * 2);
 		}
 	} else {
-		GUI_output(get_tx2(0x6c));
+		GUI_output(get_tx2(27));
 	}
 
 	resume_traveling();
@@ -374,8 +374,8 @@ void octopus_attack(void)
 	pause_traveling(31);
 	memset(overboard, 0, 7);
 
-	GUI_output(get_tx2(0x70));
-	GUI_output(get_tx2(0x74));
+	GUI_output(get_tx2(28));
+	GUI_output(get_tx2(29));
 
 	do {
 		hero = get_hero(0);
@@ -396,7 +396,7 @@ void octopus_attack(void)
 					add_hero_ap(hero, 5);
 					sub_hero_le(hero, random_schick(6));
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x78),
+						(char*)get_tx2(30),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -406,7 +406,7 @@ void octopus_attack(void)
 					add_hero_ap(hero, 20);
 					sub_hero_le(hero, random_schick(6));
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x7c),
+						(char*)get_tx2(31),
 						(char*)hero + HERO_NAME2);
 					GUI_output(Real2Host(ds_readd(DTP2)));
 
@@ -429,7 +429,7 @@ void octopus_attack(void)
 
 	sub_group_le(3);
 	add_hero_ap_all(5);
-	GUI_output(get_tx2(0x80));
+	GUI_output(get_tx2(32));
 
 	ds_writew(BASEPOS_X, ds_writew(BASEPOS_Y, 0));
 	status_menu(get_hero_index(Real2Host(get_first_hero_available_in_group())));
@@ -444,19 +444,19 @@ void hunt_bison(void)
 	pause_traveling(29);
 
 	do {
-		answer = GUI_radio(get_tx2(0x84), 2, get_tx2(0x88), get_tx2(0x8c));
+		answer = GUI_radio(get_tx2(33), 2, get_tx2(34), get_tx2(35));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 		timewarp(MINUTES(30));
-		GUI_output(get_tx2(0x98));
+		GUI_output(get_tx2(38));
 	} else {
-		GUI_output(get_tx2(0x90));
+		GUI_output(get_tx2(36));
 
 		hero = get_hero(get_random_hero());
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0x94),
+			(char*)get_tx2(37),
 			(char*)hero + HERO_NAME2);
 		GUI_output(Real2Host(ds_readd(DTP2)));
 		sub_hero_le(hero, random_schick(6));
@@ -474,19 +474,19 @@ void hunt_rhino(void)
 	pause_traveling(33);
 
 	do {
-		answer = GUI_radio(get_tx2(0x9c), 2, get_tx2(0xa0), get_tx2(0xa4));
+		answer = GUI_radio(get_tx2(39), 2, get_tx2(40), get_tx2(41));
 
 	} while (answer == -1);
 
 	if (answer == 1) {
 		timewarp(MINUTES(30));
-		GUI_output(get_tx2(0xb0));
+		GUI_output(get_tx2(44));
 	} else {
-		GUI_output(get_tx2(0xa8));
+		GUI_output(get_tx2(42));
 
 		hero = get_hero(get_random_hero());
 		sprintf((char*)Real2Host(ds_readd(DTP2)),
-			(char*)get_tx2(0xac),
+			(char*)get_tx2(43),
 			(char*)hero + HERO_NAME2);
 		GUI_output(Real2Host(ds_readd(DTP2)));
 		sub_hero_le(hero, dice_roll(2, 6, 0));
@@ -500,9 +500,9 @@ void pirates_attack(void)
 {
 	pause_traveling(9);
 
-	GUI_output(get_tx2(0xb4));
-	GUI_output(get_tx2(0xb8));
-	GUI_output(get_tx2(0xbc));
+	GUI_output(get_tx2(45));
+	GUI_output(get_tx2(46));
+	GUI_output(get_tx2(47));
 
 	ds_writew(MAX_ENEMIES, random_interval(3, 8));
 	ds_writew(FIG_DISCARD, 1);
@@ -730,7 +730,7 @@ void TLK_way_to_ruin(signed short state)
 		hero_disease_test(Real2Host(ds_readd(RUIN_HERO)), 2,
 			25 - (host_readbs(Real2Host(hero) + (HERO_ATTRIB + 3 * ATTRIB_KK)) + host_readbs(Real2Host(hero + (HERO_ATTRIB_MOD + 3 * ATTRIB_KK)))));
 
-		loose_random_item(Real2Host(ds_readd(RUIN_HERO)), 10, get_ttx(0x7e8));
+		loose_random_item(Real2Host(ds_readd(RUIN_HERO)), 10, get_ttx(506));
 
 	} else if (state == 13 || state == 25 || state == 34 || state == 59 || state == 62) {
 		timewarp(MINUTES(30));
@@ -745,10 +745,10 @@ void TLK_way_to_ruin(signed short state)
 		ds_writed(RUIN_HERO, (Bit32u)((RealPt)ds_readd(HEROS) + SIZEOF_HERO * get_random_hero()));
 		ds_writew(DIALOG_NEXT_STATE, test_skill(Real2Host(ds_readd(RUIN_HERO)), TA_AEXTE, 2) > 0 ? 20 : 21);
 	} else if (state == 20) {
-		loose_random_item(get_hero(get_random_hero()), 5, get_ttx(0x7e8));
+		loose_random_item(get_hero(get_random_hero()), 5, get_ttx(506));
 	} else if (state == 21) {
 		timewarp(MINUTES(10));
-		loose_random_item(hero2, 10, get_ttx(0x7e8));
+		loose_random_item(hero2, 10, get_ttx(506));
 		sub_hero_le(hero2, random_schick(4) + 2);
 	} else if (state == 22 || state == 30 || state == 52 || state == 53) {
 		timewarp(HOURS(3));

--- a/src/custom/schick/rewrite_m302de/seg118.cpp
+++ b/src/custom/schick/rewrite_m302de/seg118.cpp
@@ -51,9 +51,9 @@ void tevent_037(void)
 		init_ani(0);
 
 		do {
-			answer = GUI_radio(get_tx2(0x68), 2,
-						get_tx2(0x6c),
-						get_tx2(0x70));
+			answer = GUI_radio(get_tx2(26), 2,
+						get_tx2(27),
+						get_tx2(28));
 		} while (answer == -1);
 
 		if (answer == 1) {
@@ -62,9 +62,9 @@ void tevent_037(void)
 			timewarp(MINUTES(15));
 
 			do {
-				answer = GUI_radio(get_tx2(0x74), 2,
-							get_tx2(0x78),
-							get_tx2(0x70));
+				answer = GUI_radio(get_tx2(29), 2,
+							get_tx2(30),
+							get_tx2(28));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -74,9 +74,9 @@ void tevent_037(void)
 
 				/* loop until you decicide to go on */
 				do {
-					answer = GUI_radio(get_tx2(0x7c), 2,
-								get_tx2(0x78),
-								get_tx2(0x70));
+					answer = GUI_radio(get_tx2(31), 2,
+								get_tx2(30),
+								get_tx2(28));
 
 				} while (answer == -1 || answer == 1);
 			}
@@ -86,9 +86,9 @@ void tevent_037(void)
 			/* go on */
 
 			do {
-				answer = GUI_radio(get_tx2(0x80), 2,
-							get_tx2(0x84),
-							get_tx2(0x88));
+				answer = GUI_radio(get_tx2(32), 2,
+							get_tx2(33),
+							get_tx2(34));
 
 			} while (answer == -1);
 		}
@@ -98,12 +98,12 @@ void tevent_037(void)
 			if (answer == 1)
 			{
 				/* turn around */
-				hours = GUI_input(get_tx2(0x8c), 2);
+				hours = GUI_input(get_tx2(35), 2);
 
 				if (hours >= 4)
 				{
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0x90),
+						(char*)get_tx2(36),
 						hours);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -114,9 +114,9 @@ void tevent_037(void)
 
 					/* entered time was to short */
 					do {
-						answer = GUI_radio(get_tx2(0x94), 2,
-									get_tx2(0x84),
-									get_tx2(0x88));
+						answer = GUI_radio(get_tx2(37), 2,
+									get_tx2(33),
+									get_tx2(34));
 
 					} while (answer == -1);
 
@@ -124,17 +124,17 @@ void tevent_037(void)
 					{
 						timewarp(HOURS(4));
 
-						GUI_output(get_tx2(0x98));
+						GUI_output(get_tx2(38));
 
 						done = 1;
 					}
 				}
 			} else {
 				do {
-					answer = GUI_radio(get_tx2(0x9c), 3,
-								get_tx2(0xa0),
-								get_tx2(0xa4),
-								get_tx2(0xa8));
+					answer = GUI_radio(get_tx2(39), 3,
+								get_tx2(40),
+								get_tx2(41),
+								get_tx2(42));
 
 				} while (answer == -1);
 
@@ -147,7 +147,7 @@ void tevent_037(void)
 					hero = get_hero(answer = get_random_hero());
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0xb4),
+						(char*)get_tx2(45),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 2)));
 
@@ -157,25 +157,25 @@ void tevent_037(void)
 
 					add_hero_ap_all(20);
 
-					GUI_output(get_tx2(0xb8));
+					GUI_output(get_tx2(46));
 
-					GUI_input(get_tx2(0xbc), 10);
+					GUI_input(get_tx2(47), 10);
 
 					/* check if the answer is "RAD" 1st */
 					if (strcmp((char*)Real2Host(ds_readd(TEXT_INPUT_BUF)), (char*)p_datseg + STR_RAD1))
 					{
-						GUI_input(get_tx2(0xc0), 10);
+						GUI_input(get_tx2(48), 10);
 
 						/* check if the answer is "RAD" 2nd */
 						if (strcmp((char*)Real2Host(ds_readd(TEXT_INPUT_BUF)), (char*)p_datseg + STR_RAD2))
 						{
-							GUI_input(get_tx2(0xc4), 10);
+							GUI_input(get_tx2(49), 10);
 
 							/* check if the answer is "RAD" 3rd */
 							if (strcmp((char*)Real2Host(ds_readd(TEXT_INPUT_BUF)), (char*)p_datseg + STR_RAD3))
 							{
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_tx2(0xc8),
+									(char*)get_tx2(50),
 									(char*)hero + HERO_NAME2,
 									(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)),
 									(char*)hero + HERO_NAME2,
@@ -189,7 +189,7 @@ void tevent_037(void)
 								done = 1;
 							} else {
 
-								GUI_output(get_tx2(0xcc));
+								GUI_output(get_tx2(51));
 
 								add_hero_ap_all(10);
 
@@ -197,7 +197,7 @@ void tevent_037(void)
 							}
 						} else {
 
-							GUI_output(get_tx2(0xcc));
+							GUI_output(get_tx2(51));
 
 							add_hero_ap_all(10);
 
@@ -205,7 +205,7 @@ void tevent_037(void)
 						}
 					} else {
 
-						GUI_output(get_tx2(0xcc));
+						GUI_output(get_tx2(51));
 
 						add_hero_ap_all(10);
 
@@ -216,9 +216,9 @@ void tevent_037(void)
 					/* talk of hetmann or hyggelik */
 
 					do {
-						answer = GUI_radio(get_tx2(0xac), 2,
-									get_tx2(0x84),
-									get_tx2(0x88));
+						answer = GUI_radio(get_tx2(43), 2,
+									get_tx2(33),
+									get_tx2(34));
 
 					} while (answer == -1);
 
@@ -230,7 +230,7 @@ void tevent_037(void)
 						timewarp(HOURS(1));
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_tx2(0xb0),
+							(char*)get_tx2(44),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -270,9 +270,9 @@ void tevent_078(void)
 	{
 
 		do {
-			answer = GUI_radio(get_tx2(0x138), 2,
-						get_tx2(0x13c),
-						get_tx2(0x140));
+			answer = GUI_radio(get_tx2(78), 2,
+						get_tx2(79),
+						get_tx2(80));
 		} while (answer == -1);
 
 		load_in_head(57);
@@ -290,7 +290,7 @@ void tevent_078(void)
 
 			timewarp(HOURS(hours));
 
-			GUI_dialog_na(0, get_tx2(0x144));
+			GUI_dialog_na(0, get_tx2(81));
 
 			/* each hero in the group looses hours / 2 LE */
 			sub_group_le(hours >> 1);
@@ -307,7 +307,7 @@ void tevent_078(void)
 			/* if a campfight occurs, the picture needs to be reloaded */
 			load_in_head(57);
 #endif
-			GUI_dialog_na(0, get_tx2(0x150));
+			GUI_dialog_na(0, get_tx2(84));
 
 		} else {
 			/* try to find another path */
@@ -322,14 +322,14 @@ void tevent_078(void)
 
 					sub_group_le(2);
 
-					GUI_dialog_na(0, !answer ? get_tx2(0x148) : get_tx2(0x154));
+					GUI_dialog_na(0, !answer ? get_tx2(82) : get_tx2(85));
 
 					found_path = 1;
 				} else {
 					/* fail */
 					timewarp(HOURS(8));
 
-					GUI_dialog_na(0, get_tx2(0x14c));
+					GUI_dialog_na(0, get_tx2(83));
 
 					sub_group_le(4);
 
@@ -352,7 +352,7 @@ void tevent_078(void)
 
 			if (found_path == 0)
 			{
-				GUI_dialog_na(0, get_tx2(0x158));
+				GUI_dialog_na(0, get_tx2(86));
 
 				timewarp(HOURS(8));
 
@@ -390,15 +390,15 @@ void tevent_051(void)
 		if (!TRV_follow_trail_question())
 		{
 
-			GUI_output(get_tx2(0x104));
-			GUI_output(get_tx2(0x108));
+			GUI_output(get_tx2(65));
+			GUI_output(get_tx2(66));
 
 			load_in_head(53);
 
 			do {
-				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x10c), 2,
-							get_tx2(0x110),
-							get_tx2(0x114));
+				answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(67), 2,
+							get_tx2(68),
+							get_tx2(69));
 			} while (answer == -1);
 
 			if (answer == 1)
@@ -412,9 +412,9 @@ void tevent_051(void)
 		load_in_head(53);
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x118), 2,
-						get_tx2(0x11c),
-						get_tx2(0x120));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(70), 2,
+						get_tx2(71),
+						get_tx2(72));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -437,16 +437,16 @@ void tevent_052(void)
 	do {
 
 		do {
-			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0x124), 2,
-						get_tx2(0x128),
-						get_tx2(0x12c));
+			answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(73), 2,
+						get_tx2(74),
+						get_tx2(75));
 		} while (answer == -1);
 
 		if (answer == 1)
 		{
 			timewarp(HOURS(1));
 
-			GUI_dialog_na(0, get_tx2(0x130));
+			GUI_dialog_na(0, get_tx2(76));
 
 			done = 1;
 		} else {
@@ -466,9 +466,9 @@ void tevent_052(void)
 			{
 				timewarp(HOURS(3));
 
-				GUI_dialog_na(0, get_tx2(0x134));
+				GUI_dialog_na(0, get_tx2(77));
 			} else {
-				GUI_dialog_na(0, get_tx2(0x138));
+				GUI_dialog_na(0, get_tx2(78));
 			}
 		}
 
@@ -487,7 +487,7 @@ void tevent_120(void)
 
 void tevent_121(void)
 {
-	TRV_cross_a_ford(get_tx(0xd4), 30, 0);
+	TRV_cross_a_ford(get_tx(53), 30, 0);
 }
 
 void tevent_124(void)
@@ -501,19 +501,19 @@ void tevent_124(void)
 
 	have_climb_tools = 0;
 
-	GUI_output(get_tx2(0xc4));
+	GUI_output(get_tx2(49));
 
 	if (DNG_check_climb_tools() != -1)
 	{
 		have_climb_tools = 1;
 
-		GUI_output(get_tx2(0xc8));
+		GUI_output(get_tx2(50));
 	}
 
 	do {
-		answer = GUI_radio(get_tx2(0xcc), 2,
-					get_tx2(0xd0),
-					get_tx2(0xd4));
+		answer = GUI_radio(get_tx2(51), 2,
+					get_tx2(52),
+					get_tx2(53));
 	} while (answer == -1);
 
 	if (answer == 2)
@@ -542,7 +542,7 @@ void tevent_124(void)
 				{
 					/* fatal */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0xe0),
+						(char*)get_tx2(56),
 						(char*)hero + HERO_NAME2,
 						(char*)Real2Host(GUI_get_ptr(host_readbs(hero + HERO_SEX), 0)));
 
@@ -553,7 +553,7 @@ void tevent_124(void)
 				} else {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_tx2(0xdc),
+						(char*)get_tx2(55),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -565,7 +565,7 @@ void tevent_124(void)
 
 		if (!counter)
 		{
-			GUI_output(get_tx2(0xd8));
+			GUI_output(get_tx2(54));
 		}
 	}
 
@@ -578,15 +578,15 @@ void tevent_125(void)
 	load_in_head(17);
 
 	do {
-		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(0xe4), 3,
-					get_tx2(0xe8),
-					get_tx2(0xec),
-					get_tx2(0xf0));
+		answer = GUI_dialogbox((RealPt)ds_readd(DTP2), NULL, get_tx2(57), 3,
+					get_tx2(58),
+					get_tx2(59),
+					get_tx2(60));
 	} while (answer == -1);
 
 	if (answer == 1 || answer == 2)
 	{
-		GUI_dialog_na(0, answer == 1 ? get_tx2(0xf4) : get_tx2(0xf8));
+		GUI_dialog_na(0, answer == 1 ? get_tx2(61) : get_tx2(62));
 
 		timewarp(MINUTES(30));
 	}
@@ -602,9 +602,9 @@ void tevent_145(void)
 	if (!(cast_u16(ds_readb(ROUTE59_FLAG)) & 1))
 	{
 		do {
-			answer = GUI_radio(get_tx2(0xa8), 2,
-						get_tx2(0xac),
-						get_tx2(0xb0));
+			answer = GUI_radio(get_tx2(42), 2,
+						get_tx2(43),
+						get_tx2(44));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -619,9 +619,9 @@ void tevent_145(void)
 
 	} else {
 		do {
-			answer = GUI_radio(get_tx2(0x9c), 2,
-						get_tx2(0xa0),
-						get_tx2(0xa4));
+			answer = GUI_radio(get_tx2(39), 2,
+						get_tx2(40),
+						get_tx2(41));
 		} while (answer == -1);
 
 		if (answer == 1)
@@ -636,8 +636,8 @@ void tevent_145(void)
 	}
 
 	sprintf((char*)Real2Host(ds_readd(DTP2)),
-		(char*)get_tx2(0xb4),
-		(char*)get_ttx(4 * (ds_readws(TRV_DESTINATION) + 0xeb)));
+		(char*)get_tx2(45),
+		(char*)get_ttx(ds_readws(TRV_DESTINATION) + 0xeb));
 
 	GUI_output(Real2Host(ds_readd(DTP2)));
 }

--- a/src/custom/schick/rewrite_m302de/seg119.cpp
+++ b/src/custom/schick/rewrite_m302de/seg119.cpp
@@ -66,7 +66,7 @@ void disease_effect(void)
 
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8c4),
+						(char*)get_ttx(561),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -77,7 +77,7 @@ void disease_effect(void)
 
 					if (host_readbs(Real2Host(hero) + (HERO_ATTRIB + 3 * ATTRIB_KK)) != 0) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f0),
+							(char*)get_ttx(572),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -98,7 +98,7 @@ void disease_effect(void)
 				} else {
 					/* hero regains the lost strength */
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8f4),
+						(char*)get_ttx(573),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -128,7 +128,7 @@ void disease_effect(void)
 
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8f8),
+						(char*)get_ttx(574),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -203,7 +203,7 @@ void disease_effect(void)
 
 				/* regeneration complete */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x8fc),
+					(char*)get_ttx(575),
 					(char*)Real2Host(hero) + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -231,7 +231,7 @@ void disease_effect(void)
 					sub_ptr_bs(Real2Host(hero) + (HERO_ATTRIB + 3 * ATTRIB_KK), host_readbs(disease_ptr + 2));
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x904),
+						(char*)get_ttx(577),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -269,7 +269,7 @@ void disease_effect(void)
 
 				/* regeneration complete */
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x900),
+					(char*)get_ttx(576),
 					(char*)Real2Host(hero) + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -311,7 +311,7 @@ void disease_effect(void)
 					sub_ptr_bs(Real2Host(hero) + (HERO_ATTRIB + 3 * ATTRIB_KK), j);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x90c),
+						(char*)get_ttx(579),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -328,7 +328,7 @@ void disease_effect(void)
 
 					if (!host_readbs(disease_ptr + 2)) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f4),
+							(char*)get_ttx(573),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -339,7 +339,7 @@ void disease_effect(void)
 
 					if (!host_readbs(disease_ptr + 3)) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x908),
+							(char*)get_ttx(578),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -362,7 +362,7 @@ void disease_effect(void)
 					if (random_schick(100) <= (host_readbs(Real2Host(hero) + HERO_TYPE) >= HERO_TYPE_GREEN_ELF ? 30 : 20)) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x910),
+							(char*)get_ttx(580),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -384,7 +384,7 @@ void disease_effect(void)
 							sub_ptr_bs(Real2Host(hero) + (HERO_ATTRIB + 3 * ATTRIB_KK), 5);
 
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x914),
+								(char*)get_ttx(581),
 								(char*)Real2Host(hero) + HERO_NAME2,
 								(char*)Real2Host(GUI_get_ptr(host_readbs(Real2Host(hero) + HERO_SEX), 0)));
 
@@ -422,7 +422,7 @@ void disease_effect(void)
 				}
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x918),
+					(char*)get_ttx(582),
 					(char*)Real2Host(hero) + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -443,7 +443,7 @@ void disease_effect(void)
 					j = 1;
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x91c),
+						(char*)get_ttx(583),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -466,7 +466,7 @@ void disease_effect(void)
 				if (j == 0) {
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xb90),
+						(char*)get_ttx(740),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -482,7 +482,7 @@ void disease_effect(void)
 				} else {
 					if (!host_readbs(disease_ptr + 2)) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f4),
+							(char*)get_ttx(573),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -493,7 +493,7 @@ void disease_effect(void)
 
 					if (!host_readbs(disease_ptr + 3)) {
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x908),
+							(char*)get_ttx(578),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -544,7 +544,7 @@ void disease_effect(void)
 					} else {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f0),
+							(char*)get_ttx(572),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -562,7 +562,7 @@ void disease_effect(void)
 
 				} else {
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x8f4),
+						(char*)get_ttx(573),
 						(char*)Real2Host(hero) + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));

--- a/src/custom/schick/rewrite_m302de/seg120.cpp
+++ b/src/custom/schick/rewrite_m302de/seg120.cpp
@@ -75,17 +75,17 @@ void rabies(RealPt hero, signed short hero_pos)
 		if (count_heroes_available_in_group() > 1) {
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xb94),
+				(char*)get_ttx(741),
 				(char*)Real2Host(hero) + HERO_NAME2,
 				(char*)Real2Host(GUI_get_ptr(host_readbs(Real2Host(hero) + HERO_SEX), 2)),
 				(char*)Real2Host(GUI_get_ptr(host_readbs(Real2Host(hero) + HERO_SEX), 2)));
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)) + 500,
-				(char*)get_ttx(0xb98),
+				(char*)get_ttx(742),
 				(char*)Real2Host(hero) + HERO_NAME2);
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)) + 600,
-				(char*)get_ttx(0xb9c),
+				(char*)get_ttx(743),
 				(char*)Real2Host(hero) + HERO_NAME2);
 
 			textbox_width_bak = ds_readws(TEXTBOX_WIDTH);
@@ -97,7 +97,7 @@ void rabies(RealPt hero, signed short hero_pos)
 						3,
 						Real2Host(ds_readd(DTP2)) + 500,
 						Real2Host(ds_readd(DTP2)) + 600,
-						get_ttx(0xba0));
+						get_ttx(744));
 
 			ds_writew(TEXTBOX_WIDTH, textbox_width_bak);
 
@@ -107,14 +107,14 @@ void rabies(RealPt hero, signed short hero_pos)
 				sub_hero_le(Real2Host(hero), host_readws(Real2Host(hero) + HERO_LE) / 2);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xba4),
+					(char*)get_ttx(745),
 					(char*)Real2Host(hero) + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
 
 				ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-				answer = select_hero_ok(get_ttx(0x62c));
+				answer = select_hero_ok(get_ttx(395));
 
 				if (answer != -1) {
 
@@ -134,14 +134,14 @@ void rabies(RealPt hero, signed short hero_pos)
 					{
 						done = 1;
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xba8),
+							(char*)get_ttx(746),
 							(char*)Real2Host(hero) + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
 
 						ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-						answer = select_hero_ok(get_ttx(0x62c));
+						answer = select_hero_ok(get_ttx(395));
 
 						if (answer != -1) {
 							skill_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
@@ -154,7 +154,7 @@ void rabies(RealPt hero, signed short hero_pos)
 
 				ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-				answer = select_hero_ok(get_ttx(0x354));
+				answer = select_hero_ok(get_ttx(213));
 
 				if (answer != -1) {
 
@@ -174,14 +174,14 @@ void rabies(RealPt hero, signed short hero_pos)
 								sub_ae_splash(hero2, 15);
 
 								sprintf((char*)Real2Host(ds_readd(DTP2)),
-									(char*)get_ttx(0xba8),
+									(char*)get_ttx(746),
 									(char*)Real2Host(hero) + HERO_NAME2);
 
 								GUI_output(Real2Host(ds_readd(DTP2)));
 
 								ds_writeb(HERO_SEL_EXCLUDE, (signed char)hero_pos);
 
-								answer = select_hero_ok(get_ttx(0x62c));
+								answer = select_hero_ok(get_ttx(395));
 
 								if ((answer != -1) && (answer != hero_pos)) {
 									skill_cure_disease(get_hero(answer), Real2Host(hero), 10, 1);
@@ -189,7 +189,7 @@ void rabies(RealPt hero, signed short hero_pos)
 							}
 						} else {
 							sprintf((char*)Real2Host(ds_readd(DTP2)),
-								(char*)get_ttx(0x97c),
+								(char*)get_ttx(607),
 								(char*)hero2 + HERO_NAME2);
 
 							GUI_output(Real2Host(ds_readd(DTP2)));
@@ -202,7 +202,7 @@ void rabies(RealPt hero, signed short hero_pos)
 			/* Hero has rabies / Tollwut */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xbac),
+				(char*)get_ttx(747),
 				(char*)Real2Host(hero) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));
@@ -227,7 +227,7 @@ void rabies(RealPt hero, signed short hero_pos)
 			/* hero has berserker fury / Berserkerwut */
 
 			sprintf((char*)Real2Host(ds_readd(DTP2)),
-				(char*)get_ttx(0xc5c),
+				(char*)get_ttx(791),
 				(char*)Real2Host(hero) + HERO_NAME2);
 
 			GUI_output(Real2Host(ds_readd(DTP2)));

--- a/src/custom/schick/rewrite_m302de/seg121.cpp
+++ b/src/custom/schick/rewrite_m302de/seg121.cpp
@@ -45,7 +45,7 @@ void poison_effect(void)
 					if (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) != 0) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f0),
+							(char*)get_ttx(572),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -58,7 +58,7 @@ void poison_effect(void)
 					if (host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_GE)) != 0) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xb4),
+							(char*)get_ttx(45),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -88,7 +88,7 @@ void poison_effect(void)
 				if ((host_readbs(poison_ptr + 2) != 0) && (!host_readbs(poison_ptr + 1) % 12 )) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x8f4),
+							(char*)get_ttx(573),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -100,7 +100,7 @@ void poison_effect(void)
 				if ((host_readbs(poison_ptr + 3) != 0) && (!host_readbs(poison_ptr + 1) % 12 )) {
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0x908),
+							(char*)get_ttx(578),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));
@@ -133,7 +133,7 @@ void poison_effect(void)
 					host_writebs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK), host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) - 2);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x94),
+						(char*)get_ttx(37),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -166,7 +166,7 @@ void poison_effect(void)
 				host_writebs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK), host_readbs(hero + (HERO_ATTRIB + 3 * ATTRIB_KK)) + 2);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0x98),
+					(char*)get_ttx(38),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -193,7 +193,7 @@ void poison_effect(void)
 					or_ptr_bs(hero + HERO_STATUS2, 1);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0x9c),
+						(char*)get_ttx(39),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -224,7 +224,7 @@ void poison_effect(void)
 					and_ptr_bs(hero + HERO_STATUS2, 0xfe);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xa0),
+						(char*)get_ttx(40),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -242,7 +242,7 @@ void poison_effect(void)
 					or_ptr_bs(hero + HERO_STATUS1, 0x02);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xa4),
+						(char*)get_ttx(41),
 						(char*)hero + HERO_NAME2);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -263,7 +263,7 @@ void poison_effect(void)
 				and_ptr_bs(hero + HERO_STATUS1, 0xfd);
 
 				sprintf((char*)Real2Host(ds_readd(DTP2)),
-					(char*)get_ttx(0xa8),
+					(char*)get_ttx(42),
 					(char*)hero + HERO_NAME2);
 
 				GUI_output(Real2Host(ds_readd(DTP2)));
@@ -361,7 +361,7 @@ void poison_effect(void)
 					sub_ptr_ws(hero + HERO_AE, j);
 
 					sprintf((char*)Real2Host(ds_readd(DTP2)),
-						(char*)get_ttx(0xac),
+						(char*)get_ttx(43),
 						(char*)hero + HERO_NAME2, j);
 
 					GUI_output(Real2Host(ds_readd(DTP2)));
@@ -380,7 +380,7 @@ void poison_effect(void)
 						inc_ptr_ws(hero + HERO_AE);
 
 						sprintf((char*)Real2Host(ds_readd(DTP2)),
-							(char*)get_ttx(0xb0),
+							(char*)get_ttx(44),
 							(char*)hero + HERO_NAME2);
 
 						GUI_output(Real2Host(ds_readd(DTP2)));

--- a/src/custom/schick/rewrite_m302de/v302de.h
+++ b/src/custom/schick/rewrite_m302de/v302de.h
@@ -872,15 +872,18 @@ static inline Bit8u *get_monname(unsigned short off)
 	return Real2Host(host_readd(Real2Host(ds_readd(MONNAMES_INDEX) + off * 4)));
 }
 
-static inline Bit8u *get_tx2(unsigned short off) {
+#define get_tx2(no) get_tx2_func(4*(no))
+static inline Bit8u *get_tx2_func(unsigned short off) {
 	return Real2Host(host_readd(Real2Host(ds_readd(TX2_INDEX) + off)));
 }
 
-static inline Bit8u *get_ttx(unsigned short off) {
+#define get_ttx(no) get_ttx_func(4*(no))
+static inline Bit8u *get_ttx_func(unsigned short off) {
 	return Real2Host(host_readd(Real2Host(ds_readd(TEXT_LTX_INDEX) + off)));
 }
 
-static inline Bit8u *get_tx(unsigned short off) {
+#define get_tx(no) get_tx_func(4*(no))
+static inline Bit8u *get_tx_func(unsigned short off) {
 	return Real2Host(host_readd(Real2Host(ds_readd(TX_INDEX) + off)));
 }
 
@@ -1172,9 +1175,9 @@ struct bittest {
 
 #define get_itemuser() ((Bit8u*)ds_readfp(ITEMUSER))
 
-#define get_ttx(nr) (char*)(host_readd(ds_readfp(TEXT_LTX_INDEX) + (nr)))
-#define get_tx(nr) (char*)(host_readd(ds_readfp(TX_INDEX) + (nr)))
-#define get_tx2(nr) (char*)(host_readd(ds_readfp(TX2_INDEX) + (nr)))
+#define get_ttx(nr) (char*)(host_readd(ds_readfp(TEXT_LTX_INDEX) + 4 * (nr)))
+#define get_tx(nr) (char*)(host_readd(ds_readfp(TX_INDEX) + 4 * (nr)))
+#define get_tx2(nr) (char*)(host_readd(ds_readfp(TX2_INDEX) + 4 * (nr)))
 #define get_monname(nr) ((char*)(host_readd(ds_readfp(MONNAMES_INDEX) + 4 * (nr))))
 #define get_itemsdat(nr) ((char*)(ds_readfp(ITEMSDAT) + 12 * (nr)))
 #define get_itemname(nr) ((char*)(host_readd(ds_readfp(ITEMSNAME) + 4 * (nr))))


### PR DESCRIPTION
Instead of giving the offset of a string in the text indices TX_INDEX etc. it makes sense to provide the number of the string instead, which means dividing all the numbers in get_tx(...) etc. by 4. That's what this commit does.