### PR TITLE
M302de: Original-Bugfix: workaround for bad index calculation in spel…

### DIFF
--- a/src/custom/schick/rewrite_m302de/seg099.cpp
+++ b/src/custom/schick/rewrite_m302de/seg099.cpp
@@ -965,7 +965,15 @@ RealPt spell_analues(void)
 	}
 
 	item_pos = select_item_to_drop(get_spelluser());
+
+#ifdef M302de_ORIGINAL_BUGFIX
+	/* If the player cancels item selection or has no items select_item_to_drop() returns -1.
+	The original uses the return value to calculate an index, whithout checking for this. */
+	if (item_pos == -1) item_id = 0;
+	else item_id = host_readws(get_spelluser() + 14 * item_pos + HERO_ITEM_HEAD);
+#else
 	item_id = host_readws(get_spelluser() + 14 * item_pos + HERO_ITEM_HEAD);
+#endif
 
 	strcpy((char*)Real2Host(ds_readd(TEXT_OUTPUT_BUF)), (char*)get_tx(52));
 

--- a/src/custom/schick/rewrite_m302de/seg100.cpp
+++ b/src/custom/schick/rewrite_m302de/seg100.cpp
@@ -151,7 +151,19 @@ void spell_odem_arcanum(void)
 	signed short pos;
 	signed short id;
 
+
 	pos = select_item_to_drop(get_spelluser());
+
+#ifdef M302de_ORIGINAL_BUGFIX
+	/* If the player cancels item selection or has no items select_item_to_drop() returns -1.
+	   The original uses the return value to calculate an index, whithout checking for this. */
+	if (pos == -1)
+	{
+		sprintf((char*)Real2Host(ds_readd(DTP2)), "");
+		return;
+	}
+
+#endif
 
 	id = host_readws(get_spelluser() + pos * 14 + HERO_ITEM_HEAD);
 


### PR DESCRIPTION
…l_analues() or spell_odem_arcanum() if item selection is canceled or spell user has no items

As this file is marked as "Borlandified and identical", there seems to be a (potential) problem in the original code for the spells "Odem Arcanum" and "Analüs". If the player presses the right mouse button or the escape key, when the game shows the list of items (or if the inventory of the spell user is empty), `select_item_to_drop()` returns -1. This value is then used to calculate an offset into the inventory of the spell user. If the value is -1 the game will look at one inventory slot before the start of the inventory and will therefore use and potentially modify other values of that character.

In the case of "Odem Arcanum" the found value will also be used to find and then display the name of an item, which may in this case show a bit of memory that may not be text at all and may also lead to serious graphical errors (actually this is why i looked at this function). My suggestion would be to set the output buffer to an empty string (which will not be displayed) and just return from the function before anything else gets done.

The spell "Analüs" will probably cause much less trouble, because the found id is compared to a list of ids and it is probably unlikely to get a match here. But if it does happen, the function will still change a bit in a location outside of the inventory. My suggestion would be to set the item id to 0 so that the main part of the function (the loop comparing the item id to the list) gets skipped and the default text is used as output.