### PR TITLE
G105de: Fix for crash, if player hits esc or right mouse button durin…

### DIFF
--- a/src/custom/schick/rewrite_g105de/g105de_seg002.cpp
+++ b/src/custom/schick/rewrite_g105de/g105de_seg002.cpp
@@ -4518,7 +4518,7 @@ void new_values()
 				type_names[6]);
 
 			ds_writew(0x1327, 0);
-		} while (di == -1);
+		} while (di == 0xffff);
 		di = values[di - 1];
 		hero.attribs[di].current = bv1;
 		hero.attribs[di].normal = bv1;


### PR DESCRIPTION
…g input of new positive values.

The character generator chrashes if the player presses the right mouse button or the escape key while assigning new Values to positive stats. Changing `di == -1` to `di == 0xffff` in line 4521 prevents the crash and creates the same behaviour as in an unmodified dosbox.