### PR TITLE
M302de: Fix for crash when getting informer hints in taverns.

### DIFF
--- a/src/custom/schick/rewrite_m302de/seg060.cpp
+++ b/src/custom/schick/rewrite_m302de/seg060.cpp
@@ -119,7 +119,7 @@ void talk_tavern(void)
 
 			} else if (txt_id == 66) {
 
-				sprintf(text_buffer, format, get_informer_hint());
+				sprintf(text_buffer, format, Real2Host(get_informer_hint()));
 
 			} else if (txt_id == 105) {
 


### PR DESCRIPTION
The game crashed whenever an innkeeper decided to give me a hint, where an informer lives. Wrapping the call to `get_informer_hint()` into a call to `Real2Host()` seems to fix this.

I am not sure if this is the correct fix for the problem or if this is a problem specific to Windows or VS2017.