### PR TITLE
VC2017: Add buildfiles and small fix (in Dosbox) for VS2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ autom4te.cache
 aclocal.m4
 lastbuild.log
 src/dosbox
+/visualc_2017/Debug
+/visualc_2017/Release

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -39,7 +39,7 @@ static struct {
 static char string_oem[]="S3 Incorporated. Trio64";
 static char string_vendorname[]="DOSBox Development Team";
 static char string_productname[]="DOSBox - The DOS Emulator";
-static char string_productrev[]="DOSBox "VERSION;
+static char string_productrev[]="DOSBox " VERSION;
 
 #ifdef _MSC_VER
 #pragma pack (1)

--- a/visualc_2017/dosbox.sln
+++ b/visualc_2017/dosbox.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dosbox", "dosbox.vcxproj", "{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Debug|Win32.Build.0 = Debug|Win32
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Release|Win32.ActiveCfg = Release|Win32
+		{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D9819667-9685-43CC-A16D-728466D0F76D}
+	EndGlobalSection
+EndGlobal

--- a/visualc_2017/dosbox.vcxproj
+++ b/visualc_2017/dosbox.vcxproj
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7FCFFB9B-8629-4D51-849C-8490CECF8AB7}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>15.0.26730.12</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>.\Debug\</OutDir>
+    <IntDir>.\Debug\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>.\Release\</OutDir>
+    <IntDir>.\Release\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/dosbox.tlb</TypeLibraryName>
+      <HeaderFileName />
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../include;../src/platform/visualc;../src/custom/schick;../src/custom/schick/rewrite_m302de;../src/custom/schweif;../src/custom/schweif/rewrite_c102de;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeaderOutputFile>.\Debug/dosbox.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;sdlmain.lib;sdl.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>.\Debug/dosbox.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreSpecificDefaultLibraries>msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/dosbox.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/dosbox.tlb</TypeLibraryName>
+      <HeaderFileName />
+    </Midl>
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalIncludeDirectories>../include;../src/platform/visualc;../src/custom/schick;../src/custom/schick/rewrite_m302de;../src/custom/schweif;../src/custom/schweif/rewrite_c102de;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeaderOutputFile>.\Release/dosbox.pch</PrecompiledHeaderOutputFile>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;sdlmain.lib;sdl.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>.\Release/dosbox.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <SubSystem>Console</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <FixedBaseAddress>false</FixedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\cpu\callback.cpp" />
+    <ClCompile Include="..\src\cpu\core_dynrec.cpp" />
+    <ClCompile Include="..\src\cpu\core_dyn_x86.cpp" />
+    <ClCompile Include="..\src\cpu\core_full.cpp" />
+    <ClCompile Include="..\src\cpu\core_normal.cpp" />
+    <ClCompile Include="..\src\cpu\core_prefetch.cpp" />
+    <ClCompile Include="..\src\cpu\core_simple.cpp" />
+    <ClCompile Include="..\src\cpu\cpu.cpp" />
+    <ClCompile Include="..\src\cpu\flags.cpp" />
+    <ClCompile Include="..\src\cpu\modrm.cpp" />
+    <ClCompile Include="..\src\cpu\paging.cpp" />
+    <ClCompile Include="..\src\custom\custom.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg000.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg001.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg002.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg003.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg004.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg005.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg006.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\datseg.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg000.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg001.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg002.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg003.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg004.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg005.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg006.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg007.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg008.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg009.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg010.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg011.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg024.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg025.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg026.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg027.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg028.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg029.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg030.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg031.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg032.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg033.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg034.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg035.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg036.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg037.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg038.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg039.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg040.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg041.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg042.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg043.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg044.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg045.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg046.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg047.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg048.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg049.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg050.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg051.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg052.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg053.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg054.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg055.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg056.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg057.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg058.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg059.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg060.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg061.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg062.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg063.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg064.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg065.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg066.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg067.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg068.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg069.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg070.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg071.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg072.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg073.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg074.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg075.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg076.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg077.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg078.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg079.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg080.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg081.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg082.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg083.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg084.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg085.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg086.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg087.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg088.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg089.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg090.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg091.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg092.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg093.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg094.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg095.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg096.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg097.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg098.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg099.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg100.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg101.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg102.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg103.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg104.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg105.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg106.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg107.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg108.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg109.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg110.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg111.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg112.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg113.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg114.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg115.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg116.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg117.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg118.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg119.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg120.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg121.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg122.cpp" />
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\t_map.cpp" />
+    <ClCompile Include="..\src\custom\schick\schick.cpp" />
+    <ClCompile Include="..\src\custom\schick\schick_g105de.cpp" />
+    <ClCompile Include="..\src\custom\schick\schick_m302de.cpp" />
+    <ClCompile Include="..\src\custom\schick\schick_status.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg000.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg002.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg013.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg024.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg029.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg033.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg034.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg037.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg043.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg066.cpp" />
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg136.cpp" />
+    <ClCompile Include="..\src\custom\schweif\schweif.cpp" />
+    <ClCompile Include="..\src\custom\schweif\schweif_c102de.cpp" />
+    <ClCompile Include="..\src\debug\debug.cpp" />
+    <ClCompile Include="..\src\debug\debug_disasm.cpp" />
+    <ClCompile Include="..\src\debug\debug_gui.cpp" />
+    <ClCompile Include="..\src\debug\debug_win32.cpp" />
+    <ClCompile Include="..\src\dosbox.cpp" />
+    <ClCompile Include="..\src\dos\cdrom.cpp" />
+    <ClCompile Include="..\src\dos\cdrom_aspi_win32.cpp" />
+    <ClCompile Include="..\src\dos\cdrom_image.cpp" />
+    <ClCompile Include="..\src\dos\cdrom_ioctl_win32.cpp" />
+    <ClCompile Include="..\src\dos\dos.cpp" />
+    <ClCompile Include="..\src\dos\dos_classes.cpp" />
+    <ClCompile Include="..\src\dos\dos_devices.cpp" />
+    <ClCompile Include="..\src\dos\dos_execute.cpp" />
+    <ClCompile Include="..\src\dos\dos_files.cpp" />
+    <ClCompile Include="..\src\dos\dos_ioctl.cpp" />
+    <ClCompile Include="..\src\dos\dos_keyboard_layout.cpp" />
+    <ClCompile Include="..\src\dos\dos_memory.cpp" />
+    <ClCompile Include="..\src\dos\dos_misc.cpp" />
+    <ClCompile Include="..\src\dos\dos_mscdex.cpp" />
+    <ClCompile Include="..\src\dos\dos_programs.cpp" />
+    <ClCompile Include="..\src\dos\dos_tables.cpp" />
+    <ClCompile Include="..\src\dos\drives.cpp" />
+    <ClCompile Include="..\src\dos\drive_cache.cpp" />
+    <ClCompile Include="..\src\dos\drive_fat.cpp" />
+    <ClCompile Include="..\src\dos\drive_iso.cpp" />
+    <ClCompile Include="..\src\dos\drive_local.cpp" />
+    <ClCompile Include="..\src\dos\drive_virtual.cpp" />
+    <ClCompile Include="..\src\fpu\fpu.cpp" />
+    <ClCompile Include="..\src\gui\midi.cpp" />
+    <ClCompile Include="..\src\gui\render.cpp" />
+    <ClCompile Include="..\src\gui\render_scalers.cpp" />
+    <ClCompile Include="..\src\gui\sdlmain.cpp" />
+    <ClCompile Include="..\src\gui\sdl_gui.cpp" />
+    <ClCompile Include="..\src\gui\sdl_mapper.cpp" />
+    <ClCompile Include="..\src\hardware\adlib.cpp" />
+    <ClCompile Include="..\src\hardware\cmos.cpp" />
+    <ClCompile Include="..\src\hardware\dbopl.cpp" />
+    <ClCompile Include="..\src\hardware\disney.cpp" />
+    <ClCompile Include="..\src\hardware\dma.cpp" />
+    <ClCompile Include="..\src\hardware\gameblaster.cpp" />
+    <ClCompile Include="..\src\hardware\gus.cpp" />
+    <ClCompile Include="..\src\hardware\hardware.cpp" />
+    <ClCompile Include="..\src\hardware\iohandler.cpp" />
+    <ClCompile Include="..\src\hardware\ipx.cpp" />
+    <ClCompile Include="..\src\hardware\ipxserver.cpp" />
+    <ClCompile Include="..\src\hardware\joystick.cpp" />
+    <ClCompile Include="..\src\hardware\keyboard.cpp" />
+    <ClCompile Include="..\src\hardware\memory.cpp" />
+    <ClCompile Include="..\src\hardware\mixer.cpp" />
+    <ClCompile Include="..\src\hardware\mpu401.cpp" />
+    <ClCompile Include="..\src\hardware\pcspeaker.cpp" />
+    <ClCompile Include="..\src\hardware\pic.cpp" />
+    <ClCompile Include="..\src\hardware\sblaster.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\directserial.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\libserial.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\misc_util.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\nullmodem.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\serialdummy.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\serialport.cpp" />
+    <ClCompile Include="..\src\hardware\serialport\softmodem.cpp" />
+    <ClCompile Include="..\src\hardware\tandy_sound.cpp" />
+    <ClCompile Include="..\src\hardware\timer.cpp" />
+    <ClCompile Include="..\src\hardware\vga.cpp" />
+    <ClCompile Include="..\src\hardware\vga_attr.cpp" />
+    <ClCompile Include="..\src\hardware\vga_crtc.cpp" />
+    <ClCompile Include="..\src\hardware\vga_dac.cpp" />
+    <ClCompile Include="..\src\hardware\vga_draw.cpp" />
+    <ClCompile Include="..\src\hardware\vga_gfx.cpp" />
+    <ClCompile Include="..\src\hardware\vga_memory.cpp" />
+    <ClCompile Include="..\src\hardware\vga_misc.cpp" />
+    <ClCompile Include="..\src\hardware\vga_other.cpp" />
+    <ClCompile Include="..\src\hardware\vga_paradise.cpp" />
+    <ClCompile Include="..\src\hardware\vga_s3.cpp" />
+    <ClCompile Include="..\src\hardware\vga_seq.cpp" />
+    <ClCompile Include="..\src\hardware\vga_tseng.cpp" />
+    <ClCompile Include="..\src\hardware\vga_xga.cpp" />
+    <ClCompile Include="..\src\ints\bios.cpp" />
+    <ClCompile Include="..\src\ints\bios_disk.cpp" />
+    <ClCompile Include="..\src\ints\bios_keyboard.cpp" />
+    <ClCompile Include="..\src\ints\ems.cpp" />
+    <ClCompile Include="..\src\ints\int10.cpp" />
+    <ClCompile Include="..\src\ints\int10_char.cpp" />
+    <ClCompile Include="..\src\ints\int10_memory.cpp" />
+    <ClCompile Include="..\src\ints\int10_misc.cpp" />
+    <ClCompile Include="..\src\ints\int10_modes.cpp" />
+    <ClCompile Include="..\src\ints\int10_pal.cpp" />
+    <ClCompile Include="..\src\ints\int10_put_pixel.cpp" />
+    <ClCompile Include="..\src\ints\int10_vesa.cpp" />
+    <ClCompile Include="..\src\ints\int10_video_state.cpp" />
+    <ClCompile Include="..\src\ints\int10_vptable.cpp" />
+    <ClCompile Include="..\src\ints\mouse.cpp" />
+    <ClCompile Include="..\src\ints\xms.cpp" />
+    <ClCompile Include="..\src\libs\gui_tk\gui_tk.cpp" />
+    <ClCompile Include="..\src\misc\cross.cpp" />
+    <ClCompile Include="..\src\misc\messages.cpp" />
+    <ClCompile Include="..\src\misc\programs.cpp" />
+    <ClCompile Include="..\src\misc\setup.cpp" />
+    <ClCompile Include="..\src\misc\support.cpp" />
+    <ClCompile Include="..\src\shell\shell.cpp" />
+    <ClCompile Include="..\src\shell\shell_batch.cpp" />
+    <ClCompile Include="..\src\shell\shell_cmds.cpp" />
+    <ClCompile Include="..\src\shell\shell_misc.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\src\winres.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\bios.h" />
+    <ClInclude Include="..\include\bios_disk.h" />
+    <ClInclude Include="..\include\callback.h" />
+    <ClInclude Include="..\include\control.h" />
+    <ClInclude Include="..\include\cpu.h" />
+    <ClInclude Include="..\include\cross.h" />
+    <ClInclude Include="..\include\custom.h" />
+    <ClInclude Include="..\include\debug.h" />
+    <ClInclude Include="..\include\dma.h" />
+    <ClInclude Include="..\include\dosbox.h" />
+    <ClInclude Include="..\include\dos_inc.h" />
+    <ClInclude Include="..\include\dos_system.h" />
+    <ClInclude Include="..\include\fpu.h" />
+    <ClInclude Include="..\include\hardware.h" />
+    <ClInclude Include="..\include\inout.h" />
+    <ClInclude Include="..\include\joystick.h" />
+    <ClInclude Include="..\include\keyboard.h" />
+    <ClInclude Include="..\include\logging.h" />
+    <ClInclude Include="..\include\mem.h" />
+    <ClInclude Include="..\include\mixer.h" />
+    <ClInclude Include="..\include\modules.h" />
+    <ClInclude Include="..\include\mouse.h" />
+    <ClInclude Include="..\include\paging.h" />
+    <ClInclude Include="..\include\pic.h" />
+    <ClInclude Include="..\include\programs.h" />
+    <ClInclude Include="..\include\regs.h" />
+    <ClInclude Include="..\include\render.h" />
+    <ClInclude Include="..\include\serialport.h" />
+    <ClInclude Include="..\include\setup.h" />
+    <ClInclude Include="..\include\shell.h" />
+    <ClInclude Include="..\include\support.h" />
+    <ClInclude Include="..\include\timer.h" />
+    <ClInclude Include="..\include\vga.h" />
+    <ClInclude Include="..\include\video.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\cache.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder_basic.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder_opcodes.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\dyn_fpu.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\operators.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\risc_x64.h" />
+    <ClInclude Include="..\src\cpu\core_dynrec\risc_x86.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\cache.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\decoder.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu_dh.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\helpers.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x86.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\string.h" />
+    <ClInclude Include="..\src\cpu\core_full\ea_lookup.h" />
+    <ClInclude Include="..\src\cpu\core_full\load.h" />
+    <ClInclude Include="..\src\cpu\core_full\loadwrite.h" />
+    <ClInclude Include="..\src\cpu\core_full\op.h" />
+    <ClInclude Include="..\src\cpu\core_full\optable.h" />
+    <ClInclude Include="..\src\cpu\core_full\save.h" />
+    <ClInclude Include="..\src\cpu\core_full\string.h" />
+    <ClInclude Include="..\src\cpu\core_full\support.h" />
+    <ClInclude Include="..\src\cpu\core_normal\helpers.h" />
+    <ClInclude Include="..\src\cpu\core_normal\prefix_0f.h" />
+    <ClInclude Include="..\src\cpu\core_normal\prefix_66.h" />
+    <ClInclude Include="..\src\cpu\core_normal\prefix_66_0f.h" />
+    <ClInclude Include="..\src\cpu\core_normal\prefix_none.h" />
+    <ClInclude Include="..\src\cpu\core_normal\string.h" />
+    <ClInclude Include="..\src\cpu\core_normal\support.h" />
+    <ClInclude Include="..\src\cpu\core_normal\table_ea.h" />
+    <ClInclude Include="..\src\cpu\instructions.h" />
+    <ClInclude Include="..\src\cpu\lazyflags.h" />
+    <ClInclude Include="..\src\cpu\modrm.h" />
+    <ClInclude Include="..\src\custom\custom_hooks.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg000.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg001.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg003.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg004.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg005.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg006.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\port.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\common.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\dagseg.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg000.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg001.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg002.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg003.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg004.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg005.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg006.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg007.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg008.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg009.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg010.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg011.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg024.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg025.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg026.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg027.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg028.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg029.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg030.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg031.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg032.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg033.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg034.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg035.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg036.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg037.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg038.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg039.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg040.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg041.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg042.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg043.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg044.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg045.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg046.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg047.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg048.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg049.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg050.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg051.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg052.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg053.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg054.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg055.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg056.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg057.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg058.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg059.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg060.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg061.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg062.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg063.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg064.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg065.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg066.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg067.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg068.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg069.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg070.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg071.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg072.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg073.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg074.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg075.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg076.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg077.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg078.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg079.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg080.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg081.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg082.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg083.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg084.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg085.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg086.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg087.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg088.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg089.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg090.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg091.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg092.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg093.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg094.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg095.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg096.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg097.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg098.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg099.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg100.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg101.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg102.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg103.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg104.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg105.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg106.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg107.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg108.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg109.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg110.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg111.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg112.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg113.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg114.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg115.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg116.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg117.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg118.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg119.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg120.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg121.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg122.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\symbols.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\t_map.h" />
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\v302de.h" />
+    <ClInclude Include="..\src\custom\schick\schick.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg000.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg002.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg013.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg024.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg029.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg033.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg034.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg037.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg043.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg066.h" />
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg136.h" />
+    <ClInclude Include="..\src\custom\schweif\schweif.h" />
+    <ClInclude Include="..\src\debug\debug_inc.h" />
+    <ClInclude Include="..\src\debug\disasm_tables.h" />
+    <ClInclude Include="..\src\dos\cdrom.h" />
+    <ClInclude Include="..\src\dos\dev_con.h" />
+    <ClInclude Include="..\src\dos\drives.h" />
+    <ClInclude Include="..\src\dos\Ntddcdrm.h" />
+    <ClInclude Include="..\src\dos\Ntddscsi.h" />
+    <ClInclude Include="..\src\dos\Ntddstor.h" />
+    <ClInclude Include="..\src\dos\scsidefs.h" />
+    <ClInclude Include="..\src\dos\wnaspi32.h" />
+    <ClInclude Include="..\src\fpu\fpu_instructions.h" />
+    <ClInclude Include="..\src\fpu\fpu_instructions_x86.h" />
+    <ClInclude Include="..\src\gui\midi_win32.h" />
+    <ClInclude Include="..\src\gui\render_scalers.h" />
+    <ClInclude Include="..\src\gui\render_templates.h" />
+    <ClInclude Include="..\src\hardware\font-switch.h" />
+    <ClInclude Include="..\src\hardware\serialport\directserial.h" />
+    <ClInclude Include="..\src\hardware\serialport\libserial.h" />
+    <ClInclude Include="..\src\hardware\serialport\misc_util.h" />
+    <ClInclude Include="..\src\hardware\serialport\nullmodem.h" />
+    <ClInclude Include="..\src\hardware\serialport\serialdummy.h" />
+    <ClInclude Include="..\src\hardware\serialport\softmodem.h" />
+    <ClInclude Include="..\src\ints\int10.h" />
+    <ClInclude Include="..\src\ints\xms.h" />
+    <ClInclude Include="..\src\platform\visualc\config.h" />
+    <ClInclude Include="..\src\platform\visualc\unistd.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\src\dosbox.ico" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/visualc_2017/dosbox.vcxproj.filters
+++ b/visualc_2017/dosbox.vcxproj.filters
@@ -1,0 +1,1552 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{fdda9e2c-675c-4aa6-8c96-7ae2376816bb}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
+    </Filter>
+    <Filter Include="Source Files\cpu">
+      <UniqueIdentifier>{b5afa923-f4ae-428f-8a34-239c9e79e90e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cpu\core_normal">
+      <UniqueIdentifier>{5b5d3ab8-2dd8-45ef-90a3-040640a93698}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cpu\core_full">
+      <UniqueIdentifier>{936004c9-0c9a-47a5-899a-664fe823cd4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cpu\core_dyn_x86">
+      <UniqueIdentifier>{707450f5-074e-47aa-b061-e7c1e28509ea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cpu\core_dynrec">
+      <UniqueIdentifier>{220cd3cd-c840-43a0-94ee-5efaee01c5ab}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\debug">
+      <UniqueIdentifier>{0b8d55bc-2b5e-4a08-8662-76aa6a5adb94}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dos">
+      <UniqueIdentifier>{02e0cc41-03ee-4c82-9796-f5e57ab78289}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dos\win32headers">
+      <UniqueIdentifier>{6e9083fd-2539-4c1d-bbd9-1344032dea94}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dos\cdrom">
+      <UniqueIdentifier>{f7897f41-1f3c-43a3-b99b-b113900311a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dos\drives">
+      <UniqueIdentifier>{12be4f46-f129-4ae4-8f6c-ce9d2626a17c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\hardware">
+      <UniqueIdentifier>{7e25cfa6-6dac-48a1-90d8-f0b4dab28b63}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\hardware\vga">
+      <UniqueIdentifier>{f6823069-307c-407d-acc3-f93c76c210fb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\hardware\sound">
+      <UniqueIdentifier>{bfff972c-adc3-4c4d-9568-626b2d1075b1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\hardware\serialport">
+      <UniqueIdentifier>{1a2c53ec-8575-46bc-849a-5721a09fc113}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\gui">
+      <UniqueIdentifier>{202e2973-01ef-4403-8ef4-8cd3f78f5659}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ints">
+      <UniqueIdentifier>{b45418ff-e2b7-4e0d-8461-03f4641306b3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ints\int10">
+      <UniqueIdentifier>{afe662f5-53e8-4e2c-bb34-23f5125eb8f0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\shell">
+      <UniqueIdentifier>{563a6020-91fc-4bbc-932a-d17c63625cf7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\misc">
+      <UniqueIdentifier>{f08f23d0-0a5d-49b4-bc2b-a3ac76faa682}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\visualc">
+      <UniqueIdentifier>{7efbb86a-0a9a-47a5-b3e2-267d24da7f34}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\fpu">
+      <UniqueIdentifier>{e64146e0-61e2-4c39-9602-45552d2718ae}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom">
+      <UniqueIdentifier>{532ea538-5e40-4be6-8814-4646bc455869}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom\schick">
+      <UniqueIdentifier>{2730282a-109f-4d65-850c-39cc1efb2ee0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom\schick\schick_rewrite_g105de">
+      <UniqueIdentifier>{fd62fae9-8fef-410c-ae9f-a091853d30d4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom\schick\schick_rewrite_m302de">
+      <UniqueIdentifier>{79a45d97-5122-460b-b629-2e28a8d061fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom\schweif">
+      <UniqueIdentifier>{cc73f4e8-2df3-4a1a-b9cf-29f40e172468}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\custom\schweif\schweif_rewrite_c102de">
+      <UniqueIdentifier>{e2383a4c-8ae8-45ae-9857-66e77a2adebb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{451704c0-f487-4598-a99b-fe6b09476bab}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\dosbox.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\callback.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_dyn_x86.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_dynrec.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_full.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_normal.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_prefetch.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\core_simple.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\cpu.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\flags.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\modrm.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cpu\paging.cpp">
+      <Filter>Source Files\cpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\debug\debug.cpp">
+      <Filter>Source Files\debug</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\debug\debug_disasm.cpp">
+      <Filter>Source Files\debug</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\debug\debug_gui.cpp">
+      <Filter>Source Files\debug</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\debug\debug_win32.cpp">
+      <Filter>Source Files\debug</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_classes.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_devices.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_execute.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_files.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_ioctl.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_keyboard_layout.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_memory.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_misc.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_mscdex.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_programs.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\dos_tables.cpp">
+      <Filter>Source Files\dos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\cdrom.cpp">
+      <Filter>Source Files\dos\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\cdrom_aspi_win32.cpp">
+      <Filter>Source Files\dos\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\cdrom_image.cpp">
+      <Filter>Source Files\dos\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\cdrom_ioctl_win32.cpp">
+      <Filter>Source Files\dos\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drive_cache.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drive_fat.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drive_iso.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drive_local.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drive_virtual.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dos\drives.cpp">
+      <Filter>Source Files\dos\drives</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\cmos.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\dma.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\hardware.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\iohandler.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\ipx.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\ipxserver.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\joystick.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\keyboard.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\memory.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\mixer.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\pic.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\timer.cpp">
+      <Filter>Source Files\hardware</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_attr.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_crtc.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_dac.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_draw.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_gfx.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_memory.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_misc.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_other.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_paradise.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_s3.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_seq.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_tseng.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\vga_xga.cpp">
+      <Filter>Source Files\hardware\vga</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\adlib.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\dbopl.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\disney.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\gameblaster.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\gus.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\mpu401.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\pcspeaker.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\sblaster.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\tandy_sound.cpp">
+      <Filter>Source Files\hardware\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\directserial.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\libserial.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\misc_util.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\nullmodem.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\serialdummy.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\serialport.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\serialport\softmodem.cpp">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\libs\gui_tk\gui_tk.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\midi.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\render.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\render_scalers.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\sdl_gui.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\sdl_mapper.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\gui\sdlmain.cpp">
+      <Filter>Source Files\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\bios.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\bios_disk.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\bios_keyboard.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\ems.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\mouse.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\xms.cpp">
+      <Filter>Source Files\ints</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_char.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_memory.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_misc.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_modes.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_pal.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_put_pixel.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_vesa.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_video_state.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ints\int10_vptable.cpp">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\shell\shell.cpp">
+      <Filter>Source Files\shell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\shell\shell_batch.cpp">
+      <Filter>Source Files\shell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\shell\shell_cmds.cpp">
+      <Filter>Source Files\shell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\shell\shell_misc.cpp">
+      <Filter>Source Files\shell</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\cross.cpp">
+      <Filter>Source Files\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\messages.cpp">
+      <Filter>Source Files\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\programs.cpp">
+      <Filter>Source Files\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\setup.cpp">
+      <Filter>Source Files\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\misc\support.cpp">
+      <Filter>Source Files\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\fpu\fpu.cpp">
+      <Filter>Source Files\fpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\custom.cpp">
+      <Filter>Source Files\custom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\schick.cpp">
+      <Filter>Source Files\custom\schick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\schick_g105de.cpp">
+      <Filter>Source Files\custom\schick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\schick_m302de.cpp">
+      <Filter>Source Files\custom\schick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\schick_status.cpp">
+      <Filter>Source Files\custom\schick</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg000.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg001.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg002.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg003.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg004.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg005.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_g105de\g105de_seg006.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg000.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg001.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg002.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg003.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg004.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg005.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg006.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg007.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg008.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg009.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg010.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg011.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg024.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg025.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg026.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg027.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg028.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg029.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg030.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg031.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg032.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg033.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg034.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg035.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg036.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg037.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg038.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg039.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg040.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg041.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg042.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg043.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg044.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg045.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg046.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg047.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg048.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg049.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg050.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg051.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg052.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg053.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg054.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg055.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg056.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg057.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg058.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg059.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg060.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg061.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg062.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg063.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg064.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg065.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg066.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg067.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg068.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg069.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg070.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg071.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg072.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg073.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg074.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg075.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg076.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg077.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg078.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg079.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg080.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg081.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg082.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg083.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg084.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg085.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg086.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg087.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg088.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg089.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg090.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg091.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg092.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg093.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg094.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg095.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg096.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg097.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg098.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg099.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg100.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg101.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg102.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg103.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg104.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg105.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg106.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg107.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg108.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg109.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg110.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg111.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg112.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg113.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg114.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg115.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg116.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg117.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg118.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg119.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg120.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg121.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\seg122.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\t_map.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schick\rewrite_m302de\datseg.cpp">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\schweif.cpp">
+      <Filter>Source Files\custom\schweif</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\schweif_c102de.cpp">
+      <Filter>Source Files\custom\schweif</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg000.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg002.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg013.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg024.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg029.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg033.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg034.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg037.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg043.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg066.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\custom\schweif\rewrite_c102de\c102de_seg136.cpp">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\src\winres.rc">
+      <Filter>Source Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\cpu\instructions.h">
+      <Filter>Source Files\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\lazyflags.h">
+      <Filter>Source Files\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\modrm.h">
+      <Filter>Source Files\cpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\helpers.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\prefix_0f.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\prefix_66.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\prefix_66_0f.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\prefix_none.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\string.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\support.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_normal\table_ea.h">
+      <Filter>Source Files\cpu\core_normal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\ea_lookup.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\load.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\loadwrite.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\op.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\optable.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\save.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\string.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_full\support.h">
+      <Filter>Source Files\cpu\core_full</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\cache.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\decoder.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu_dh.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\helpers.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x86.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\string.h">
+      <Filter>Source Files\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\cache.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder_basic.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\decoder_opcodes.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\dyn_fpu.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\operators.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\risc_x64.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dynrec\risc_x86.h">
+      <Filter>Source Files\cpu\core_dynrec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\debug\debug_inc.h">
+      <Filter>Source Files\debug</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\debug\disasm_tables.h">
+      <Filter>Source Files\debug</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\dev_con.h">
+      <Filter>Source Files\dos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\drives.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\Ntddcdrm.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\Ntddscsi.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\Ntddstor.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\scsidefs.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\wnaspi32.h">
+      <Filter>Source Files\dos\win32headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\dos\cdrom.h">
+      <Filter>Source Files\dos\cdrom</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\font-switch.h">
+      <Filter>Source Files\hardware</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\directserial.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\libserial.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\misc_util.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\nullmodem.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\serialdummy.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\hardware\serialport\softmodem.h">
+      <Filter>Source Files\hardware\serialport</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\gui\midi_win32.h">
+      <Filter>Source Files\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\gui\render_scalers.h">
+      <Filter>Source Files\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\gui\render_templates.h">
+      <Filter>Source Files\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\ints\xms.h">
+      <Filter>Source Files\ints</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\ints\int10.h">
+      <Filter>Source Files\ints\int10</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\platform\visualc\config.h">
+      <Filter>Source Files\visualc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\platform\visualc\unistd.h">
+      <Filter>Source Files\visualc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\fpu\fpu_instructions.h">
+      <Filter>Source Files\fpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\fpu\fpu_instructions_x86.h">
+      <Filter>Source Files\fpu</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\custom_hooks.h">
+      <Filter>Source Files\custom</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\schick.h">
+      <Filter>Source Files\custom\schick</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\port.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg000.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg001.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg003.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg004.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg005.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_g105de\g105de_seg006.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_g105de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\common.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\v302de.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\symbols.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg000.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg001.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg002.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg003.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg004.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg005.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg006.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg007.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg008.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg009.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg010.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg011.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg024.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg025.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg026.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg027.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg028.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg029.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg030.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg031.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg033.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg032.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg035.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg034.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg036.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg037.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg038.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg039.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg040.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg043.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg042.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg041.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg044.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg045.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg046.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg047.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg048.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg049.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg052.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg051.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg050.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg062.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg061.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg060.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg059.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg058.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg057.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg056.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg055.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg054.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg053.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg063.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg065.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg064.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg067.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg066.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg071.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg070.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg069.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg068.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg072.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg073.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg074.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg075.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg091.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg090.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg089.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg088.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg087.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg086.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg085.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg084.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg083.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg082.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg081.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg080.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg079.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg078.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg077.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg076.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg094.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg093.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg092.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg095.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg096.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg097.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg098.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg099.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg100.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg101.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg102.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg103.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg104.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg105.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg106.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg107.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg108.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg110.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg109.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg112.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg111.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg116.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg115.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg114.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg113.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg118.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg117.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg119.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg120.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg121.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\seg122.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\t_map.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schick\rewrite_m302de\dagseg.h">
+      <Filter>Source Files\custom\schick\schick_rewrite_m302de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\schweif.h">
+      <Filter>Source Files\custom\schweif</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg000.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg002.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg013.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg024.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg029.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg033.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg034.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg037.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg043.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg066.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\custom\schweif\rewrite_c102de\c102de_seg136.h">
+      <Filter>Source Files\custom\schweif\schweif_rewrite_c102de</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\bios.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\bios_disk.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\callback.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\control.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\cpu.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\cross.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\custom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\debug.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\dma.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\dos_inc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\dos_system.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\dosbox.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\fpu.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\hardware.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\inout.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\joystick.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\keyboard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\logging.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\mem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\mixer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\modules.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\mouse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\paging.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\pic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\programs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\regs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\render.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\serialport.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\setup.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\shell.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\support.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\timer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vga.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\video.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\src\dosbox.ico" />
+  </ItemGroup>
+</Project>

--- a/visualc_2017/dosbox.vcxproj.user
+++ b/visualc_2017/dosbox.vcxproj.user
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommandArguments>c:\dosgames\DSA1\schick.bat -exit -conf dosboxDSA1.conf</LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>C:\dosgames</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerEnvironment>SDL_VIDEODRIVER=windib</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Hi,

I was successfully able to build Bright Eyes in Visual Studio 2017 with these project files. I hope they are helpful for others woking on Windows, but there are a few additional steps necessary for it to work: 

As far as I know, there are no precompiled SDL development libraries compatible with VS2017, so someone who wants to build Bright Eyes with VS2017 also needs to comile SDL and set the include and library paths.

There are also some settings for starting a debug session from within visual studio which may need to be adjusted (dosbox parameters and working directory). These settings also add an environment variable to the debugging session, which prevents systemwide input lag whenever a breakpoint is hit (`SDL_VIDEODRIVER=windib`).

The change in int10_vesa.cpp is necessary, because VS2017 will not compile this line without an error, if that space is missing.